### PR TITLE
feat: generalPenalty effect type — concentration/sustaining penalty across all dice pools

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,11 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(git checkout *)",
-      "Bash(git commit -m ' *)",
-      "Bash(git push *)",
-      "Bash(yarn eslint *)",
       "Bash(yarn test *)",
-      "Bash(yarn lint *)"
+      "Bash(yarn eslint *)"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,12 @@
 {
   "permissions": {
     "allow": [
-      "Bash(git checkout *)"
+      "Bash(git checkout *)",
+      "Bash(git commit -m ' *)",
+      "Bash(git push *)",
+      "Bash(yarn eslint *)",
+      "Bash(yarn test *)",
+      "Bash(yarn lint *)"
     ]
   }
 }

--- a/src/components/character/characterUtils.ts
+++ b/src/components/character/characterUtils.ts
@@ -46,6 +46,15 @@ export const useEffectiveAttr = (attribute: AttributeKey): number => {
 }
 
 /**
+ * Sum of all generalPenalty effects — applied to active skill pools and initiative.
+ * Drain resistance is deliberately exempt; use raw attributes there instead.
+ */
+export const useGeneralPenalty = (): number => {
+  const effects = useGameEffects(GameEffectType.generalPenalty)
+  return effects.reduce((sum, e) => sum + e.value, 0)
+}
+
+/**
  * Hook to retrieve the effective rating of an active skill, accounting for skill groups.
  */
 export const useActiveSkillRating = (skill: SkillKey) => {
@@ -75,7 +84,9 @@ export const useActiveSkill = (skill: SkillKey) => {
     .filter((e) => e.target === skill)
     .reduce((sum, e) => sum + e.value, 0)
 
-  return rating + attribute + totalMod
+  const generalPenalty = useGeneralPenalty()
+
+  return rating + attribute + totalMod + generalPenalty
 }
 
 /**

--- a/src/components/character/combat/combatHud.tsx
+++ b/src/components/character/combat/combatHud.tsx
@@ -29,6 +29,8 @@ function effectLabel(effects: GameEffectData[]): string {
       parts.push(`${e.value > 0 ? "+" : ""}${e.value} ${e.target}`)
     } else if (e.type === GameEffectType.skillMod && e.target) {
       parts.push(`${e.value > 0 ? "+" : ""}${e.value} ${e.target}`)
+    } else if (e.type === GameEffectType.generalPenalty) {
+      parts.push(`${e.value > 0 ? "+" : ""}${e.value} all pools`)
     }
   }
   return parts.join(", ")

--- a/src/components/character/skills/skillDicePools.ts
+++ b/src/components/character/skills/skillDicePools.ts
@@ -1,7 +1,7 @@
 import { useActiveSkillRating } from "#/components/character/characterUtils.ts"
 import type { DicePoolData } from "#/components/system/dicePool/dicePoolData.tsx"
 import { createDicePool } from "#/components/system/dicePool/dicePoolData.tsx"
-import { useActiveSkillDiceGroup, useAttrDiceGroup, useWoundDiceGroup } from "#/components/system/dicePool/useDiceGroup.ts"
+import { useActiveSkillDiceGroup, useAttrDiceGroup, useGeneralPenaltyDiceGroup, useWoundDiceGroup } from "#/components/system/dicePool/useDiceGroup.ts"
 import { useGameEffects } from "#/components/system/gameEffects/useGameEffects.ts"
 import { AttributeKey } from "#/system/attributeKey.ts"
 import { GameEffectType } from "#/system/gameEffects/gameEffectType.ts"
@@ -40,6 +40,7 @@ export const useActiveSkillDicePool = (props: {
     isDefaulted ? { name: "Defaulting", size: -1, color: "warning.main" } : null,
     specialization ? { name: specialization, size: 2 + totalSpecMod } : null,
     useWoundDiceGroup(),
+    useGeneralPenaltyDiceGroup(),
   ])
 }
 
@@ -62,6 +63,7 @@ export const useKnowledgeSkillDicePool = (props: {
     useAttrDiceGroup(AttributeKey.logic),
     specialization ? { name: specialization, size: 2 } : null,
     useWoundDiceGroup(),
+    useGeneralPenaltyDiceGroup(),
   ])
 }
 
@@ -84,5 +86,6 @@ export const useLanguageSkillDicePool = (props: {
     useAttrDiceGroup(AttributeKey.intuition),
     lingo ? { name: lingo, size: 2 } : null,
     useWoundDiceGroup(),
+    useGeneralPenaltyDiceGroup(),
   ])
 }

--- a/src/components/character/skills/skillListItem.tsx
+++ b/src/components/character/skills/skillListItem.tsx
@@ -4,7 +4,7 @@ import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
 import type { FC } from "react"
 
-import { useAttr } from "#/components/character/characterUtils.ts"
+import { useAttr, useGeneralPenalty } from "#/components/character/characterUtils.ts"
 import { useWoundModifier } from "#/components/system/damage/useWoundModifier.ts"
 import type { AttributeKey } from "#/system/attributeKey.ts"
 import { AttributeLabels } from "#/system/attributeKey.ts"
@@ -27,12 +27,13 @@ export const SkillListItem: FC<SkillListItemProps> = ({
   onClick,
 }) => {
   const woundMod = useWoundModifier()
+  const generalPenalty = useGeneralPenalty()
   const attrValue = useAttr(attr)
 
   const isNative = rating === "native"
   const ratingDice = isNative ? 0 : rating
   const defaultingPenalty = isDefaulted ? 1 : 0
-  const totalDice = Math.max(0, ratingDice + attrValue - defaultingPenalty - woundMod)
+  const totalDice = Math.max(0, ratingDice + attrValue - defaultingPenalty - woundMod + generalPenalty)
 
   return (
     <Stack

--- a/src/components/character/spells/drainResistanceDicePool.tsx
+++ b/src/components/character/spells/drainResistanceDicePool.tsx
@@ -1,10 +1,7 @@
 import type { FC } from "react"
 
 import { DicePool } from "#/components/system/dicePool/dicePool.tsx"
-import {
-  useAttrDiceGroup,
-  useWoundDiceGroup,
-} from "#/components/system/dicePool/useDiceGroup.ts"
+import { useAttrDiceGroup } from "#/components/system/dicePool/useDiceGroup.ts"
 import { AttributeKey } from "#/system/attributeKey.ts"
 
 interface DrainResistanceDicePoolProps {
@@ -15,7 +12,6 @@ interface DrainResistanceDicePoolProps {
 export const DrainResistanceDicePool: FC<DrainResistanceDicePoolProps> = ({ drainAttribute, onRoll }) => {
   const willpowerGroup = useAttrDiceGroup(AttributeKey.willpower)
   const drainAttrGroup = useAttrDiceGroup(drainAttribute)
-  const woundGroup = useWoundDiceGroup()
 
   // When drainAttribute is willpower, disambiguate group names to avoid duplicate React keys
   const resolvedDrainAttrGroup =
@@ -26,7 +22,7 @@ export const DrainResistanceDicePool: FC<DrainResistanceDicePoolProps> = ({ drai
   return (
     <DicePool
       name="Drain Resistance"
-      groups={[willpowerGroup, resolvedDrainAttrGroup, woundGroup]}
+      groups={[willpowerGroup, resolvedDrainAttrGroup]}
       onRoll={onRoll}
     />
   )

--- a/src/components/character/spells/spellCastSection.tsx
+++ b/src/components/character/spells/spellCastSection.tsx
@@ -16,7 +16,7 @@ import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 import { useState } from "react"
 
-import { useActiveSkillRating, useAttr } from "#/components/character/characterUtils.ts"
+import { useActiveSkillRating, useAttr, useGeneralPenalty } from "#/components/character/characterUtils.ts"
 import { useCharacterSheet } from "#/components/character/sheet/characterSheetProvider.tsx"
 import {
   selectPhysicalCurrent,
@@ -46,6 +46,7 @@ export const SpellCastSection: FC<SpellCastSectionProps> = ({ spell, onClose, on
   const magicAttr = useAttr(AttributeKey.magic)
   const spellcastingRating = useActiveSkillRating(SkillKey.spellcasting)
   const woundMod = useWoundModifier()
+  const generalPenalty = useGeneralPenalty()
   const tradition = useCharacterSheet((sheet) => sheet.tradition)
   const drainAttribute = tradition?.drainAttribute ?? AttributeKey.willpower
 
@@ -56,7 +57,7 @@ export const SpellCastSection: FC<SpellCastSectionProps> = ({ spell, onClose, on
   const drainDv = computeDrainValue(force, spell)
   const drainIsPhysical = isOvercasting
 
-  const spellcastingPool = Math.max(0, magicAttr + spellcastingRating - woundMod)
+  const spellcastingPool = Math.max(0, magicAttr + spellcastingRating - woundMod + generalPenalty)
 
   const damageStore = useDamageStore()
   const physicalMax = useSelector(damageStore, selectPhysicalMax)

--- a/src/components/character/spells/spellCastSection.tsx
+++ b/src/components/character/spells/spellCastSection.tsx
@@ -4,19 +4,17 @@ import ButtonGroup from "@mui/material/ButtonGroup"
 import Divider from "@mui/material/Divider"
 import FormControl from "@mui/material/FormControl"
 import Grid from "@mui/material/Grid"
-import IconButton from "@mui/material/IconButton"
 import InputLabel from "@mui/material/InputLabel"
 import MenuItem from "@mui/material/MenuItem"
 import Select from "@mui/material/Select"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
 import { alpha } from "@mui/material/styles"
-import { RiDiceLine } from "@remixicon/react"
 import { useSelector } from "@tanstack/react-store"
 import type { FC } from "react"
 import { useState } from "react"
 
-import { useActiveSkillRating, useAttr, useGeneralPenalty } from "#/components/character/characterUtils.ts"
+import { useAttr } from "#/components/character/characterUtils.ts"
 import { useCharacterSheet } from "#/components/character/sheet/characterSheetProvider.tsx"
 import {
   selectPhysicalCurrent,
@@ -25,12 +23,10 @@ import {
   selectStunMax,
 } from "#/components/system/damage/damageSelectors.ts"
 import { useDamageStore } from "#/components/system/damage/useDamageStore.ts"
-import { useWoundModifier } from "#/components/system/damage/useWoundModifier.ts"
 import { Label } from "#/components/ui/text/label.tsx"
 import { AttributeKey } from "#/system/attributeKey.ts"
 import { DamageTrackKey } from "#/system/damageTrackKey.ts"
 import type { SpellData } from "#/system/magic/spellData.ts"
-import { SkillKey } from "#/system/skills/skillKey.ts"
 
 import { DrainResistanceDicePool } from "./drainResistanceDicePool.tsx"
 import { computeDrainValue } from "./spellDrainFormula.ts"
@@ -44,9 +40,6 @@ interface SpellCastSectionProps {
 
 export const SpellCastSection: FC<SpellCastSectionProps> = ({ spell, onClose, onRoll }) => {
   const magicAttr = useAttr(AttributeKey.magic)
-  const spellcastingRating = useActiveSkillRating(SkillKey.spellcasting)
-  const woundMod = useWoundModifier()
-  const generalPenalty = useGeneralPenalty()
   const tradition = useCharacterSheet((sheet) => sheet.tradition)
   const drainAttribute = tradition?.drainAttribute ?? AttributeKey.willpower
 
@@ -56,8 +49,6 @@ export const SpellCastSection: FC<SpellCastSectionProps> = ({ spell, onClose, on
   const isOvercasting = force > magicAttr
   const drainDv = computeDrainValue(force, spell)
   const drainIsPhysical = isOvercasting
-
-  const spellcastingPool = Math.max(0, magicAttr + spellcastingRating - woundMod + generalPenalty)
 
   const damageStore = useDamageStore()
   const physicalMax = useSelector(damageStore, selectPhysicalMax)
@@ -92,17 +83,7 @@ export const SpellCastSection: FC<SpellCastSectionProps> = ({ spell, onClose, on
     >
       <Stack sx={{ gap: 1 }}>
         <Stack sx={{ gap: 0.5 }}>
-          <Stack direction="row" sx={{ alignItems: "center", justifyContent: "space-between" }}>
-            <Label label="Cast" variant="text" />
-            <IconButton
-              size="small"
-              color="secondary"
-              aria-label={`Roll spellcasting pool (${spellcastingPool}d6)`}
-              onClick={() => onRoll(spellcastingPool)}
-            >
-              <RiDiceLine size={18} />
-            </IconButton>
-          </Stack>
+          <Label label="Cast" variant="text" />
           {isOvercasting && (
             <Typography color="error.main">
               Force exceeds Magic — drain is Physical

--- a/src/components/character/spells/spellcastingDicePool.tsx
+++ b/src/components/character/spells/spellcastingDicePool.tsx
@@ -1,7 +1,7 @@
 import type { FC } from "react"
 
 import { DicePool } from "#/components/system/dicePool/dicePool.tsx"
-import { useActiveSkillDiceGroup, useAttrDiceGroup, useWoundDiceGroup } from "#/components/system/dicePool/useDiceGroup.ts"
+import { useActiveSkillDiceGroup, useAttrDiceGroup, useGeneralPenaltyDiceGroup, useWoundDiceGroup } from "#/components/system/dicePool/useDiceGroup.ts"
 import { AttributeKey } from "#/system/attributeKey.ts"
 import { SkillKey } from "#/system/skills/skillKey.ts"
 
@@ -17,7 +17,7 @@ export const SpellcastingDicePool: FC<SpellcastingDicePoolProps> = ({ onRoll }) 
   return (
     <DicePool
       name="Spellcasting"
-      groups={[magicGroup, spellcastingGroup, woundGroup]}
+      groups={[magicGroup, spellcastingGroup, woundGroup, useGeneralPenaltyDiceGroup()]}
       onRoll={onRoll}
     />
   )

--- a/src/components/character/spirits/summoningDicePool.tsx
+++ b/src/components/character/spirits/summoningDicePool.tsx
@@ -2,7 +2,7 @@ import type { FC } from "react"
 
 import { useCharacterSheet } from "#/components/character/sheet/characterSheetProvider.tsx"
 import { DicePool } from "#/components/system/dicePool/dicePool.tsx"
-import { useActiveSkillDiceGroup, useAttrDiceGroup, useWoundDiceGroup } from "#/components/system/dicePool/useDiceGroup.ts"
+import { useActiveSkillDiceGroup, useAttrDiceGroup, useGeneralPenaltyDiceGroup, useWoundDiceGroup } from "#/components/system/dicePool/useDiceGroup.ts"
 import { useGameEffects } from "#/components/system/gameEffects/useGameEffects.ts"
 import { AttributeKey } from "#/system/attributeKey.ts"
 import { GameEffectType } from "#/system/gameEffects/gameEffectType.ts"
@@ -53,5 +53,5 @@ export const SummoningDicePool: FC<SummoningDicePoolProps> = ({ spiritType, isBo
     ? { name: specialization, size: 2 + totalSpecMod }
     : null
 
-  return <DicePool name={poolName} groups={[magicGroup, skillGroup, specGroup, woundGroup]} />
+  return <DicePool name={poolName} groups={[magicGroup, skillGroup, specGroup, woundGroup, useGeneralPenaltyDiceGroup()]} />
 }

--- a/src/components/system/dicePool/dicePools/attackDicePool.tsx
+++ b/src/components/system/dicePool/dicePools/attackDicePool.tsx
@@ -1,7 +1,7 @@
 import type { FC } from "react"
 
 import { DicePool } from "#/components/system/dicePool/dicePool.tsx"
-import { useActiveSkillDiceGroup, useAttrDiceGroup, useWoundDiceGroup } from "#/components/system/dicePool/useDiceGroup.ts"
+import { useActiveSkillDiceGroup, useAttrDiceGroup, useGeneralPenaltyDiceGroup, useWoundDiceGroup } from "#/components/system/dicePool/useDiceGroup.ts"
 import { AttributeKey } from "#/system/attributeKey.ts"
 import type { WeaponData } from "#/system/gear/weaponData.ts"
 
@@ -20,6 +20,7 @@ export const AttackDicePool: FC<AttackDicePoolProps> = ({ weapon, onRoll }) => {
         useAttrDiceGroup(attrKey),
         useActiveSkillDiceGroup(weapon.skill),
         useWoundDiceGroup(),
+        useGeneralPenaltyDiceGroup(),
       ]}
       onRoll={onRoll}
     />

--- a/src/components/system/dicePool/useDiceGroup.ts
+++ b/src/components/system/dicePool/useDiceGroup.ts
@@ -1,6 +1,6 @@
 import { useId } from "react"
 
-import { useActiveSkillRating, useAttr, useEffectiveAttr } from "#/components/character/characterUtils.ts"
+import { useActiveSkillRating, useAttr, useEffectiveAttr, useGeneralPenalty } from "#/components/character/characterUtils.ts"
 import { useWoundModifier } from "#/components/system/damage/useWoundModifier.ts"
 import { useGameEffects } from "#/components/system/gameEffects/useGameEffects.ts"
 import type { AttributeKey } from "#/system/attributeKey.ts"
@@ -41,6 +41,12 @@ export function useWoundDiceGroup(): DiceGroup | null {
   const woundMod = useWoundModifier()
   if (woundMod === 0) return null
   return { name: "Wound", size: woundMod * -1, color: "error.main" }
+}
+
+export function useGeneralPenaltyDiceGroup(): DiceGroup | null {
+  const penalty = useGeneralPenalty()
+  if (penalty === 0) return null
+  return { name: "Concentration", size: penalty, color: "warning.main" }
 }
 
 export function useDefaultingDiceGroup(skillKey: SkillKey): DiceGroup | null {

--- a/src/components/system/initiative/useInitiative.ts
+++ b/src/components/system/initiative/useInitiative.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react"
 
-import { useAttr } from "#/components/character/characterUtils.ts"
+import { useAttr, useGeneralPenalty } from "#/components/character/characterUtils.ts"
 import { useGameEffects } from "#/components/system/gameEffects/useGameEffects.ts"
 import { AttributeKey } from "#/system/attributeKey.ts"
 import { GameEffectType } from "#/system/gameEffects/gameEffectType.ts"
@@ -17,6 +17,7 @@ export const useInitiative = (): InitiativeInfo => {
   const initiativeBonuses = useGameEffects(GameEffectType.initiativeBonus)
   const extraPassEffects = useGameEffects(GameEffectType.extraInitiativePasses)
   const extraDiceEffects = useGameEffects(GameEffectType.extraInitiativeDice)
+  const generalPenalty = useGeneralPenalty()
 
   return useMemo(() => {
     const initiativeBonus = initiativeBonuses.reduce((sum, e) => sum + e.value, 0)
@@ -24,8 +25,8 @@ export const useInitiative = (): InitiativeInfo => {
     const extraDice = extraDiceEffects.reduce((sum, e) => sum + e.value, 0)
 
     return {
-      dicePool: reactionAttr + intuitionAttr + initiativeBonus + extraDice,
+      dicePool: reactionAttr + intuitionAttr + initiativeBonus + extraDice + generalPenalty,
       initiativePasses: 1 + extraInitiativePasses,
     }
-  }, [reactionAttr, intuitionAttr, initiativeBonuses, extraPassEffects, extraDiceEffects])
+  }, [reactionAttr, intuitionAttr, initiativeBonuses, extraPassEffects, extraDiceEffects, generalPenalty])
 }

--- a/src/components/system/initiative/useInitiative.ts
+++ b/src/components/system/initiative/useInitiative.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react"
 
 import { useAttr, useGeneralPenalty } from "#/components/character/characterUtils.ts"
+import { useWoundModifier } from "#/components/system/damage/useWoundModifier.ts"
 import { useGameEffects } from "#/components/system/gameEffects/useGameEffects.ts"
 import { AttributeKey } from "#/system/attributeKey.ts"
 import { GameEffectType } from "#/system/gameEffects/gameEffectType.ts"
@@ -18,6 +19,7 @@ export const useInitiative = (): InitiativeInfo => {
   const extraPassEffects = useGameEffects(GameEffectType.extraInitiativePasses)
   const extraDiceEffects = useGameEffects(GameEffectType.extraInitiativeDice)
   const generalPenalty = useGeneralPenalty()
+  const woundMod = useWoundModifier()
 
   return useMemo(() => {
     const initiativeBonus = initiativeBonuses.reduce((sum, e) => sum + e.value, 0)
@@ -25,8 +27,8 @@ export const useInitiative = (): InitiativeInfo => {
     const extraDice = extraDiceEffects.reduce((sum, e) => sum + e.value, 0)
 
     return {
-      dicePool: reactionAttr + intuitionAttr + initiativeBonus + extraDice + generalPenalty,
+      dicePool: reactionAttr + intuitionAttr + initiativeBonus + extraDice + generalPenalty - woundMod,
       initiativePasses: 1 + extraInitiativePasses,
     }
-  }, [reactionAttr, intuitionAttr, initiativeBonuses, extraPassEffects, extraDiceEffects, generalPenalty])
+  }, [reactionAttr, intuitionAttr, initiativeBonuses, extraPassEffects, extraDiceEffects, generalPenalty, woundMod])
 }

--- a/src/components/system/manualStatus/manualStatusPanel.tsx
+++ b/src/components/system/manualStatus/manualStatusPanel.tsx
@@ -28,6 +28,7 @@ type SupportedEffectType =
   | GameEffectType.initiativeBonus
   | GameEffectType.extraInitiativePasses
   | GameEffectType.extraInitiativeDice
+  | GameEffectType.generalPenalty
 
 const EFFECT_TYPE_LABELS: Record<SupportedEffectType, string> = {
   [GameEffectType.attrMod]: "Attribute modifier",
@@ -35,6 +36,7 @@ const EFFECT_TYPE_LABELS: Record<SupportedEffectType, string> = {
   [GameEffectType.initiativeBonus]: "Initiative bonus",
   [GameEffectType.extraInitiativePasses]: "Extra initiative passes",
   [GameEffectType.extraInitiativeDice]: "Extra initiative dice",
+  [GameEffectType.generalPenalty]: "Concentration penalty (all pools)",
 }
 
 const NEEDS_ATTR_TARGET = new Set<SupportedEffectType>([GameEffectType.attrMod])
@@ -53,6 +55,8 @@ function singleEffectLabel(effect: GameEffectData): string {
       return `+${effect.value} IP`
     case GameEffectType.extraInitiativeDice:
       return `+${effect.value} Init Dice`
+    case GameEffectType.generalPenalty:
+      return `${sign}${effect.value} all pools`
     default:
       return `${sign}${effect.value}`
   }

--- a/src/system/gameEffects/gameEffectData.ts
+++ b/src/system/gameEffects/gameEffectData.ts
@@ -86,6 +86,15 @@ export interface PainToleranceEffect extends GameEffectData {
 }
 
 /**
+ * Flat penalty to all general action dice pools (active skills, initiative).
+ * Used for concentration penalties from sustaining spells without a sustaining focus.
+ * Drain resistance is exempt — it uses raw attributes.
+ */
+export interface GeneralPenaltyEffect extends GameEffectData {
+  type: GameEffectType.generalPenalty
+}
+
+/**
  * Mapped type for looking up concrete effect interfaces by their type enum.
  */
 export type EffectByType = {
@@ -98,6 +107,7 @@ export type EffectByType = {
   [GameEffectType.painTolerance]: PainToleranceEffect
   [GameEffectType.recoilReduction]: RecoilReductionEffect
   [GameEffectType.dicePoolMod]: DicePoolModEffect
+  [GameEffectType.generalPenalty]: GeneralPenaltyEffect
 }
 
 const InitiativeBonusSchema = z.object({
@@ -153,6 +163,11 @@ const PainToleranceSchema = z.object({
   value: z.number(),
 })
 
+const GeneralPenaltySchema = z.object({
+  type: z.literal(GameEffectType.generalPenalty),
+  value: z.number(),
+})
+
 /**
  * Discriminated union schema for all game effects.
  */
@@ -166,4 +181,5 @@ export const GameEffectDataSchema = z.discriminatedUnion("type", [
   ExtraInitiativePassesSchema,
   ExtraInitiativeDiceSchema,
   PainToleranceSchema,
+  GeneralPenaltySchema,
 ]) satisfies z.ZodType<GameEffectData>

--- a/src/system/gameEffects/gameEffectType.ts
+++ b/src/system/gameEffects/gameEffectType.ts
@@ -8,4 +8,5 @@ export enum GameEffectType {
   extraInitiativePasses = "extraInitiativePasses",
   extraInitiativeDice = "extraInitiativeDice",
   painTolerance = "painTolerance",
+  generalPenalty = "generalPenalty",
 }


### PR DESCRIPTION
## Summary
- Adds `generalPenalty` game effect type applied to all dice pools (spellcasting, summoning, attack, skills)
- Wires `useGeneralPenaltyDiceGroup` into all relevant dice pool components
- Applies wound modifier consistently to skill roll display (`skillListItem`, `spellCastSection`)
- Exempts `DrainResistanceDicePool` from wound modifier (SR4 rules: drain resistance is not penalized by wounds)
- Removes duplicate roll button from spell cast section

## Stack
This is part of a stack split from `feat/spellcasting-drain` (PR #188):
1. `feat/sustained-spells` → `feat/initiative-roll` — sustained spells display (PR #209)
2. `feat/manual-status` → `feat/sustained-spells` — player-entered temporary modifiers (PR #210)
3. **This PR** — concentration/sustaining penalty across all dice pools

## Test plan
- [ ] Add a `generalPenalty` manual status; verify all dice pools (spellcasting, attack, skills) decrease by that amount
- [ ] Verify drain resistance pool is NOT affected by wound modifier
- [ ] Verify wound modifier applies to spellcasting, attack, and skill dice pools
- [ ] Verify the cast roll button in the spell dialog no longer appears twice