### PR TITLE
test: add setup file to flush React scheduler

### DIFF
--- a/testUtils/setup.ts
+++ b/testUtils/setup.ts
@@ -1,0 +1,9 @@
+import { afterEach } from "vitest"
+
+afterEach(async () => {
+  // React's scheduler queues work via Node's setImmediate. In the happy-dom
+  // environment, setImmediate callbacks that fire after window teardown throw
+  // "window is not defined". Awaiting a setImmediate here ensures all
+  // previously-queued callbacks have run before the environment is torn down.
+  await new Promise<void>((resolve) => setImmediate(resolve))
+})

--- a/testUtils/setup.ts
+++ b/testUtils/setup.ts
@@ -1,3 +1,5 @@
+import { setImmediate } from "node:timers"
+
 import { afterEach } from "vitest"
 
 afterEach(async () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,7 @@ const config = defineConfig({
 
   test: {
     include: ["**/*.test.{ts,tsx}"],
+    setupFiles: ["./testUtils/setup.ts"],
     environment: "happy-dom",
     // Concurrent test execution is disabled because tests using
     // `vi.useFakeTimers()` (notably `src/system/dice/diceRoller.test.ts`)


### PR DESCRIPTION
Root cause: implantItemList.test.tsx imports RTL directly (not via renderUtils.tsx), so it didn't get the afterEach(() => cleanup()) from that file. More critically, React's scheduler queues async work via Node's native setImmediate during component teardown — and in CI's happy-dom environment, those callbacks were firing after the window was torn down, causing ReferenceError: window is not defined.

Fix: testUtils/setup.ts — a global Vitest setup file (wired via setupFiles in vite.config.ts) that runs afterEach, awaiting a setImmediate. Since Node processes setImmediate callbacks in FIFO order, this guarantees all of React's pending scheduler work has completed before the happy-dom environment tears down.