### PR TITLE
feat: add damage tracking to equipped armor

### DIFF
--- a/src/components/items/types/armor/equippedArmorCard.tsx
+++ b/src/components/items/types/armor/equippedArmorCard.tsx
@@ -1,0 +1,68 @@
+import Grid from "@mui/material/Grid"
+import Stack from "@mui/material/Stack"
+import type { FC } from "react"
+
+import { ItemCard } from "#/components/items/card/itemCard.tsx"
+import { ItemStatChip } from "#/components/items/card/itemStatChip.tsx"
+import DamageTrack from "#/components/system/damage/damageTrack.tsx"
+import type { ArmorData } from "#/system/gear/armorData.ts"
+
+export interface EquippedArmorCardProps {
+  armor: ArmorData
+  onDamageChange: (damage: NonNullable<ArmorData["damage"]>) => void
+}
+
+export const EquippedArmorCard: FC<EquippedArmorCardProps> = ({ armor, onDamageChange }) => {
+  const damage = armor.damage ?? { ballistic: 0, impact: 0 }
+  const effectiveBallistic = Math.max(0, armor.ballistic - damage.ballistic)
+  const effectiveImpact = Math.max(0, armor.impact - damage.impact)
+
+  const ballisticLabel = damage.ballistic > 0
+    ? `B: ${effectiveBallistic}/${armor.ballistic}`
+    : `B: ${armor.ballistic}`
+  const impactLabel = damage.impact > 0
+    ? `I: ${effectiveImpact}/${armor.impact}`
+    : `I: ${armor.impact}`
+
+  const hasTracks = armor.ballistic > 0 || armor.impact > 0
+
+  return (
+    <ItemCard>
+      <ItemCard.Title>{armor.name}</ItemCard.Title>
+      <ItemCard.Meta type="stat">
+        <ItemStatChip label={ballisticLabel} />
+        <ItemStatChip label={impactLabel} />
+      </ItemCard.Meta>
+      {hasTracks && (
+        <ItemCard.Children>
+          <Stack sx={{ p: 1, gap: 1 }}>
+            <Grid container columns={2} spacing={1}>
+              {armor.ballistic > 0 && (
+                <Grid size={1}>
+                  <DamageTrack
+                    label="Ballistic"
+                    max={armor.ballistic}
+                    current={damage.ballistic}
+                    woundInterval={armor.ballistic + 1}
+                    onChange={(value) => onDamageChange({ ...damage, ballistic: value })}
+                  />
+                </Grid>
+              )}
+              {armor.impact > 0 && (
+                <Grid size={1}>
+                  <DamageTrack
+                    label="Impact"
+                    max={armor.impact}
+                    current={damage.impact}
+                    woundInterval={armor.impact + 1}
+                    onChange={(value) => onDamageChange({ ...damage, impact: value })}
+                  />
+                </Grid>
+              )}
+            </Grid>
+          </Stack>
+        </ItemCard.Children>
+      )}
+    </ItemCard>
+  )
+}

--- a/src/system/gear/armorData.ts
+++ b/src/system/gear/armorData.ts
@@ -5,6 +5,10 @@ export interface ArmorData extends ItemData {
   itemType: ItemType.armor
   ballistic: number
   impact: number
+  damage?: {
+    ballistic: number
+    impact: number
+  }
 }
 
 export function isArmorData(item: ItemData): item is ArmorData {

--- a/src/system/gear/armorData.ts
+++ b/src/system/gear/armorData.ts
@@ -1,5 +1,11 @@
+import type { UUID } from "node:crypto"
+
+import { z } from "zod"
+
+import { GameEffectDataSchema } from "#/system/gameEffects/gameEffectData.ts"
 import type { ItemData } from "#/system/itemData.ts"
 import { ItemType } from "#/system/itemType.ts"
+import { SourceDataSchema } from "#/system/sourceData.ts"
 
 export interface ArmorData extends ItemData {
   itemType: ItemType.armor
@@ -10,6 +16,44 @@ export interface ArmorData extends ItemData {
     impact: number
   }
 }
+
+export const ArmorDataSchema = z.object({
+  id: z.uuid() as z.ZodType<UUID>,
+  name: z.string(),
+  itemType: z.literal(ItemType.armor),
+
+  description: z.string().optional(),
+  cost: z.number().optional(),
+  quantity: z.number().int().min(0).optional(),
+  availability: z.object({
+    rating: z.number().int().min(0),
+    restricted: z.boolean().optional(),
+    forbidden: z.boolean().optional(),
+  }).optional(),
+  source: SourceDataSchema.optional(),
+  rating: z.union([z.number(), z.string()]).optional(),
+
+  parentId: (z.uuid() as z.ZodType<UUID>).optional(),
+  childIds: z.array(z.uuid() as z.ZodType<UUID>).optional(),
+
+  notes: z.string().optional(),
+  equipped: z.boolean().optional(),
+  fixed: z.boolean().optional(),
+
+  wireless: z.object({
+    enabled: z.boolean().optional(),
+    removed: z.boolean().optional(),
+  }).optional(),
+
+  effects: z.array(GameEffectDataSchema).optional(),
+
+  ballistic: z.number().int().min(0),
+  impact: z.number().int().min(0),
+  damage: z.object({
+    ballistic: z.number().int().min(0),
+    impact: z.number().int().min(0),
+  }).optional(),
+}) satisfies z.ZodType<ArmorData>
 
 export function isArmorData(item: ItemData): item is ArmorData {
   return item.itemType === ItemType.armor


### PR DESCRIPTION
Add optional damage property to armor data to track ballistic
and impact damage separately. Implement damage tracks in the
equipped armor card component to allow users to mark damage
on their armor. Display effective armor values by subtracting
damage from base values.