### PR TITLE
Migrate `useStore` → `useSelector` (TanStack Store)

### DIFF
--- a/src/components/builder/alerts/hooks/useContactsAlerts.ts
+++ b/src/components/builder/alerts/hooks/useContactsAlerts.ts
@@ -1,4 +1,4 @@
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 
 import { selectAllContacts } from "#/components/character/contacts/contactsSelectors.ts"
 import { useContactsStore } from "#/components/character/contacts/useContactsStore.ts"
@@ -13,7 +13,7 @@ export const useContactsAlerts = (): AlertInfo[] => {
     alerts.push({ section: "Contacts", ...alert })
   }
 
-  const contacts = useStore(contactsStore, selectAllContacts)
+  const contacts = useSelector(contactsStore, selectAllContacts)
 
   if (contacts.length === 0) {
     addAlert({

--- a/src/components/builder/buildPoints/hooks/useAdeptPowersBuildPoints.ts
+++ b/src/components/builder/buildPoints/hooks/useAdeptPowersBuildPoints.ts
@@ -1,10 +1,13 @@
 import type { BpLineItem } from "#/components/builder/buildPoints/bpLineItem.ts"
 import { BuilderSectionId } from "#/components/builder/sections/builderSectionId.ts"
 import { isAdept } from "#/components/character/adeptPowers/adeptPowersUtils.ts"
-import { useCharacterSheet } from "#/components/character/sheet/characterSheetProvider.tsx"
+import {
+  selectAwakeningType,
+  useCharacterSheetSelector,
+} from "#/components/character/sheet/characterSheet.selectors.ts"
 
 export const useAdeptPowersBuildPoints = (): BpLineItem => {
-  const awakeningType = useCharacterSheet((sheet) => sheet.biology.awakening)
+  const awakeningType = useCharacterSheetSelector(selectAwakeningType)
 
   return {
     sectionId: BuilderSectionId.adeptPowers,

--- a/src/components/builder/buildPoints/hooks/useBuildPointsApi.ts
+++ b/src/components/builder/buildPoints/hooks/useBuildPointsApi.ts
@@ -1,9 +1,7 @@
 import type { BpLineItem } from "#/components/builder/buildPoints/bpLineItem.ts"
 import { useAdeptPowersBuildPoints } from "#/components/builder/buildPoints/hooks/useAdeptPowersBuildPoints.ts"
 import { useAttributesBuildPoints } from "#/components/builder/buildPoints/hooks/useAttributesBuildPoints.ts"
-import {
-  useComplexFormsBuildPoints,
-} from "#/components/builder/buildPoints/hooks/useComplexFormsBuildPoints.ts"
+import { useComplexFormsBuildPoints } from "#/components/builder/buildPoints/hooks/useComplexFormsBuildPoints.ts"
 import { useContactsBuildPoints } from "#/components/builder/buildPoints/hooks/useContactsBuildPoints.ts"
 import { useGearBuildPoints } from "#/components/builder/buildPoints/hooks/useGearBuildPoints.ts"
 import { useQualitiesBuildPoints } from "#/components/builder/buildPoints/hooks/useQualitiesBuildPoints.ts"
@@ -18,10 +16,16 @@ import {
   getFreeSkillPoints,
 } from "#/components/builder/sections/skills/skillsBuilderUtils.ts"
 import { useAttr } from "#/components/character/characterUtils.ts"
-import { useCharacterSheet } from "#/components/character/sheet/characterSheetProvider.tsx"
+import {
+  selectActiveSkills,
+  selectAwakening,
+  selectKnowledgeSkills,
+  selectLanguageSkills,
+  selectMetatype,
+  selectSkillGroups,
+  useCharacterSheetSelector,
+} from "#/components/character/sheet/characterSheet.selectors.ts"
 import { AttributeKey } from "#/system/attributeKey.ts"
-import { awakenings } from "#/system/awakeningType.ts"
-import { metatypes } from "#/system/metatypeData.ts"
 
 export const useBuilderBuildPointsApi = () => {
   const lineItems: BpLineItem[] = [
@@ -54,11 +58,8 @@ export const useBuilderBuildPointsApi = () => {
 }
 
 const useBuilderBiologyBuildPoints = (): BpLineItem => {
-  const metatypeKey = useCharacterSheet((sheet) => sheet.biology.metatype)
-  const awakeningType = useCharacterSheet((sheet) => sheet.biology.awakening)
-
-  const metatypeCost = metatypes[metatypeKey].cost
-  const awakeningCost = awakenings[awakeningType].cost
+  const metatypeCost = useCharacterSheetSelector(selectMetatype).cost
+  const awakeningCost = useCharacterSheetSelector(selectAwakening).cost
 
   return {
     sectionId: BuilderSectionId.biology,
@@ -83,8 +84,8 @@ export const useBuilderSkillsBuildPoints = () => {
 }
 
 const useActiveSkillsBuildPoints = () => {
-  const activeSkills = useCharacterSheet((sheet) => sheet.skills.activeSkills)
-  const activeSkillGroups = useCharacterSheet((sheet) => sheet.skills.skillGroups)
+  const activeSkills = useCharacterSheetSelector(selectActiveSkills)
+  const activeSkillGroups = useCharacterSheetSelector(selectSkillGroups)
 
   const activeSkillsBp = calculateActiveSkillsBp(
     activeSkills,
@@ -102,8 +103,8 @@ const useKnowledgeSkillsBuildPoints = () => {
   const logicAttr = useAttr(AttributeKey.logic)
   const intuitionAttr = useAttr(AttributeKey.intuition)
 
-  const knowledgeSkills = useCharacterSheet((sheet) => sheet.skills.knowledgeSkills)
-  const languageSkills = useCharacterSheet((sheet) => sheet.skills.languageSkills)
+  const knowledgeSkills = useCharacterSheetSelector(selectKnowledgeSkills)
+  const languageSkills = useCharacterSheetSelector(selectLanguageSkills)
 
   const totalSpUsed = calculateKnowledgeAndLanguageSpUsed(
     knowledgeSkills,

--- a/src/components/builder/buildPoints/hooks/useSpellsBuildPoints.ts
+++ b/src/components/builder/buildPoints/hooks/useSpellsBuildPoints.ts
@@ -1,4 +1,4 @@
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 
 import type { BpLineItem } from "#/components/builder/buildPoints/bpLineItem.ts"
 import { BuilderSectionId } from "#/components/builder/sections/builderSectionId.ts"
@@ -12,7 +12,7 @@ import { SkillKey } from "#/system/skills/skillKey.ts"
 export const useSpellsBuildPoints = (): BpLineItem => {
   const awakeningType = useCharacterSheet((sheet) => sheet.biology.awakening)
   const spellsStore = useSpellsStore()
-  const spells = useStore(spellsStore, selectAllSpells)
+  const spells = useSelector(spellsStore, selectAllSpells)
   const spellcasting = useActiveSkill(SkillKey.spellcasting)
   const ritualSpellcasting = useActiveSkill(SkillKey.ritualSpellcasting)
 

--- a/src/components/builder/sections/biology/biologySection.tsx
+++ b/src/components/builder/sections/biology/biologySection.tsx
@@ -4,7 +4,7 @@ import MenuItem from "@mui/material/MenuItem"
 import Select from "@mui/material/Select"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import { produce } from "immer"
 import type { FC } from "react"
 
@@ -20,8 +20,8 @@ import { metatypes, MetatypeType } from "#/system/metatypeData.ts"
 export const BiologySection: FC = () => {
   const sheet = useCharacterSheetContext()
   const biologyStore = useBiologyStore()
-  const metatypeKey = useStore(biologyStore, selectMetatype)
-  const awakeningType = useStore(biologyStore, selectAwakening)
+  const metatypeKey = useSelector(biologyStore, selectMetatype)
+  const awakeningType = useSelector(biologyStore, selectAwakening)
 
   return (
     <>

--- a/src/components/builder/sections/contacts/contactsBuilderSection.tsx
+++ b/src/components/builder/sections/contacts/contactsBuilderSection.tsx
@@ -1,5 +1,5 @@
 import Stack from "@mui/material/Stack"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 
 import { useContactsAlerts } from "#/components/builder/alerts/hooks/useContactsAlerts.ts"
@@ -13,7 +13,7 @@ import { BuildPoints } from "#/components/ui/buildPoints.tsx"
 
 export const ContactsBuilderSection: FC = () => {
   const contactsStore = useContactsStore()
-  const allContacts = useStore(contactsStore, selectAllContacts)
+  const allContacts = useSelector(contactsStore, selectAllContacts)
   const contactsAlerts = useContactsAlerts()
 
   const bpSpent = allContacts

--- a/src/components/builder/sections/gear/gearSection.tsx
+++ b/src/components/builder/sections/gear/gearSection.tsx
@@ -5,7 +5,7 @@ import LinearProgress from "@mui/material/LinearProgress"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
 import { RiArrowDownSLine, RiErrorWarningLine } from "@remixicon/react"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { FC, SyntheticEvent } from "react"
 import { useState } from "react"
 
@@ -162,11 +162,11 @@ const GearSectionNuyen: FC<{
   section: SectionHeader
 }> = ({ section }) => {
   const gearApi = useGearStore()
-  const allGearItems = useStore(gearApi, selectAllGear)
+  const allGearItems = useSelector(gearApi, selectAllGear)
 
   const lifestyleStore = useLifestyleStore()
-  const lifestyleInfo = useStore(lifestyleStore, selectLifestyleInfo)
-  const lifestyleMonths = useStore(lifestyleStore, selectLifestyleMonthsPaid)
+  const lifestyleInfo = useSelector(lifestyleStore, selectLifestyleInfo)
+  const lifestyleMonths = useSelector(lifestyleStore, selectLifestyleMonthsPaid)
 
   if (section === SectionHeader.Lifestyle) {
     return (

--- a/src/components/builder/sections/gear/lifestyle/lifestylePanel.tsx
+++ b/src/components/builder/sections/gear/lifestyle/lifestylePanel.tsx
@@ -5,7 +5,7 @@ import Select from "@mui/material/Select"
 import Stack from "@mui/material/Stack"
 import TextField from "@mui/material/TextField"
 import Typography from "@mui/material/Typography"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 
 import { selectLifestyleMonthsPaid, selectLifestyleQuality } from "#/components/character/profile/lifestyleSelectors.ts"
@@ -16,9 +16,9 @@ import { Lifestyles, LifestyleType } from "#/system/lifestyleType.ts"
 export const LifestylePanel: FC = () => {
   const lifestyleStore = useLifestyleStore()
 
-  const quality = useStore(lifestyleStore, selectLifestyleQuality)
+  const quality = useSelector(lifestyleStore, selectLifestyleQuality)
   const upkeep = Lifestyles[quality].upkeep
-  const monthsPaid = useStore(lifestyleStore, selectLifestyleMonthsPaid)
+  const monthsPaid = useSelector(lifestyleStore, selectLifestyleMonthsPaid)
 
   const totalCost = upkeep * monthsPaid
 

--- a/src/components/builder/sections/profile/profileSection.tsx
+++ b/src/components/builder/sections/profile/profileSection.tsx
@@ -1,5 +1,5 @@
 import MuiTextField from "@mui/material/TextField"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 
 import { selectProfile } from "#/components/character/profile/profileSelectors.ts"
@@ -7,7 +7,7 @@ import { useProfileStore } from "#/components/character/profile/useProfileStore.
 
 export const ProfileSection: FC = () => {
   const profileStore = useProfileStore()
-  const profile = useStore(profileStore, selectProfile)
+  const profile = useSelector(profileStore, selectProfile)
 
   return (
     <>

--- a/src/components/builder/sections/profile/useProfileAlerts.ts
+++ b/src/components/builder/sections/profile/useProfileAlerts.ts
@@ -1,4 +1,4 @@
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 
 import { selectProfileAlias, selectProfileName } from "#/components/character/profile/profileSelectors.ts"
 import { useProfileStore } from "#/components/character/profile/useProfileStore.ts"
@@ -13,7 +13,7 @@ export const useProfileAlerts = (): AlertInfo[] => {
 
   const alerts: AlertInfo[] = []
 
-  const alias = useStore(profileStore, selectProfileAlias)
+  const alias = useSelector(profileStore, selectProfileAlias)
   if (!alias) {
     addAlert({
       severity: "error",
@@ -23,7 +23,7 @@ export const useProfileAlerts = (): AlertInfo[] => {
     })
   }
 
-  const name = useStore(profileStore, selectProfileName)
+  const name = useSelector(profileStore, selectProfileName)
   if (!name) {
     addAlert({
       severity: "error",

--- a/src/components/builder/sections/qualities/qualitiesList.tsx
+++ b/src/components/builder/sections/qualities/qualitiesList.tsx
@@ -1,7 +1,7 @@
 import Alert from "@mui/material/Alert"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 
 import { useQualitiesBuildPoints } from "#/components/builder/buildPoints/hooks/useQualitiesBuildPoints.ts"
@@ -18,7 +18,7 @@ interface QualitiesListProps {
 
 export const QualitiesList: FC<QualitiesListProps> = ({ type = "all" }) => {
   const qualitiesStore = useQualitiesStore()
-  const qualities = useStore(qualitiesStore, selectAllQualities)
+  const qualities = useSelector(qualitiesStore, selectAllQualities)
   const qualitiesBuildPoints = useQualitiesBuildPoints()
   const qualityFormDialog = useQualityFormDialog()
 

--- a/src/components/builder/sections/resources/adept/adeptPowersList.tsx
+++ b/src/components/builder/sections/resources/adept/adeptPowersList.tsx
@@ -2,7 +2,7 @@ import Button from "@mui/material/Button"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
 import { RiAddLine } from "@remixicon/react"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 
 import { AdeptPowersListItem } from "#/components/builder/sections/resources/adept/adeptPowersListItem.tsx"
@@ -15,7 +15,7 @@ import type { AdeptPowerData } from "#/system/magic/adeptPowerData.ts"
 
 export const AdeptPowersList: FC = () => {
   const adeptPowersStore = useAdeptPowersStore()
-  const adeptPowers = useStore(adeptPowersStore, selectAllAdeptPowers)
+  const adeptPowers = useSelector(adeptPowersStore, selectAllAdeptPowers)
   const powerPoints = usePowerPoints()
   const adeptPowerFormDialog = useAdeptPowerFormDialog()
 

--- a/src/components/builder/sections/resources/adept/useAdeptPowersAlerts.ts
+++ b/src/components/builder/sections/resources/adept/useAdeptPowersAlerts.ts
@@ -1,4 +1,4 @@
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 
 import { selectAllAdeptPowers } from "#/components/character/adeptPowers/adeptPowersSelectors.ts"
 import { isAdept } from "#/components/character/adeptPowers/adeptPowersUtils.ts"
@@ -12,7 +12,7 @@ export const useAdeptPowersAlerts = (): AlertInfo[] => {
   const awakeningType = useCharacterSheet((sheet) => sheet.biology.awakening)
   const magicAttr = useAttr(AttributeKey.magic)
   const adeptPowersStore = useAdeptPowersStore()
-  const adeptPowers = useStore(adeptPowersStore, selectAllAdeptPowers)
+  const adeptPowers = useSelector(adeptPowersStore, selectAllAdeptPowers)
 
   const statuses: AlertInfo[] = []
 

--- a/src/components/builder/sections/resources/magician/spellsList.tsx
+++ b/src/components/builder/sections/resources/magician/spellsList.tsx
@@ -2,7 +2,7 @@ import Button from "@mui/material/Button"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
 import { RiAddLine } from "@remixicon/react"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 
 import { useSpellsBuildPoints } from "#/components/builder/buildPoints/hooks/useSpellsBuildPoints.ts"
@@ -17,7 +17,7 @@ import type { SpellData } from "#/system/magic/spellData.ts"
 
 export const SpellsList: FC = () => {
   const spellsStore = useSpellsStore()
-  const spells = useStore(spellsStore, selectAllSpells)
+  const spells = useSelector(spellsStore, selectAllSpells)
   const buildPoints = useSpellsBuildPoints()
   const spellFormDialog = useSpellFormDialog()
 

--- a/src/components/builder/sections/resources/magician/traditionCard.tsx
+++ b/src/components/builder/sections/resources/magician/traditionCard.tsx
@@ -1,7 +1,7 @@
 import Paper from "@mui/material/Paper"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 
 import { selectTradition } from "#/components/builder/sections/resources/magician/traditionSelectors.ts"
@@ -11,7 +11,7 @@ import { AttributeLabels } from "#/system/attributeKey.ts"
 
 export const TraditionCard: FC = () => {
   const traditionStore = useTraditionStore()
-  const tradition = useStore(traditionStore, selectTradition)
+  const tradition = useSelector(traditionStore, selectTradition)
   const traditionFormDialog = useTraditionFormDialog()
 
   const handleOpen = async () => {
@@ -32,18 +32,18 @@ export const TraditionCard: FC = () => {
     >
       {tradition
         ? (
-            <Stack direction="row" sx={{ gap: 1, alignItems: "center" }}>
-              <Typography sx={{ flexGrow: 1 }}>{tradition.name}</Typography>
-              <Typography color="text.secondary">
-                WIL + {AttributeLabels[tradition.drainAttribute]}
-              </Typography>
-            </Stack>
-          )
-        : (
-            <Typography color="text.secondary" sx={{ textAlign: "center" }}>
-              Set Tradition
+          <Stack direction="row" sx={{ gap: 1, alignItems: "center" }}>
+            <Typography sx={{ flexGrow: 1 }}>{tradition.name}</Typography>
+            <Typography color="text.secondary">
+              WIL + {AttributeLabels[tradition.drainAttribute]}
             </Typography>
-          )}
+          </Stack>
+        )
+        : (
+          <Typography color="text.secondary" sx={{ textAlign: "center" }}>
+            Set Tradition
+          </Typography>
+        )}
     </Paper>
   )
 }

--- a/src/components/builder/sections/resources/magician/useSpellsAlerts.ts
+++ b/src/components/builder/sections/resources/magician/useSpellsAlerts.ts
@@ -1,4 +1,4 @@
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 
 import { useActiveSkill, useAttr } from "#/components/character/characterUtils.ts"
 import { useCharacterSheet } from "#/components/character/sheet/characterSheetProvider.tsx"
@@ -15,7 +15,7 @@ export const useSpellsAlerts = (): AlertInfo[] => {
   const spellcasting = useActiveSkill(SkillKey.spellcasting)
   const ritualSpellcasting = useActiveSkill(SkillKey.ritualSpellcasting)
   const spellsStore = useSpellsStore()
-  const spells = useStore(spellsStore, selectAllSpells)
+  const spells = useSelector(spellsStore, selectAllSpells)
 
   const statuses: AlertInfo[] = []
 

--- a/src/components/builder/sections/resources/technomancer/complexForms/complexFormsList.tsx
+++ b/src/components/builder/sections/resources/technomancer/complexForms/complexFormsList.tsx
@@ -4,7 +4,7 @@ import LinearProgress from "@mui/material/LinearProgress"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
 import { RiAddLine } from "@remixicon/react"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 
 import { useComplexFormsBuildPoints } from "#/components/builder/buildPoints/hooks/useComplexFormsBuildPoints.ts"
@@ -14,9 +14,7 @@ import {
 import { useAttr } from "#/components/character/characterUtils.ts"
 import { useMaxComplexForms } from "#/components/character/technomancer/complexFormsHooks.ts"
 import { selectAllComplexForms } from "#/components/character/technomancer/complexFormsSelectors.ts"
-import {
-  useComplexFormDialog,
-} from "#/components/character/technomancer/dialogs/complexFormDialog.tsx"
+import { useComplexFormDialog } from "#/components/character/technomancer/dialogs/complexFormDialog.tsx"
 import { useComplexFormsStore } from "#/components/character/technomancer/useComplexFormsStore.ts"
 import { BuildPoints } from "#/components/ui/buildPoints.tsx"
 import { getProgress } from "#/lib/progressUtils.ts"
@@ -26,7 +24,7 @@ import type { ComplexFormData } from "#/system/magic/complexFormData.ts"
 export const ComplexFormsList: FC = () => {
   const resonance = useAttr(AttributeKey.resonance)
   const complexFormsStore = useComplexFormsStore()
-  const complexForms = useStore(complexFormsStore, selectAllComplexForms)
+  const complexForms = useSelector(complexFormsStore, selectAllComplexForms)
   const complexFormsBp = useComplexFormsBuildPoints()
   const maxComplexForms = useMaxComplexForms()
   const complexFormDialog = useComplexFormDialog()

--- a/src/components/builder/sections/resources/technomancer/sprites/spritesList.tsx
+++ b/src/components/builder/sections/resources/technomancer/sprites/spritesList.tsx
@@ -4,13 +4,11 @@ import LinearProgress from "@mui/material/LinearProgress"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
 import { RiAddLine } from "@remixicon/react"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 
 import { useSpritesBuildPoints } from "#/components/builder/buildPoints/hooks/useSpritesBuildPoints.ts"
-import {
-  SpritesListItem,
-} from "#/components/builder/sections/resources/technomancer/sprites/spritesListItem.tsx"
+import { SpritesListItem } from "#/components/builder/sections/resources/technomancer/sprites/spritesListItem.tsx"
 import { useAttr } from "#/components/character/characterUtils.ts"
 import { useSpriteDialog } from "#/components/character/technomancer/dialogs/spriteDialog.tsx"
 import { useMaxSpritesRegistered } from "#/components/character/technomancer/spritesHooks.ts"
@@ -26,7 +24,7 @@ export const SpritesList: FC = () => {
   const resonance = useAttr(AttributeKey.resonance)
   const maxSpritesRegistered = useMaxSpritesRegistered()
   const spritesStore = useSpritesStore()
-  const sprites = useStore(spritesStore, selectAllSprites)
+  const sprites = useSelector(spritesStore, selectAllSprites)
   const spritesBp = useSpritesBuildPoints()
   const spriteDialog = useSpriteDialog()
 

--- a/src/components/builder/sections/skills/activeSkills/activeSkillsList.tsx
+++ b/src/components/builder/sections/skills/activeSkills/activeSkillsList.tsx
@@ -2,7 +2,7 @@ import Button from "@mui/material/Button"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
 import { RiAddLine } from "@remixicon/react"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 
 import { useBuilderSkillsBuildPoints } from "#/components/builder/buildPoints/hooks/useBuildPointsApi.ts"
@@ -26,8 +26,8 @@ import type { SkillGroupData } from "#/system/skills/skillGroupData"
 export const ActiveSkillsList: FC = () => {
   const skillsBuildPoints = useBuilderSkillsBuildPoints()
   const skillsStore = useSkillsStore()
-  const activeSkills = useStore(skillsStore, selectActiveSkills)
-  const skillGroups = useStore(skillsStore, selectSkillGroups)
+  const activeSkills = useSelector(skillsStore, selectActiveSkills)
+  const skillGroups = useSelector(skillsStore, selectSkillGroups)
 
   const activeSkillDialog = useActiveSkillDialog()
   const activeSkillGroupDialog = useActiveSkillGroupDialog()

--- a/src/components/builder/sections/skills/activeSkills/hooks/useActiveSkillsAlerts.ts
+++ b/src/components/builder/sections/skills/activeSkills/hooks/useActiveSkillsAlerts.ts
@@ -1,4 +1,4 @@
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 
 import { getSkillsInGroup } from "#/components/builder/sections/skills/activeSkills/skillGroupUtils.ts"
 import { selectActiveSkills, selectSkillGroups } from "#/components/character/skills/skillsSelectors.ts"
@@ -7,8 +7,8 @@ import type { AlertInfo } from "#/components/ui/alerts/alertInfo.ts"
 
 export const useActiveSkillsAlerts = (): AlertInfo[] => {
   const skillsStore = useSkillsStore()
-  const activeSkills = useStore(skillsStore, selectActiveSkills)
-  const skillGroups = useStore(skillsStore, selectSkillGroups)
+  const activeSkills = useSelector(skillsStore, selectActiveSkills)
+  const skillGroups = useSelector(skillsStore, selectSkillGroups)
 
   const statuses: AlertInfo[] = []
 

--- a/src/components/builder/sections/skills/hooks/useSkillsSummaryAlerts.ts
+++ b/src/components/builder/sections/skills/hooks/useSkillsSummaryAlerts.ts
@@ -1,4 +1,4 @@
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 
 import {
   selectActiveSkills,
@@ -10,9 +10,9 @@ import type { AlertInfo } from "#/components/ui/alerts/alertInfo.ts"
 
 export const useSkillsSummaryAlerts = (): AlertInfo[] => {
   const skillsStore = useSkillsStore()
-  const active = useStore(skillsStore, selectActiveSkills)
-  const knowledge = useStore(skillsStore, selectKnowledgeSkills)
-  const language = useStore(skillsStore, selectLanguageSkills)
+  const active = useSelector(skillsStore, selectActiveSkills)
+  const knowledge = useSelector(skillsStore, selectKnowledgeSkills)
+  const language = useSelector(skillsStore, selectLanguageSkills)
 
   if (active.length === 0 && knowledge.length === 0 && language.length === 0) {
     return [{

--- a/src/components/builder/sections/skills/knowledgeSkills/hooks/useKnowledgeSkillPoints.ts
+++ b/src/components/builder/sections/skills/knowledgeSkills/hooks/useKnowledgeSkillPoints.ts
@@ -1,4 +1,4 @@
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 
 import { getKnowledgeSkillSp, getLanguageSkillSp } from "#/components/builder/sections/skills/skillsBuilderUtils.ts"
 import { useAttr } from "#/components/character/characterUtils.ts"
@@ -12,8 +12,8 @@ export const useKnowledgeSkillPoints = () => {
   const logicAttr = useAttr(AttributeKey.logic)
   const intuitionAttr = useAttr(AttributeKey.intuition)
 
-  const knowledgeSkills = useStore(skillsStore, selectKnowledgeSkills)
-  const languageSkills = useStore(skillsStore, selectLanguageSkills)
+  const knowledgeSkills = useSelector(skillsStore, selectKnowledgeSkills)
+  const languageSkills = useSelector(skillsStore, selectLanguageSkills)
 
   const knowledgeSp = knowledgeSkills.reduce((total, skill) => {
     return total + getKnowledgeSkillSp(skill)

--- a/src/components/builder/sections/skills/knowledgeSkills/hooks/useKnowledgeSkillsAlerts.ts
+++ b/src/components/builder/sections/skills/knowledgeSkills/hooks/useKnowledgeSkillsAlerts.ts
@@ -1,4 +1,4 @@
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import pluralize from "pluralize"
 
 import {
@@ -10,8 +10,8 @@ import type { AlertInfo } from "#/components/ui/alerts/alertInfo.ts"
 
 export const useKnowledgeSkillsAlerts = (): AlertInfo[] => {
   const skillsStore = useSkillsStore()
-  const knowledgeSkills = useStore(skillsStore, selectKnowledgeSkills)
-  const languageSkills = useStore(skillsStore, selectLanguageSkills)
+  const knowledgeSkills = useSelector(skillsStore, selectKnowledgeSkills)
+  const languageSkills = useSelector(skillsStore, selectLanguageSkills)
   const skillPoints = useKnowledgeSkillPoints()
 
   const statuses: AlertInfo[] = []

--- a/src/components/builder/sections/skills/knowledgeSkills/knowledgeSkillsList.tsx
+++ b/src/components/builder/sections/skills/knowledgeSkills/knowledgeSkillsList.tsx
@@ -2,7 +2,7 @@ import Button from "@mui/material/Button"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
 import { RiAddLine } from "@remixicon/react"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 
 import { useKnowledgeSkillsBuildPoints } from "#/components/builder/buildPoints/hooks/useKnowledgeSkillsBuildPoints.ts"
@@ -18,9 +18,7 @@ import {
 import {
   useKnowledgeSkillDialog,
 } from "#/components/character/skills/knowledgeSkills/dialogs/knowledgeSkillEditDialog.tsx"
-import {
-  useLanguageSkillDialog,
-} from "#/components/character/skills/knowledgeSkills/dialogs/languageSkillDialog.tsx"
+import { useLanguageSkillDialog } from "#/components/character/skills/knowledgeSkills/dialogs/languageSkillDialog.tsx"
 import { selectKnowledgeSkills, selectLanguageSkills } from "#/components/character/skills/skillsSelectors.ts"
 import { useSkillsStore } from "#/components/character/skills/useSkillsStore.ts"
 import { BuildPoints } from "#/components/ui/buildPoints.tsx"
@@ -33,8 +31,8 @@ export const KnowledgeSkillsList: FC = () => {
   const skillPoints = useKnowledgeSkillPoints()
   const buildPoints = useKnowledgeSkillsBuildPoints()
 
-  const knowledgeSkills = useStore(skillsStore, selectKnowledgeSkills)
-  const languageSkills = useStore(skillsStore, selectLanguageSkills)
+  const knowledgeSkills = useSelector(skillsStore, selectKnowledgeSkills)
+  const languageSkills = useSelector(skillsStore, selectLanguageSkills)
 
   const knowledgeSkillDialog = useKnowledgeSkillDialog()
   const languageSkillDialog = useLanguageSkillDialog()

--- a/src/components/character/adeptPowers/adeptPowersHooks.ts
+++ b/src/components/character/adeptPowers/adeptPowersHooks.ts
@@ -1,4 +1,4 @@
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 
 import { selectAllAdeptPowers } from "#/components/character/adeptPowers/adeptPowersSelectors.ts"
 import { useAdeptPowersStore } from "#/components/character/adeptPowers/useAdeptPowersStore.ts"
@@ -7,7 +7,7 @@ import { AttributeKey } from "#/system/attributeKey.ts"
 
 export const usePowerPoints = () => {
   const adeptPowersStore = useAdeptPowersStore()
-  const adeptPowers = useStore(adeptPowersStore, selectAllAdeptPowers)
+  const adeptPowers = useSelector(adeptPowersStore, selectAllAdeptPowers)
   const magicAttr = useAttr(AttributeKey.magic)
 
   const used = adeptPowers

--- a/src/components/character/finances/endOfMonth/endOfMonthDialog.tsx
+++ b/src/components/character/finances/endOfMonth/endOfMonthDialog.tsx
@@ -10,7 +10,7 @@ import Divider from "@mui/material/Divider"
 import FormControlLabel from "@mui/material/FormControlLabel"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 import { useState } from "react"
 
@@ -46,9 +46,9 @@ export const EndOfMonthDialog: FC<Props> = ({ open, onClose, onClosed }) => {
   const nuyenStore = useNuyenStore()
   const lifestyleStore = useLifestyleStore()
 
-  const loans = useStore(nuyenStore, selectLoans)
-  const quality = useStore(lifestyleStore, selectLifestyleQuality)
-  const monthsPaid = useStore(lifestyleStore, selectLifestyleMonthsPaid)
+  const loans = useSelector(nuyenStore, selectLoans)
+  const quality = useSelector(lifestyleStore, selectLifestyleQuality)
+  const monthsPaid = useSelector(lifestyleStore, selectLifestyleMonthsPaid)
   const upkeep = Lifestyles[quality].upkeep
 
   const loanItems: EndOfMonthLineItem[] = loans

--- a/src/components/character/finances/lifestyle/lifestyleSection.tsx
+++ b/src/components/character/finances/lifestyle/lifestyleSection.tsx
@@ -5,7 +5,7 @@ import Select from "@mui/material/Select"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
 import { RiInfinityLine } from "@remixicon/react"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 
 import { selectNuyenAmount } from "#/components/character/finances/nuyen/nuyenSelectors.ts"
@@ -23,10 +23,10 @@ interface Props {
 export const LifestyleSection: FC<Props> = ({ nuyenStore }) => {
   const lifestyleStore = useLifestyleStore()
 
-  const quality = useStore(lifestyleStore, selectLifestyleQuality)
-  const monthsPaid = useStore(lifestyleStore, selectLifestyleMonthsPaid)
+  const quality = useSelector(lifestyleStore, selectLifestyleQuality)
+  const monthsPaid = useSelector(lifestyleStore, selectLifestyleMonthsPaid)
   const upkeep = Lifestyles[quality].upkeep
-  const currentNuyen = useStore(nuyenStore, selectNuyenAmount)
+  const currentNuyen = useSelector(nuyenStore, selectNuyenAmount)
 
   const canPrepay = upkeep > 0 && currentNuyen >= upkeep
 

--- a/src/components/character/finances/loans/loanDialog.tsx
+++ b/src/components/character/finances/loans/loanDialog.tsx
@@ -7,7 +7,7 @@ import Divider from "@mui/material/Divider"
 import Stack from "@mui/material/Stack"
 import TextField from "@mui/material/TextField"
 import Typography from "@mui/material/Typography"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 import { useState } from "react"
 
@@ -48,7 +48,7 @@ export const LoanDialog: FC<LoanDialogProps> = ({
 }) => {
   const nuyenStore = useNuyenStore()
   const isEditMode = mode === "edit"
-  const currentNuyen = useStore(nuyenStore, selectNuyenAmount)
+  const currentNuyen = useSelector(nuyenStore, selectNuyenAmount)
 
   const [lender, setLender] = useState(loan?.lender ?? "")
   const [amount, setAmount] = useState<number>(loan?.amount ?? 0)

--- a/src/components/character/gearPage/gearViewSection.tsx
+++ b/src/components/character/gearPage/gearViewSection.tsx
@@ -4,7 +4,7 @@ import AccordionSummary from "@mui/material/AccordionSummary"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
 import { RiArrowDownSLine } from "@remixicon/react"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 import { useState } from "react"
 
@@ -23,7 +23,7 @@ interface GearViewSectionProps {
 export const GearViewSection: FC<GearViewSectionProps> = ({ section, searchTerms }) => {
   const [isManuallyOpen, setIsManuallyOpen] = useState(false)
   const gearStore = useGearStore()
-  const allGearItems = useStore(gearStore, selectAllGear)
+  const allGearItems = useSelector(gearStore, selectAllGear)
 
   const allowedTypes = sectionGearTypes[section]
   const isSearching = searchTerms.length > 0

--- a/src/components/character/karma/karmaSection.tsx
+++ b/src/components/character/karma/karmaSection.tsx
@@ -2,7 +2,7 @@ import Button from "@mui/material/Button"
 import Grid from "@mui/material/Grid"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 
 import { useAddKarmaDialog } from "#/components/character/karma/addKarmaDialog.tsx"
@@ -13,8 +13,8 @@ import { Label } from "#/components/ui/text/label"
 export const KarmaSection: FC = () => {
   const addKarmaDialog = useAddKarmaDialog()
   const karmaStore = useKarmaStore()
-  const currentKarma = useStore(karmaStore, selectCurrentKarma)
-  const totalKarma = useStore(karmaStore, selectTotalKarma)
+  const currentKarma = useSelector(karmaStore, selectCurrentKarma)
+  const totalKarma = useSelector(karmaStore, selectTotalKarma)
 
   const handleOpenAddKarma = () => {
     addKarmaDialog.open({

--- a/src/components/character/quickPanel/quickDamageSection.tsx
+++ b/src/components/character/quickPanel/quickDamageSection.tsx
@@ -1,6 +1,6 @@
 import Grid from "@mui/material/Grid"
 import Stack from "@mui/material/Stack"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 
 import DamageTrack from "#/components/system/damage/damageTrack.tsx"
@@ -11,8 +11,8 @@ import { DamageTrackKey } from "#/system/damageTrackKey.ts"
 
 export const QuickDamageSection: FC = () => {
   const damageStore = useDamageStore()
-  const physical = useStore(damageStore, (state) => state.physical)
-  const stun = useStore(damageStore, (state) => state.stun)
+  const physical = useSelector(damageStore, (state) => state.physical)
+  const stun = useSelector(damageStore, (state) => state.stun)
 
   return (
     <Stack sx={{ gap: 0.5 }}>

--- a/src/components/character/quickPanel/quickEdgeSection.tsx
+++ b/src/components/character/quickPanel/quickEdgeSection.tsx
@@ -2,7 +2,7 @@ import Box from "@mui/material/Box"
 import Button from "@mui/material/Button"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 
 import { selectEdgeCurrent, selectEdgeMax } from "#/components/character/quickPanel/edgeSelectors.ts"
@@ -14,8 +14,8 @@ export const QuickEdgeSection: FC = () => {
   const confirmDialog = useConfirmDialog()
   const edgeStore = useEdgeStore()
 
-  const max = useStore(edgeStore, selectEdgeMax)
-  const current = useStore(edgeStore, selectEdgeCurrent)
+  const max = useSelector(edgeStore, selectEdgeMax)
+  const current = useSelector(edgeStore, selectEdgeCurrent)
 
   const onBurnClick = async () => {
     if (

--- a/src/components/character/sheet/characterSheet.selectors.ts
+++ b/src/components/character/sheet/characterSheet.selectors.ts
@@ -1,0 +1,54 @@
+import { useSelector } from "@tanstack/react-store"
+import { createSelector } from "reselect"
+
+import { useCharacterSheetContext } from "#/components/character/sheet/characterSheetProvider.tsx"
+import type { AwakeningData, AwakeningType } from "#/system/awakeningType.ts"
+import { awakenings } from "#/system/awakeningType.ts"
+import type { CharacterSheet } from "#/system/characterSheet.ts"
+import type { MetatypeData, MetatypeType } from "#/system/metatypeData.ts"
+import { metatypes } from "#/system/metatypeData.ts"
+import type { ActiveSkillData } from "#/system/skills/activeSkillData.ts"
+import type { KnowledgeSkillData } from "#/system/skills/knowledgeSkillData.ts"
+import type { LanguageSkillData } from "#/system/skills/languageSkillData.ts"
+import type { SkillGroupData } from "#/system/skills/skillGroupData.ts"
+
+export type CharacterDataSelector<TData> = (state: CharacterSheet) => TData
+
+export function useCharacterSheetSelector<T>(selector: CharacterDataSelector<T>) {
+  const store = useCharacterSheetContext()
+  return useSelector(store, selector)
+}
+
+export const selectAwakeningType: CharacterDataSelector<AwakeningType> = (state) => {
+  return state.biology.awakening
+}
+
+export const selectAwakening: CharacterDataSelector<AwakeningData> = createSelector(
+  selectAwakeningType,
+  (awakening) => awakenings[awakening],
+)
+
+export const selectMetatypeKey: CharacterDataSelector<MetatypeType> = (state) => {
+  return state.biology.metatype
+}
+
+export const selectMetatype: CharacterDataSelector<MetatypeData> = createSelector(
+  selectMetatypeKey,
+  (awakening) => metatypes[awakening],
+)
+
+export const selectActiveSkills: CharacterDataSelector<ActiveSkillData[]> = (state) => {
+  return state.skills.activeSkills
+}
+
+export const selectSkillGroups: CharacterDataSelector<SkillGroupData[]> = (state) => {
+  return state.skills.skillGroups
+}
+
+export const selectKnowledgeSkills: CharacterDataSelector<KnowledgeSkillData[]> = (state) => {
+  return state.skills.knowledgeSkills
+}
+
+export const selectLanguageSkills: CharacterDataSelector<LanguageSkillData[]> = (state) => {
+  return state.skills.languageSkills
+}

--- a/src/components/character/sheet/characterSheetProvider.tsx
+++ b/src/components/character/sheet/characterSheetProvider.tsx
@@ -1,7 +1,8 @@
-import { useStore } from "@tanstack/react-store"
 import type { FC, PropsWithChildren } from "react"
 import { createContext, useContext } from "react"
 
+// eslint-disable-next-line import-x/no-cycle
+import { useCharacterSheetSelector } from "#/components/character/sheet/characterSheet.selectors.ts"
 import type { CharacterSheetStore } from "#/components/character/sheet/characterSheetStore.ts"
 import type { CharacterSheet } from "#/system/characterSheet.ts"
 
@@ -24,14 +25,6 @@ export const CharacterSheetProvider: FC<CharacterSheetProviderProps> = ({
 
 type CharacterDataSelector<TData> = (state: CharacterSheet) => TData
 
-export function useCharacterSheet<TData>(
-  selector: CharacterDataSelector<TData>,
-  compare?: (a: TData, b: TData) => boolean,
-) {
-  const store = useCharacterSheetContext()
-  return useStore(store, selector, compare)
-}
-
 export const useCharacterSheetContext = (): CharacterSheetStore => {
   const store = useContext(CharacterSheetContext)
 
@@ -42,4 +35,14 @@ export const useCharacterSheetContext = (): CharacterSheetStore => {
   }
 
   return store
+}
+
+/**
+ * @deprecated use {@link useCharacterSheetSelector} instead
+ * @param selector
+ */
+export function useCharacterSheet<TData>(
+  selector: CharacterDataSelector<TData>,
+) {
+  return useCharacterSheetSelector(selector)
 }

--- a/src/components/character/skills/activeSkills/dialogs/activeSkillFormDialog.tsx
+++ b/src/components/character/skills/activeSkills/dialogs/activeSkillFormDialog.tsx
@@ -10,7 +10,7 @@ import MuiSelect from "@mui/material/Select"
 import Stack from "@mui/material/Stack"
 import MuiTextField from "@mui/material/TextField"
 import Typography from "@mui/material/Typography"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 import { useState } from "react"
 import { z } from "zod"
@@ -82,7 +82,7 @@ export const ActiveSkillFormDialog: FC<ActiveSkillFormDialogProps> = ({
   })
 
   // Reactively subscribe to the selected skill name so the specialization section updates
-  const selectedSkillName = useStore(form.baseStore, (state) => state.values.name)
+  const selectedSkillName = useSelector(form.baseStore, (state) => state.values.name)
   const selectedSkillInfo = selectedSkillName ? skillList[selectedSkillName as SkillKey] : undefined
   const linkedAttr = selectedSkillInfo?.attr
   const allSpecs = selectedSkillInfo?.specializations ?? []

--- a/src/components/character/skills/knowledgeSkills/forms/languageSkillFormFields.tsx
+++ b/src/components/character/skills/knowledgeSkills/forms/languageSkillFormFields.tsx
@@ -1,12 +1,10 @@
 import Stack from "@mui/material/Stack"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 import { z } from "zod"
 
 import { useCharacterSheet } from "#/components/character/sheet/characterSheetProvider.tsx"
-import type {
-  LanguageSkillForm,
-} from "#/components/character/skills/knowledgeSkills/forms/useLanguageSkillForm.ts"
+import type { LanguageSkillForm } from "#/components/character/skills/knowledgeSkills/forms/useLanguageSkillForm.ts"
 import { SkillRatingMax } from "#/system/skills/skillUtils.ts"
 
 interface LanguageSkillFormFieldsProps {
@@ -16,7 +14,7 @@ interface LanguageSkillFormFieldsProps {
 export const LanguageSkillFormFields: FC<LanguageSkillFormFieldsProps> = ({
   form,
 }) => {
-  const skillName = useStore(form.store, (state) => state.values.name)
+  const skillName = useSelector(form.store, (state) => state.values.name)
   const nativeLanguage = useCharacterSheet((sheet) => {
     return sheet.skills.languageSkills.find((skill) => skill.rating === "native")
   })

--- a/src/components/character/spells/spellCastSection.tsx
+++ b/src/components/character/spells/spellCastSection.tsx
@@ -10,7 +10,7 @@ import Select from "@mui/material/Select"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
 import { darken, lighten } from "@mui/material/styles"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 import { useState } from "react"
 
@@ -49,10 +49,10 @@ export const SpellCastSection: FC<SpellCastSectionProps> = ({ spell, onClose }) 
   const drainIsPhysical = isOvercasting
 
   const damageStore = useDamageStore()
-  const physicalMax = useStore(damageStore, selectPhysicalMax)
-  const physicalCurrent = useStore(damageStore, selectPhysicalCurrent)
-  const stunMax = useStore(damageStore, selectStunMax)
-  const stunCurrent = useStore(damageStore, selectStunCurrent)
+  const physicalMax = useSelector(damageStore, selectPhysicalMax)
+  const physicalCurrent = useSelector(damageStore, selectPhysicalCurrent)
+  const stunMax = useSelector(damageStore, selectStunMax)
+  const stunCurrent = useSelector(damageStore, selectStunCurrent)
 
   const handleApplyDrain = (amount: number) => {
     if (amount <= 0) return

--- a/src/components/character/technomancer/complexFormsHooks.ts
+++ b/src/components/character/technomancer/complexFormsHooks.ts
@@ -1,4 +1,4 @@
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 
 import { useAttr } from "#/components/character/characterUtils.ts"
 import { useCharacterSheet } from "#/components/character/sheet/characterSheetProvider.tsx"
@@ -10,7 +10,7 @@ import { AwakeningType } from "#/system/awakeningType.ts"
 export const useComplexForms = () => {
   const awakeningType = useCharacterSheet((sheet) => sheet.biology.awakening)
   const complexFormsStore = useComplexFormsStore()
-  const complexForms = useStore(complexFormsStore, selectAllComplexForms)
+  const complexForms = useSelector(complexFormsStore, selectAllComplexForms)
 
   if (awakeningType !== AwakeningType.Technomancer) {
     return []

--- a/src/components/character/technomancer/spritesHooks.ts
+++ b/src/components/character/technomancer/spritesHooks.ts
@@ -1,4 +1,4 @@
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 
 import { useActiveSkill, useAttr } from "#/components/character/characterUtils.ts"
 import { useCharacterSheet } from "#/components/character/sheet/characterSheetProvider.tsx"
@@ -11,7 +11,7 @@ import { SkillKey } from "#/system/skills/skillKey.ts"
 export const useSprites = () => {
   const awakeningType = useCharacterSheet((sheet) => sheet.biology.awakening)
   const spritesStore = useSpritesStore()
-  const sprites = useStore(spritesStore, selectAllSprites)
+  const sprites = useSelector(spritesStore, selectAllSprites)
 
   if (awakeningType !== AwakeningType.Technomancer) {
     return []

--- a/src/components/dialogs/api/dialogWrapper.tsx
+++ b/src/components/dialogs/api/dialogWrapper.tsx
@@ -1,4 +1,4 @@
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 
 import type { AnyDialog } from "#/components/dialogs/api/dialogApiDialog.ts"
@@ -21,7 +21,7 @@ interface DialogApiWrapperProps {
 export const DialogWrapper: FC<DialogApiWrapperProps> = ({ ctrl, dialog: Dialog, onClosed }) => {
   return (
     <Dialog
-      open={useStore(ctrl.isOpenStore, (state) => state)}
+      open={useSelector(ctrl.isOpenStore, (state) => state)}
       onClose={(value) => ctrl.close(value)}
       onClosed={onClosed}
     />

--- a/src/components/items/types/credsticks/credstickDialog.tsx
+++ b/src/components/items/types/credsticks/credstickDialog.tsx
@@ -11,7 +11,7 @@ import Select from "@mui/material/Select"
 import Stack from "@mui/material/Stack"
 import TextField from "@mui/material/TextField"
 import Typography from "@mui/material/Typography"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 import { useState } from "react"
 
@@ -53,7 +53,7 @@ export const CredstickDialog: FC<CredstickDialogProps> = ({
 }) => {
   const gearStore = useGearStore()
   const nuyenStore = useNuyenStore()
-  const currentNuyen = useStore(nuyenStore, selectNuyenAmount)
+  const currentNuyen = useSelector(nuyenStore, selectNuyenAmount)
 
   const isEditMode = mode === "edit"
   const isCertified = mode === "add-certified"

--- a/src/components/items/types/implants/forms/implantFormFields.tsx
+++ b/src/components/items/types/implants/forms/implantFormFields.tsx
@@ -6,7 +6,7 @@ import Chip from "@mui/material/Chip"
 import Grid from "@mui/material/Grid"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 import { z } from "zod"
 
@@ -66,7 +66,7 @@ interface CapacitySlotsChipProps extends ChipProps {
 
 const CapacitySlotsChip: FC<CapacitySlotsChipProps> = ({ implantId, capacity, ...props }) => {
   const gearStore = useGearStore()
-  const gear = useStore(gearStore, selectAllGear)
+  const gear = useSelector(gearStore, selectAllGear)
   const usedCapacity = Object.values(gear)
     .filter(isImplant)
     .filter((item) => item.parentId === implantId)
@@ -80,8 +80,8 @@ const CapacitySlotsChip: FC<CapacitySlotsChipProps> = ({ implantId, capacity, ..
 export const ImplantFormFields = withFieldGroup({
   ...implantFormOpts,
   render: function Render({ group }) {
-    const parentId = useStore(group.store, (state) => state.values.parentId)
-    const itemId = useStore(group.store, (state) => state.values.id)
+    const parentId = useSelector(group.store, (state) => state.values.parentId)
+    const itemId = useSelector(group.store, (state) => state.values.id)
 
     return (
       <Stack sx={{ gap: 1 }}>

--- a/src/components/items/useGearStore.ts
+++ b/src/components/items/useGearStore.ts
@@ -1,6 +1,6 @@
 import type { UUID } from "node:crypto"
 
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import type { BaseAtom } from "@tanstack/store"
 import { batch, createStore } from "@tanstack/store"
 import { produce } from "immer"
@@ -177,6 +177,6 @@ export function useGearByType<TItem extends ItemData>(itemType: string): TItem[]
 
 export function useGearFilter<TReturn extends ItemData>(filter: (item: ItemData) => item is TReturn): TReturn[] {
   const store = useGearStore()
-  const gear = useStore(store, selectAllGear)
+  const gear = useSelector(store, selectAllGear)
   return Object.values(gear).filter(filter)
 }

--- a/src/components/system/damage/damageUtils.ts
+++ b/src/components/system/damage/damageUtils.ts
@@ -13,7 +13,7 @@ import { GameEffectType } from "#/system/gameEffects/gameEffectType.ts"
  *
  * Usage:
  *   useCharacterSheet(selectPainToleranceModifier(DamageTrackKey.physical))
- *   useStore(store, selectPainToleranceModifier("all"))
+ *   useSelector(store, selectPainToleranceModifier("all"))
  *
  * @param track - The damage track (or "all") to compute the modifier for
  * @returns A selector `(sheet) => number`
@@ -59,7 +59,7 @@ function selectPainToleranceModifier(track: DamageTrackKey | "all") {
  *
  * Usage:
  *   useCharacterSheet(selectWoundInterval(DamageTrackKey.physical))
- *   useStore(store, selectWoundInterval(DamageTrackKey.stun))
+ *   useSelector(store, selectWoundInterval(DamageTrackKey.stun))
  *
  * @param track - The damage track to compute the interval for
  * @returns A selector `(sheet) => number` (result ≥ 1)

--- a/src/components/system/damage/useDamageStore.test.tsx
+++ b/src/components/system/damage/useDamageStore.test.tsx
@@ -1,4 +1,4 @@
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import { renderHook } from "@testing-library/react"
 import type { FC, PropsWithChildren } from "react"
 import { describe, expect, it } from "vitest"
@@ -38,8 +38,8 @@ describe("useDamageStore", () => {
       () => {
         const store = useDamageStore()
         return {
-          physicalInterval: useStore(store, (s) => s.physical.woundInterval),
-          stunInterval: useStore(store, (s) => s.stun.woundInterval),
+          physicalInterval: useSelector(store, (s) => s.physical.woundInterval),
+          stunInterval: useSelector(store, (s) => s.stun.woundInterval),
         }
       },
       { wrapper: makeWrapper(sheet) },
@@ -70,8 +70,8 @@ describe("useDamageStore", () => {
       () => {
         const store = useDamageStore()
         return {
-          physicalInterval: useStore(store, (s) => s.physical.woundInterval),
-          stunInterval: useStore(store, (s) => s.stun.woundInterval),
+          physicalInterval: useSelector(store, (s) => s.physical.woundInterval),
+          stunInterval: useSelector(store, (s) => s.stun.woundInterval),
         }
       },
       { wrapper: makeWrapper(sheet) },
@@ -102,8 +102,8 @@ describe("useDamageStore", () => {
       () => {
         const store = useDamageStore()
         return {
-          physicalInterval: useStore(store, (s) => s.physical.woundInterval),
-          stunInterval: useStore(store, (s) => s.stun.woundInterval),
+          physicalInterval: useSelector(store, (s) => s.physical.woundInterval),
+          stunInterval: useSelector(store, (s) => s.stun.woundInterval),
         }
       },
       { wrapper: makeWrapper(sheet) },
@@ -134,8 +134,8 @@ describe("useDamageStore", () => {
       () => {
         const store = useDamageStore()
         return {
-          physicalInterval: useStore(store, (s) => s.physical.woundInterval),
-          stunInterval: useStore(store, (s) => s.stun.woundInterval),
+          physicalInterval: useSelector(store, (s) => s.physical.woundInterval),
+          stunInterval: useSelector(store, (s) => s.stun.woundInterval),
         }
       },
       { wrapper: makeWrapper(sheet) },
@@ -165,7 +165,7 @@ describe("useDamageStore", () => {
     const { result } = renderHook(
       () => {
         const store = useDamageStore()
-        return useStore(store, (s) => s.physical.woundInterval)
+        return useSelector(store, (s) => s.physical.woundInterval)
       },
       { wrapper: makeWrapper(sheet) },
     )
@@ -184,7 +184,7 @@ describe("useDamageStore", () => {
     const { result } = renderHook(
       () => {
         const store = useDamageStore()
-        return useStore(store, (s) => s.physical.max)
+        return useSelector(store, (s) => s.physical.max)
       },
       { wrapper: makeWrapper(sheet) },
     )
@@ -203,7 +203,7 @@ describe("useDamageStore", () => {
     const { result } = renderHook(
       () => {
         const store = useDamageStore()
-        return useStore(store, (s) => s.stun.max)
+        return useSelector(store, (s) => s.stun.max)
       },
       { wrapper: makeWrapper(sheet) },
     )
@@ -224,8 +224,8 @@ describe("useDamageStore", () => {
       () => {
         const store = useDamageStore()
         return {
-          physicalCurrent: useStore(store, (s) => s.physical.current),
-          stunCurrent: useStore(store, (s) => s.stun.current),
+          physicalCurrent: useSelector(store, (s) => s.physical.current),
+          stunCurrent: useSelector(store, (s) => s.stun.current),
         }
       },
       { wrapper: makeWrapper(sheet) },

--- a/src/components/system/initiative/useInitiativePassStore.ts
+++ b/src/components/system/initiative/useInitiativePassStore.ts
@@ -1,4 +1,4 @@
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import { produce } from "immer"
 import { useMemo } from "react"
 
@@ -32,6 +32,6 @@ export const useInitiativePassStore = (): InitiativePassStore => {
 export const useInitiativePassesCompleted = (
   store: InitiativePassStore,
 ): ReadonlySet<number> => {
-  const passesCompleted = useStore(store, selectPassesCompleted)
+  const passesCompleted = useSelector(store, selectPassesCompleted)
   return useMemo(() => new Set(passesCompleted), [passesCompleted])
 }

--- a/src/routes/$characterId/contacts.tsx
+++ b/src/routes/$characterId/contacts.tsx
@@ -1,7 +1,7 @@
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
 import { createFileRoute } from "@tanstack/react-router"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import { useState } from "react"
 
 import { ContactsList } from "#/components/character/contacts/contactsList.tsx"
@@ -24,7 +24,7 @@ export const Route = createFileRoute("/$characterId/contacts")({
  */
 function RouteComponent() {
   const contactsStore = useContactsStore()
-  const allContacts = useStore(contactsStore, selectAllContacts)
+  const allContacts = useSelector(contactsStore, selectAllContacts)
   const [searchQuery, setSearchQuery] = useState("")
 
   let filteredContacts = allContacts

--- a/src/routes/$characterId/defense.tsx
+++ b/src/routes/$characterId/defense.tsx
@@ -1,7 +1,7 @@
 import Grid from "@mui/material/Grid"
 import Stack from "@mui/material/Stack"
 import { createFileRoute } from "@tanstack/react-router"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 import { Fragment } from "react"
 
 import { EquippedArmorSection } from "#/components/items/types/armor/equippedArmorSection.tsx"
@@ -34,8 +34,8 @@ export const Route = createFileRoute("/$characterId/defense")({
 
 function RouteComponent() {
   const damageStore = useDamageStore()
-  const physical = useStore(damageStore, selectPhysicalTrack)
-  const stun = useStore(damageStore, selectStunTrack)
+  const physical = useSelector(damageStore, selectPhysicalTrack)
+  const stun = useSelector(damageStore, selectStunTrack)
 
   return (
     <Stack>

--- a/src/routes/$characterId/finances.tsx
+++ b/src/routes/$characterId/finances.tsx
@@ -3,7 +3,7 @@ import Grid from "@mui/material/Grid"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
 import { createFileRoute } from "@tanstack/react-router"
-import { useStore } from "@tanstack/react-store"
+import { useSelector } from "@tanstack/react-store"
 
 import { useEndOfMonthDialog } from "#/components/character/finances/endOfMonth/endOfMonthDialog.tsx"
 import { LifestyleSection } from "#/components/character/finances/lifestyle/lifestyleSection.tsx"
@@ -34,12 +34,12 @@ function RouteComponent() {
   const endOfMonthDialog = useEndOfMonthDialog()
 
   const netWorth = useNetWorth()
-  const nuyenBalance = useStore(nuyenStore, selectNuyenAmount)
-  const loans = useStore(nuyenStore, selectLoans)
+  const nuyenBalance = useSelector(nuyenStore, selectNuyenAmount)
+  const loans = useSelector(nuyenStore, selectLoans)
   const loansBalance = loans.reduce((sum, loan) => sum + loan.amount, 0)
 
-  const lifestyleQuality = useStore(lifestyleStore, selectLifestyleQuality)
-  const lifestyleMonthsPaid = useStore(lifestyleStore, selectLifestyleMonthsPaid)
+  const lifestyleQuality = useSelector(lifestyleStore, selectLifestyleQuality)
+  const lifestyleMonthsPaid = useSelector(lifestyleStore, selectLifestyleMonthsPaid)
   const lifestyleUpkeep = Lifestyles[lifestyleQuality].upkeep
 
   const monthlyNuyenCost = lifestyleMonthsPaid === 0 ? lifestyleUpkeep : 0


### PR DESCRIPTION
Every `useStore(store, selector)` call across components, hooks, routes, and tests has been updated to `useSelector(store, selector)`. Affected areas include:

- Builder sections: biology, contacts, gear, lifestyle, profile, qualities, skills (active/knowledge), resources (adept powers, spells, complex forms, sprites, tradition)
- Character components: adept powers, complex forms, damage tracks, edge, finances (loans, lifestyle, end-of-month), gear view, karma, quick panel, spell casting, sprites, technomancer hooks
- Gear infrastructure: `useGearStore`, `useGearFilter`, implant form fields, credstick dialog
- Dialog system: `DialogWrapper`
- Initiative: `useInitiativePassStore`
- Routes: contacts, defense, finances
- Tests: `useDamageStore.test.tsx`

#### Misc cleanup

- Normalized multi-line import braces to single-line where there were only one or two named imports
- Updated JSDoc usage examples in `damageUtils.ts` to reference `useSelector`

