### PR TITLE
feat: change itemType from single value to array

### DIFF
--- a/src/character/fixtures/artemis.ts
+++ b/src/character/fixtures/artemis.ts
@@ -102,32 +102,32 @@ export const Artemis: CharacterSheet = {
   gear: createItemMap(
     createItem<SinData>({
       name: "Sara McCabe",
-      itemType: ItemType.sin,
+      itemType: [ItemType.sin],
       notes: "General use SIN.",
       rating: 6,
     }),
     createItem<SinData>({
       name: "Jadzia Dax",
-      itemType: ItemType.sin,
+      itemType: [ItemType.sin],
       notes: "Runner SIN.",
       rating: 4,
     }, [
       createItem<LicenseData>({
         name: "Driver License (Semi-Truck)",
-        itemType: ItemType.license,
+        itemType: [ItemType.license],
         fixed: true,
         rating: 5,
       }),
     ]),
     createItem<SinData>({
       name: "Jane Smith",
-      itemType: ItemType.sin,
+      itemType: [ItemType.sin],
       notes: "Burner SIN.",
       rating: 2,
     }),
     createItem<FirearmData>({
       name: "FN P93 Predator",
-      itemType: ItemType.weapon,
+      itemType: [ItemType.weapon],
       weaponType: WeaponType.firearm,
       firearmType: FirearmTypeKey.lightPistol,
       attribute: AttributeKey.agility,
@@ -144,19 +144,19 @@ export const Artemis: CharacterSheet = {
     }, [
       createItem<FirearmAccessoryData>({
         name: "Laser sight",
-        itemType: ItemType.firearmAccessory,
+        itemType: [ItemType.firearmAccessory],
         mountPoints: [FirearmAttachmentPoint.Top, FirearmAttachmentPoint.Under],
         parentSlot: FirearmAttachmentPoint.Top,
       }),
       createItem<FirearmAccessoryData>({
         name: "Flashlight",
-        itemType: ItemType.firearmAccessory,
+        itemType: [ItemType.firearmAccessory],
         mountPoints: [FirearmAttachmentPoint.Top, FirearmAttachmentPoint.Under],
         parentSlot: FirearmAttachmentPoint.Under,
       }),
       createItem<FirearmAccessoryData>({
         name: "Rigid Stock",
-        itemType: ItemType.firearmAccessory,
+        itemType: [ItemType.firearmAccessory],
         fixed: true,
         enabled: true,
         mountPoints: [FirearmAttachmentPoint.Internal],
@@ -170,7 +170,7 @@ export const Artemis: CharacterSheet = {
       }),
       createItem<FirearmAccessoryData>({
         name: "Smart Gun Int.",
-        itemType: ItemType.firearmAccessory,
+        itemType: [ItemType.firearmAccessory],
         fixed: true,
         notes: "Wireless bonus.",
         mountPoints: [FirearmAttachmentPoint.Internal],
@@ -183,7 +183,7 @@ export const Artemis: CharacterSheet = {
       firemodes: ["SA"],
       recoil: 0,
       name: "Colt America L36",
-      itemType: ItemType.weapon,
+      itemType: [ItemType.weapon],
       weaponType: WeaponType.firearm,
       firearmType: FirearmTypeKey.smg,
       skill: SkillKey.automatics,
@@ -191,7 +191,7 @@ export const Artemis: CharacterSheet = {
     }, [
       createItem<FirearmAccessoryData>({
         name: "Smart Gun Int.",
-        itemType: ItemType.firearmAccessory,
+        itemType: [ItemType.firearmAccessory],
         fixed: true,
         notes: "Wireless bonus.",
         mountPoints: [FirearmAttachmentPoint.Internal],
@@ -200,14 +200,14 @@ export const Artemis: CharacterSheet = {
     ]),
     createItem<ArmorData>({
       name: "Armored Jacket",
-      itemType: ItemType.armor,
+      itemType: [ItemType.armor],
       equipped: true,
       ballistic: 8,
       impact: 6,
     }),
     createItem<ArmorData>({
       name: "Form-Fitting Body Armor",
-      itemType: ItemType.armor,
+      itemType: [ItemType.armor],
       equipped: true,
       ballistic: 2,
       impact: 1,
@@ -215,7 +215,7 @@ export const Artemis: CharacterSheet = {
     }),
     createItem<ImplantData>({
       name: "Control Rig",
-      itemType: ItemType.implant,
+      itemType: [ItemType.implant],
       implantType: "cyberware",
       location: ImplantLocation.head,
       cost: 72000,
@@ -226,7 +226,7 @@ export const Artemis: CharacterSheet = {
     createItem<ImplantData>({
       essenceCost: 0,
       name: "RCC Headwear",
-      itemType: ItemType.implant,
+      itemType: [ItemType.implant],
       implantType: "cyberware",
       location: ImplantLocation.head,
       cost: 2000,
@@ -235,7 +235,7 @@ export const Artemis: CharacterSheet = {
     createItem<ImplantData>({
       essenceCost: 0,
       name: "Cybereyes",
-      itemType: ItemType.implant,
+      itemType: [ItemType.implant],
       implantType: "cyberware",
       grade: ImplantGrade.alpha,
       cost: 12000,
@@ -243,35 +243,35 @@ export const Artemis: CharacterSheet = {
       capacity: 12,
     }, [
       createItem<ImplantData>({
-        itemType: ItemType.implant,
+        itemType: [ItemType.implant],
         name: "Smartlink",
         cost: 4800,
         capacityCost: 3,
         essenceCost: 0,
       }),
       createItem<ImplantData>({
-        itemType: ItemType.implant,
+        itemType: [ItemType.implant],
         name: "Imagelink",
         cost: 960,
         capacityCost: 0,
         essenceCost: 0,
       }),
       createItem<ImplantData>({
-        itemType: ItemType.implant,
+        itemType: [ItemType.implant],
         name: "Low-Light Vision",
         cost: 900,
         capacityCost: 0,
         essenceCost: 0,
       }),
       createItem<ImplantData>({
-        itemType: ItemType.implant,
+        itemType: [ItemType.implant],
         name: "Vision Enhancement",
         cost: 4800,
         capacityCost: 0,
         essenceCost: 0,
       }),
       createItem<ImplantData>({
-        itemType: ItemType.implant,
+        itemType: [ItemType.implant],
         name: "Vision Magnification",
         cost: 2400,
         capacityCost: 0,
@@ -280,7 +280,7 @@ export const Artemis: CharacterSheet = {
     ]),
     createItem<ImplantData>({
       name: "Cerebral Booster",
-      itemType: ItemType.implant,
+      itemType: [ItemType.implant],
       implantType: "bioware",
       grade: ImplantGrade.standard,
       essenceCost: 0.66,
@@ -297,7 +297,7 @@ export const Artemis: CharacterSheet = {
     }),
     createItem<ImplantData>({
       name: "Sleep Regulator",
-      itemType: ItemType.implant,
+      itemType: [ItemType.implant],
       implantType: "bioware",
       cost: 6000,
       essenceCost: 0.11,
@@ -306,7 +306,7 @@ export const Artemis: CharacterSheet = {
     }),
     createItem<ImplantData>({
       name: "Synaptic Booster",
-      itemType: ItemType.implant,
+      itemType: [ItemType.implant],
       implantType: "bioware",
       grade: ImplantGrade.standard,
       essenceCost: 0.66,
@@ -327,55 +327,55 @@ export const Artemis: CharacterSheet = {
     }),
     createItem<DeviceData>({
       name: "Proteus Poseidon",
-      itemType: ItemType.device,
+      itemType: [ItemType.device],
       cost: 68000,
       notes: "RCC; deviceRating 5, dataProcessing 5, firewall 5.",
     }, [
       createItem<SoftwareData>({
         name: "FN-HAR Targeting Autosoft",
-        itemType: ItemType.software,
+        itemType: [ItemType.software],
         cost: 4000,
         rating: 8,
       }),
       createItem<SoftwareData>({
         name: "Clearsight Autosoft",
-        itemType: ItemType.software,
+        itemType: [ItemType.software],
         cost: 4000,
         rating: 8,
       }),
       createItem<SoftwareData>({
         name: "Evasion Autosoft",
-        itemType: ItemType.software,
+        itemType: [ItemType.software],
         cost: 4000,
         rating: 8,
       }),
       createItem<SoftwareData>({
         name: "Maneuvering Autosoft",
-        itemType: ItemType.software,
+        itemType: [ItemType.software],
         cost: 4000,
         rating: 8,
       }),
       createItem<SoftwareData>({
         name: "Electronic Warfare Autosoft",
-        itemType: ItemType.software,
+        itemType: [ItemType.software],
         cost: 4000,
         rating: 8,
       }),
       createItem<SoftwareData>({
         name: "Black Knight Targeting Autosoft",
-        itemType: ItemType.software,
+        itemType: [ItemType.software],
         cost: 4000,
         rating: 8,
       }),
     ]),
     createItem<DeviceData>({
       name: "Commlink (headware)",
-      itemType: ItemType.device,
+      itemType: [ItemType.device],
       cost: 1000,
     }, [
       createItem<DeviceData>({
         name: "Hermes Ikon",
-        itemType: ItemType.device,
+        itemType: [ItemType.device],
         cost: 5000,
         fixed: true,
         rating: 5,
@@ -384,7 +384,7 @@ export const Artemis: CharacterSheet = {
     ]),
     createItem<VehicleData>({
       name: "Yamaha Growler",
-      itemType: ItemType.vehicle,
+      itemType: [ItemType.vehicle],
       vehicleCategory: VehicleCategory.vehicle,
       damage: { physical: { current: 0, max: 0 } },
       model: "",
@@ -401,7 +401,7 @@ export const Artemis: CharacterSheet = {
     }),
     createItem<VehicleData>({
       name: "Russian Osprey 9",
-      itemType: ItemType.vehicle,
+      itemType: [ItemType.vehicle],
       vehicleCategory: VehicleCategory.vehicle,
       vehicleType: "vtol",
       handling: 3,
@@ -415,7 +415,7 @@ export const Artemis: CharacterSheet = {
     }),
     createItem<ItemData>({
       name: "Engineering Shop",
-      itemType: ItemType.other,
+      itemType: [ItemType.other],
       cost: 5000,
     }),
   ),

--- a/src/character/migrations.test.ts
+++ b/src/character/migrations.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from "vitest"
 import { characterSheetToYaml, yamlToCharacterSheet } from "#/components/character/exportImport/exportUtils.ts"
 import { toJsonValue } from "#/lib/jsonUtils.ts"
 import type { AsyncJsonStorage } from "#/lib/storage/asyncStorage.ts"
+import { ItemType } from "#/system/itemType.ts"
 import BlurYaml from "#testUtils/fixtures/characters/blur.yaml?raw"
 import {
   characterV0,
@@ -147,21 +148,21 @@ describe("character migrations + yaml round-trip", () => {
     // gear is a Record, empty items stripped, itemTypes normalised
     const gearValues = Object.values(migrated.gear)
     const weapon = gearValues.find((item) => item.name === "SM-4")
-    expect(weapon?.itemType).toBe("weapon")
+    expect(weapon?.itemType).toEqual(["weapon"])
     const device = gearValues.find((item) => item.name === "Contact Lenses 3")
-    expect(device?.itemType).toBe("device")
+    expect(device?.itemType).toEqual(["device"])
     const other = gearValues.find((item) => item.name === "Power Foci 2")
-    expect(other?.itemType).toBe("other")
+    expect(other?.itemType).toEqual(["other"])
     const vehicle = gearValues.find((item) => item.name === "Indian Pathfinder")
-    expect(vehicle?.itemType).toBe("vehicle")
+    expect(vehicle?.itemType).toEqual(["vehicle"])
 
     // license linked to SIN via parentId
     const sin = migrated.gear[TEST_OLD_FORMAT_SIN_ID]
     expect(sin).toBeDefined()
-    expect(sin.itemType).toBe("sin")
+    expect(sin.itemType).toEqual(["sin"])
     const license = migrated.gear[TEST_OLD_FORMAT_LICENSE_ID]
     expect(license).toBeDefined()
-    expect(license.itemType).toBe("license")
+    expect(license.itemType).toEqual(["license"])
     expect(license.parentId).toBe(TEST_OLD_FORMAT_SIN_ID)
     expect(sin.childIds).toContain(TEST_OLD_FORMAT_LICENSE_ID)
 
@@ -198,13 +199,13 @@ describe("character migrations + yaml round-trip", () => {
 
     // gear is a Record, empty entries stripped, itemTypes normalised
     const gearValues = Object.values(character.gear)
-    expect(gearValues.find((item) => item.name === "SM-4")?.itemType).toBe("weapon")
-    expect(gearValues.find((item) => item.name === "Contact Lenses 3")?.itemType).toBe("device")
-    expect(gearValues.find((item) => item.name === "Power Foci 2")?.itemType).toBe("other")
+    expect(gearValues.find((item) => item.name === "SM-4")?.itemType).toEqual(["weapon"])
+    expect(gearValues.find((item) => item.name === "Contact Lenses 3")?.itemType).toEqual(["device"])
+    expect(gearValues.find((item) => item.name === "Power Foci 2")?.itemType).toEqual(["other"])
 
     // license linked to its parent SIN
-    const sin = gearValues.find((item) => item.itemType === "sin")
-    const license = gearValues.find((item) => item.itemType === "license")
+    const sin = gearValues.find((item) => item.itemType.includes(ItemType.sin))
+    const license = gearValues.find((item) => item.itemType.includes(ItemType.license))
     expect(sin).toBeDefined()
     expect(license).toBeDefined()
     expect(license!.parentId).toBe(sin!.id)

--- a/src/character/migrations.ts
+++ b/src/character/migrations.ts
@@ -15,6 +15,7 @@ export const migrations: AnyCharacterMigration[] = [
   await import("./migrations/20260503_nestSpellDrain.ts"),
   await import("./migrations/20260509_renameBookSR20AtoSR4A.ts"),
   await import("./migrations/20260510_renameAdeptPowersToPowers.ts"),
+  await import("./migrations/20260516_itemTypeAsArray.ts"),
 ].map((module) => module.default)
 
 export const migrationIds: readonly string[] = migrations.map((m) => m.id)

--- a/src/character/migrations/20260516_itemTypeAsArray.ts
+++ b/src/character/migrations/20260516_itemTypeAsArray.ts
@@ -1,0 +1,24 @@
+import { produce } from "immer"
+
+import type { CharacterMigration } from "#/character/characterMigration.ts"
+
+interface GearItem {
+  itemType?: string | string[]
+}
+
+const migration: CharacterMigration<{
+  gear?: Record<string, GearItem>
+}> = {
+  id: "20260516",
+  up: produce((character) => {
+    if (!character.gear) return
+
+    for (const item of Object.values(character.gear)) {
+      if (typeof item.itemType === "string") {
+        item.itemType = [item.itemType]
+      }
+    }
+  }),
+}
+
+export default migration

--- a/src/components/builder/sections/gear/gearSection.tsx
+++ b/src/components/builder/sections/gear/gearSection.tsx
@@ -219,7 +219,7 @@ const GearSectionNuyen: FC<{
   }
 
   const nuyen = Object.values(allGearItems)
-    .filter((i) => i.itemType === genericSectionTypes[section])
+    .filter((i) => i.itemType.includes(genericSectionTypes[section]!))
     .reduce((sum, item) => sum + (item.cost ?? 0), 0)
 
   return (

--- a/src/components/builder/sections/gear/gearUtils.ts
+++ b/src/components/builder/sections/gear/gearUtils.ts
@@ -5,6 +5,7 @@ import { getSinAvailability } from "#/components/items/types/licenses/sinUtils.t
 import { isImplant } from "#/system/gear/implantData.ts"
 import { isLicenseData } from "#/system/gear/licenseData.ts"
 import { isSinData } from "#/system/gear/sinData.ts"
+import type { ItemType } from "#/system/itemType.ts"
 
 import { SectionHeader } from "./sectionHeader.tsx"
 
@@ -64,7 +65,7 @@ export const useGearAvailabilityIssues = () => {
     } else {
       const sectionKey = genericSectionKeys[sectionName]
       if (sectionKey) {
-        const items = allGear.filter((i) => i.itemType === sectionKey)
+        const items = allGear.filter((i) => i.itemType.includes(sectionKey as ItemType))
         const invalidItems = items.filter((it) => (it.availability?.rating ?? Number.NEGATIVE_INFINITY) > GearMaxAvailability)
         if (invalidItems.length > 0) {
           invalidSections.add(sectionName)

--- a/src/components/character/exportImport/exportUtils.test.ts
+++ b/src/components/character/exportImport/exportUtils.test.ts
@@ -22,7 +22,7 @@ describe("gearToTree", () => {
   it("includes a root-level SIN with no children", () => {
     // Arrange
     const gear = createItemMap(
-      createItem<SinData>({ name: "Sara McCabe", itemType: ItemType.sin, rating: 6 }),
+      createItem<SinData>({ name: "Sara McCabe", itemType: [ItemType.sin], rating: 6 }),
     )
 
     // Act
@@ -31,16 +31,16 @@ describe("gearToTree", () => {
     // Assert
     expect(result).toHaveLength(1)
     expect(result[0].name).toBe("Sara McCabe")
-    expect(result[0].itemType).toBe(ItemType.sin)
+    expect(result[0].itemType).toEqual([ItemType.sin])
     expect(result[0].children).toBeUndefined()
   })
 
   it("includes multiple root-level SINs with no children", () => {
     // Arrange
     const gear = createItemMap(
-      createItem<SinData>({ name: "Sara McCabe", itemType: ItemType.sin, rating: 6 }),
-      createItem<SinData>({ name: "Jadzia Dax", itemType: ItemType.sin, rating: 4 }),
-      createItem<SinData>({ name: "Jane Smith", itemType: ItemType.sin, rating: 2 }),
+      createItem<SinData>({ name: "Sara McCabe", itemType: [ItemType.sin], rating: 6 }),
+      createItem<SinData>({ name: "Jadzia Dax", itemType: [ItemType.sin], rating: 4 }),
+      createItem<SinData>({ name: "Jane Smith", itemType: [ItemType.sin], rating: 2 }),
     )
 
     // Act
@@ -57,10 +57,10 @@ describe("gearToTree", () => {
   it("nests licenses under their parent SIN", () => {
     // Arrange
     const gear = createItemMap(
-      createItem<SinData>({ name: "Jadzia Dax", itemType: ItemType.sin, rating: 4 }, [
+      createItem<SinData>({ name: "Jadzia Dax", itemType: [ItemType.sin], rating: 4 }, [
         createItem<LicenseData>({
           name: "Driver License",
-          itemType: ItemType.license,
+          itemType: [ItemType.license],
           rating: 4,
         }),
       ]),
@@ -75,17 +75,17 @@ describe("gearToTree", () => {
     expect(sin.name).toBe("Jadzia Dax")
     expect(sin.children).toHaveLength(1)
     expect(sin.children![0].name).toBe("Driver License")
-    expect(sin.children![0].itemType).toBe(ItemType.license)
+    expect(sin.children![0].itemType).toEqual([ItemType.license])
     expect(sin.children![0].children).toBeUndefined()
   })
 
   it("nests multiple licenses under a single SIN", () => {
     // Arrange
     const gear = createItemMap(
-      createItem<SinData>({ name: "Runner SIN", itemType: ItemType.sin, rating: 4 }, [
-        createItem<LicenseData>({ name: "Driver License", itemType: ItemType.license, rating: 4 }),
-        createItem<LicenseData>({ name: "Firearms License", itemType: ItemType.license, rating: 4 }),
-        createItem<LicenseData>({ name: "Cyberware License", itemType: ItemType.license, rating: 4 }),
+      createItem<SinData>({ name: "Runner SIN", itemType: [ItemType.sin], rating: 4 }, [
+        createItem<LicenseData>({ name: "Driver License", itemType: [ItemType.license], rating: 4 }),
+        createItem<LicenseData>({ name: "Firearms License", itemType: [ItemType.license], rating: 4 }),
+        createItem<LicenseData>({ name: "Cyberware License", itemType: [ItemType.license], rating: 4 }),
       ]),
     )
 
@@ -105,11 +105,11 @@ describe("gearToTree", () => {
   it("includes SINs without licenses alongside SINs with licenses", () => {
     // Arrange
     const gear = createItemMap(
-      createItem<SinData>({ name: "Clean SIN", itemType: ItemType.sin, rating: 6 }),
-      createItem<SinData>({ name: "Runner SIN", itemType: ItemType.sin, rating: 4 }, [
-        createItem<LicenseData>({ name: "Driver License", itemType: ItemType.license, rating: 4 }),
+      createItem<SinData>({ name: "Clean SIN", itemType: [ItemType.sin], rating: 6 }),
+      createItem<SinData>({ name: "Runner SIN", itemType: [ItemType.sin], rating: 4 }, [
+        createItem<LicenseData>({ name: "Driver License", itemType: [ItemType.license], rating: 4 }),
       ]),
-      createItem<SinData>({ name: "Burner SIN", itemType: ItemType.sin, rating: 2 }),
+      createItem<SinData>({ name: "Burner SIN", itemType: [ItemType.sin], rating: 2 }),
     )
 
     // Act
@@ -135,8 +135,8 @@ describe("gearToTree", () => {
   it("omits parentId and childIds from every exported node", () => {
     // Arrange
     const gear = createItemMap(
-      createItem<SinData>({ name: "Runner SIN", itemType: ItemType.sin, rating: 4 }, [
-        createItem<LicenseData>({ name: "Driver License", itemType: ItemType.license, rating: 4 }),
+      createItem<SinData>({ name: "Runner SIN", itemType: [ItemType.sin], rating: 4 }, [
+        createItem<LicenseData>({ name: "Driver License", itemType: [ItemType.license], rating: 4 }),
       ]),
     )
 
@@ -162,8 +162,8 @@ describe("gearToTree", () => {
   it("does not include child items at the root level", () => {
     // Arrange
     const gear = createItemMap(
-      createItem<SinData>({ name: "Runner SIN", itemType: ItemType.sin, rating: 4 }, [
-        createItem<LicenseData>({ name: "Driver License", itemType: ItemType.license, rating: 4 }),
+      createItem<SinData>({ name: "Runner SIN", itemType: [ItemType.sin], rating: 4 }, [
+        createItem<LicenseData>({ name: "Driver License", itemType: [ItemType.license], rating: 4 }),
       ]),
     )
 
@@ -182,11 +182,11 @@ describe("gearToTree", () => {
     const licenseId = crypto.randomUUID()
 
     const gear: Record<string, ItemData> = {
-      [sinId]: { id: sinId, name: "Handcrafted SIN", itemType: ItemType.sin, rating: 4, childIds: [licenseId] },
+      [sinId]: { id: sinId, name: "Handcrafted SIN", itemType: [ItemType.sin], rating: 4, childIds: [licenseId] },
       [licenseId]: {
         id: licenseId,
         name: "Handcrafted License",
-        itemType: ItemType.license,
+        itemType: [ItemType.license],
         rating: 4,
         parentId: sinId,
       },
@@ -210,7 +210,7 @@ describe("gearFromTree", () => {
 
   it("round-trips a flat list of root items", () => {
     const gear = createItemMap(
-      createItem<SinData>({ name: "Sara McCabe", itemType: ItemType.sin, rating: 6 }),
+      createItem<SinData>({ name: "Sara McCabe", itemType: [ItemType.sin], rating: 6 }),
     )
     const tree = gearToTree(gear)
     const restored = gearFromTree(tree)
@@ -226,8 +226,8 @@ describe("gearFromTree", () => {
 
   it("round-trips parent/child relationships", () => {
     const gear = createItemMap(
-      createItem<SinData>({ name: "Runner SIN", itemType: ItemType.sin, rating: 4 }, [
-        createItem<LicenseData>({ name: "Driver License", itemType: ItemType.license, rating: 4 }),
+      createItem<SinData>({ name: "Runner SIN", itemType: [ItemType.sin], rating: 4 }, [
+        createItem<LicenseData>({ name: "Driver License", itemType: [ItemType.license], rating: 4 }),
       ]),
     )
 
@@ -237,8 +237,8 @@ describe("gearFromTree", () => {
     // Flat map should have both items
     expect(Object.keys(restored)).toHaveLength(2)
 
-    const sinEntry = Object.values(restored).find((item) => item.itemType === ItemType.sin)
-    const licenseEntry = Object.values(restored).find((item) => item.itemType === ItemType.license)
+    const sinEntry = Object.values(restored).find((item) => item.itemType.includes(ItemType.sin))
+    const licenseEntry = Object.values(restored).find((item) => item.itemType.includes(ItemType.license))
 
     expect(sinEntry).toBeDefined()
     expect(licenseEntry).toBeDefined()
@@ -248,7 +248,7 @@ describe("gearFromTree", () => {
 
   it("restores items without parentId for root nodes", () => {
     const gear = createItemMap(
-      createItem<SinData>({ name: "Clean SIN", itemType: ItemType.sin, rating: 6 }),
+      createItem<SinData>({ name: "Clean SIN", itemType: [ItemType.sin], rating: 6 }),
     )
     const tree = gearToTree(gear)
     const restored = gearFromTree(tree)
@@ -261,7 +261,7 @@ describe("gearFromTree", () => {
 describe("yamlToCharacterSheet / characterSheetToYaml round-trip", () => {
   it("round-trips a simple character sheet", () => {
     const gear = createItemMap(
-      createItem<SinData>({ name: "Sara McCabe", itemType: ItemType.sin, rating: 6 }),
+      createItem<SinData>({ name: "Sara McCabe", itemType: [ItemType.sin], rating: 6 }),
     )
     const original = {
       ...Artemis,
@@ -281,9 +281,9 @@ describe("yamlToCharacterSheet / characterSheetToYaml round-trip", () => {
 
   it("round-trips a character with nested gear (SIN + licenses)", () => {
     const gear = createItemMap(
-      createItem<SinData>({ name: "Runner SIN", itemType: ItemType.sin, rating: 4 }, [
-        createItem<LicenseData>({ name: "Driver License", itemType: ItemType.license, rating: 4 }),
-        createItem<LicenseData>({ name: "Firearms License", itemType: ItemType.license, rating: 4 }),
+      createItem<SinData>({ name: "Runner SIN", itemType: [ItemType.sin], rating: 4 }, [
+        createItem<LicenseData>({ name: "Driver License", itemType: [ItemType.license], rating: 4 }),
+        createItem<LicenseData>({ name: "Firearms License", itemType: [ItemType.license], rating: 4 }),
       ]),
     )
     const original = { ...Artemis, gear }
@@ -293,8 +293,8 @@ describe("yamlToCharacterSheet / characterSheetToYaml round-trip", () => {
 
     expect(Object.keys(restored.gear)).toHaveLength(3)
 
-    const sinItem = Object.values(restored.gear).find((item) => item.itemType === ItemType.sin)
-    const licenseItems = Object.values(restored.gear).filter((item) => item.itemType === ItemType.license)
+    const sinItem = Object.values(restored.gear).find((item) => item.itemType.includes(ItemType.sin))
+    const licenseItems = Object.values(restored.gear).filter((item) => item.itemType.includes(ItemType.license))
 
     expect(sinItem).toBeDefined()
     expect(licenseItems).toHaveLength(2)
@@ -328,8 +328,8 @@ describe("yamlToCharacterSheet / characterSheetToYaml round-trip", () => {
 
   it("preserves parent/child IDs exactly through a round-trip", () => {
     const [sinItem, ...licenses] = createItem<SinData>(
-      { name: "Runner SIN", itemType: ItemType.sin, rating: 4 },
-      [createItem<LicenseData>({ name: "Driver License", itemType: ItemType.license, rating: 4 })],
+      { name: "Runner SIN", itemType: [ItemType.sin], rating: 4 },
+      [createItem<LicenseData>({ name: "Driver License", itemType: [ItemType.license], rating: 4 })],
     )
     const gear = createItemMap([sinItem, ...licenses])
     const original = { ...Artemis, gear }

--- a/src/components/character/gearPage/gearViewSection.tsx
+++ b/src/components/character/gearPage/gearViewSection.tsx
@@ -10,8 +10,6 @@ import { useState } from "react"
 
 import { selectAllGear } from "#/components/items/gearSelectors.ts"
 import { useGearStore } from "#/components/items/useGearStore.ts"
-import type { ItemType } from "#/system/itemType.ts"
-
 import { CyberwareSectionHeader } from "./cyberwareSectionHeader.tsx"
 import { GearSection, sectionGearTypes } from "./gearSectionTypes.ts"
 import { GearViewSectionContent } from "./gearViewSectionContent.tsx"
@@ -30,8 +28,8 @@ export const GearViewSection: FC<GearViewSectionProps> = ({ section, searchTerms
   const isSearching = searchTerms.length > 0
 
   const sectionItems = isSearching
-    ? gearStore.search(searchTerms).filter((item) => allowedTypes.includes(item.itemType as ItemType))
-    : Object.values(allGearItems).filter((item) => allowedTypes.includes(item.itemType as ItemType))
+    ? gearStore.search(searchTerms).filter((item) => item.itemType.some((t) => allowedTypes.includes(t)))
+    : Object.values(allGearItems).filter((item) => item.itemType.some((t) => allowedTypes.includes(t)))
 
   if (isSearching && sectionItems.length === 0) return null
 

--- a/src/components/character/gearPage/gearViewSection.tsx
+++ b/src/components/character/gearPage/gearViewSection.tsx
@@ -10,6 +10,7 @@ import { useState } from "react"
 
 import { selectAllGear } from "#/components/items/gearSelectors.ts"
 import { useGearStore } from "#/components/items/useGearStore.ts"
+
 import { CyberwareSectionHeader } from "./cyberwareSectionHeader.tsx"
 import { GearSection, sectionGearTypes } from "./gearSectionTypes.ts"
 import { GearViewSectionContent } from "./gearViewSectionContent.tsx"

--- a/src/components/items/dialogs/itemDialog.test.tsx
+++ b/src/components/items/dialogs/itemDialog.test.tsx
@@ -31,7 +31,7 @@ const ItemDialogWrapper: FC<{
 
   const form = useItemForm({
     item,
-    defaultValues: { ...itemDefaults, itemType: itemType ?? ItemType.other },
+    defaultValues: { ...itemDefaults, itemType: [itemType ?? ItemType.other] },
     onSubmit: async (submittedItem) => {
       await onSave(submittedItem)
     },
@@ -74,7 +74,7 @@ describe("ItemDialog", () => {
       expect(onSave).toHaveBeenCalledOnce()
       const submitted: ItemData = onSave.mock.calls[0][0]
       expect(submitted.name).toBe("My Gadget")
-      expect(submitted.itemType).toBe(ItemType.other)
+      expect(submitted.itemType).toEqual([ItemType.other])
     })
   })
 
@@ -261,7 +261,7 @@ describe("ItemDialog", () => {
   it("shows the correct title when passed in", () => {
     const existingItem: ItemData = {
       id: "test-id-0000-0000-000000000000" as ReturnType<typeof crypto.randomUUID>,
-      itemType: ItemType.other,
+      itemType: [ItemType.other],
       name: "Old Name",
     }
 
@@ -285,7 +285,7 @@ describe("ItemDialog", () => {
       // Arrange
       const item: ItemData = {
         id: existingItemId,
-        itemType: ItemType.other,
+        itemType: [ItemType.other],
         name: "Holster",
         equipped: false,
       }
@@ -303,7 +303,7 @@ describe("ItemDialog", () => {
       // Arrange
       const item: ItemData = {
         id: existingItemId,
-        itemType: ItemType.other,
+        itemType: [ItemType.other],
         name: "Rated Gear",
         rating: 3,
       }
@@ -321,7 +321,7 @@ describe("ItemDialog", () => {
       // Arrange
       const item: ItemData = {
         id: existingItemId,
-        itemType: ItemType.other,
+        itemType: [ItemType.other],
         name: "Bulk Item",
         quantity: 5,
       }
@@ -340,7 +340,7 @@ describe("ItemDialog", () => {
       const parentId = crypto.randomUUID()
       const item: ItemData = {
         id: existingItemId,
-        itemType: ItemType.other,
+        itemType: [ItemType.other],
         name: "Sub-Item",
         parentId,
       }
@@ -363,7 +363,7 @@ describe("ItemDialog", () => {
       const onSave = vi.fn()
       const item: ItemData = {
         id: existingItemId,
-        itemType: ItemType.other,
+        itemType: [ItemType.other],
         name: "Gear",
         equipped: false,
       }

--- a/src/components/items/dialogs/itemFormDialog.test.tsx
+++ b/src/components/items/dialogs/itemFormDialog.test.tsx
@@ -21,7 +21,7 @@ describe("ItemFormDialog", () => {
     // Assert
     const savedItem = await ctrl.result()
     await waitFor(() => {
-      expect(savedItem?.itemType).toBe(ItemType.vehicle)
+      expect(savedItem?.itemType).toEqual([ItemType.vehicle])
       expect(savedItem?.name).toBe("Eurocar Westwind 2000")
     })
   })
@@ -38,7 +38,7 @@ describe("ItemFormDialog", () => {
     // Assert
     const savedItem = await ctrl.result()
     await waitFor(() => {
-      expect(savedItem?.itemType).toBe(ItemType.armor)
+      expect(savedItem?.itemType).toEqual([ItemType.armor])
     })
   })
 
@@ -54,7 +54,7 @@ describe("ItemFormDialog", () => {
     // Assert
     const savedItem = await ctrl.result()
     await waitFor(() => {
-      expect(savedItem?.itemType).toBe(ItemType.other)
+      expect(savedItem?.itemType).toEqual([ItemType.other])
     })
   })
 
@@ -70,7 +70,7 @@ describe("ItemFormDialog", () => {
     // Assert
     const savedItem = await ctrl.result()
     await waitFor(() => {
-      expect(savedItem?.itemType).toBe(ItemType.other)
+      expect(savedItem?.itemType).toEqual([ItemType.other])
     })
   })
 })

--- a/src/components/items/dialogs/itemFormDialog.tsx
+++ b/src/components/items/dialogs/itemFormDialog.tsx
@@ -27,7 +27,7 @@ export const ItemFormDialog: FC<ItemFormDialogProps> = ({
     item,
     defaultValues: {
       ...itemDefaults,
-      itemType: itemType ?? ItemType.other,
+      itemType: [itemType ?? ItemType.other],
       rating: 1,
     },
     onSubmit: (itemData) => ctrl.close(itemData),

--- a/src/components/items/dialogs/useItemOptions.test.ts
+++ b/src/components/items/dialogs/useItemOptions.test.ts
@@ -11,7 +11,7 @@ const existingItemId = crypto.randomUUID()
 const baseItem: ItemData = {
   id: existingItemId,
   name: "Test Item",
-  itemType: ItemType.other,
+  itemType: [ItemType.other],
 }
 
 const newItem: ItemData = {

--- a/src/components/items/forms/useItemForm.test.tsx
+++ b/src/components/items/forms/useItemForm.test.tsx
@@ -11,38 +11,38 @@ describe("useItemForm", () => {
     const { result } = renderHook(() =>
       useItemForm({ defaultValues: itemDefaults, onSubmit: vi.fn() }),
     )
-    expect(result.current.state.values.itemType).toBe(ItemType.other)
+    expect(result.current.state.values.itemType).toEqual([ItemType.other])
   })
 
   it("uses ItemType.vehicle when itemType=vehicle is provided", () => {
     const { result } = renderHook(() =>
       useItemForm({
-        defaultValues: { ...itemDefaults, itemType: ItemType.vehicle },
+        defaultValues: { ...itemDefaults, itemType: [ItemType.vehicle] },
         onSubmit: vi.fn(),
       }),
     )
-    expect(result.current.state.values.itemType).toBe(ItemType.vehicle)
+    expect(result.current.state.values.itemType).toEqual([ItemType.vehicle])
   })
 
   it("uses ItemType.armor when itemType=armor is provided", () => {
     const { result } = renderHook(() =>
       useItemForm({
-        defaultValues: { ...itemDefaults, itemType: ItemType.armor },
+        defaultValues: { ...itemDefaults, itemType: [ItemType.armor] },
         onSubmit: vi.fn(),
       }),
     )
-    expect(result.current.state.values.itemType).toBe(ItemType.armor)
+    expect(result.current.state.values.itemType).toEqual([ItemType.armor])
   })
 
   it("preserves the existing item's itemType when editing", () => {
     const [existingItem] = createItem({
-      itemType: ItemType.vehicle,
+      itemType: [ItemType.vehicle],
       name: "Eurocar Westwind 2000",
       cost: 65000,
     })
     const { result } = renderHook(() =>
       useItemForm({ item: existingItem, defaultValues: itemDefaults, onSubmit: vi.fn() }),
     )
-    expect(result.current.state.values.itemType).toBe(ItemType.vehicle)
+    expect(result.current.state.values.itemType).toEqual([ItemType.vehicle])
   })
 })

--- a/src/components/items/forms/useItemForm.tsx
+++ b/src/components/items/forms/useItemForm.tsx
@@ -16,7 +16,7 @@ interface ItemFormOptions<TData extends ItemData = ItemData> {
 
 export const itemDefaults: ItemData = {
   id: NullUuid,
-  itemType: ItemType.other,
+  itemType: [ItemType.other],
   name: "",
   cost: 0,
   quantity: 1,

--- a/src/components/items/types/armor/dialogs/armorFormDialog.test.tsx
+++ b/src/components/items/types/armor/dialogs/armorFormDialog.test.tsx
@@ -27,7 +27,7 @@ describe("ArmorFormDialog", () => {
     // Assert
     const savedItem = await ctrl.result()
     await waitFor(() => {
-      expect(savedItem?.itemType).toBe(ItemType.armor)
+      expect(savedItem?.itemType).toEqual([ItemType.armor])
       expect(savedItem?.name).toBe("Armor Vest")
       expect(savedItem?.ballistic).toBe(0)
       expect(savedItem?.impact).toBe(0)
@@ -58,7 +58,7 @@ describe("ArmorFormDialog", () => {
     // Assert
     const savedItem = await ctrl.result()
     await waitFor(() => {
-      expect(savedItem?.itemType).toBe(ItemType.armor)
+      expect(savedItem?.itemType).toEqual([ItemType.armor])
       expect(savedItem?.name).toBe("Lined Coat")
       expect(savedItem?.ballistic).toBe(6)
       expect(savedItem?.impact).toBe(4)
@@ -69,7 +69,7 @@ describe("ArmorFormDialog", () => {
     // Arrange
     const existingArmor: ArmorData = {
       id: "test-id" as ArmorData["id"],
-      itemType: ItemType.armor,
+      itemType: [ItemType.armor],
       name: "Full Body Armor",
       ballistic: 8,
       impact: 6,

--- a/src/components/items/types/armor/forms/useArmorForm.tsx
+++ b/src/components/items/types/armor/forms/useArmorForm.tsx
@@ -13,7 +13,7 @@ interface ArmorFormOptions {
 
 const defaultFormValues: ArmorData = {
   id: NullUuid,
-  itemType: ItemType.armor,
+  itemType: [ItemType.armor],
   name: "",
   ballistic: 0,
   impact: 0,

--- a/src/components/items/types/credsticks/credstickDialog.tsx
+++ b/src/components/items/types/credsticks/credstickDialog.tsx
@@ -79,7 +79,7 @@ const CredstickDialog: FC<CredstickDialogProps> = ({
     } else {
       const credstickItemData: Omit<CredstickData, "id" | "childIds"> = {
         name: credstickName,
-        itemType: ItemType.credstick,
+        itemType: [ItemType.credstick],
         credstickType,
         balance: clampedBalance,
       }

--- a/src/components/items/types/devices/dialogs/deviceFormDialog.test.tsx
+++ b/src/components/items/types/devices/dialogs/deviceFormDialog.test.tsx
@@ -21,7 +21,7 @@ describe("DeviceFormDialog", () => {
     // Assert
     const savedItem = await ctrl.result()
     await waitFor(() => {
-      expect(savedItem?.itemType).toBe(ItemType.device)
+      expect(savedItem?.itemType).toEqual([ItemType.device])
     })
   })
 })

--- a/src/components/items/types/devices/dialogs/programFormDialog.test.tsx
+++ b/src/components/items/types/devices/dialogs/programFormDialog.test.tsx
@@ -23,7 +23,7 @@ describe("ProgramFormDialog", () => {
     // Assert
     const savedItem = await ctrl.result()
     await waitFor(() => {
-      expect(savedItem?.itemType).toBe(ItemType.program)
+      expect(savedItem?.itemType).toEqual([ItemType.program])
     })
   })
 })

--- a/src/components/items/types/devices/dialogs/programFormDialog.tsx
+++ b/src/components/items/types/devices/dialogs/programFormDialog.tsx
@@ -34,7 +34,7 @@ export const ProgramFormDialog: FC<ProgramFormDialogProps> = ({ ctrl, program, p
       title={title}
       ctrl={ctrl}
       onClosed={() => form.reset()}
-      parentItemFilter={(item) => item.itemType === ItemType.device}
+      parentItemFilter={(item) => item.itemType.includes(ItemType.device)}
       parentItemLabel="Device"
       options={{
         hasRating: { forced: true },

--- a/src/components/items/types/devices/forms/useDeviceForm.test.tsx
+++ b/src/components/items/types/devices/forms/useDeviceForm.test.tsx
@@ -8,6 +8,6 @@ import { useDeviceForm } from "./useDeviceForm.tsx"
 describe("useDeviceForm", () => {
   it("always defaults to ItemType.device", () => {
     const { result } = renderHook(() => useDeviceForm({ onSubmit: vi.fn() }))
-    expect(result.current.state.values.itemType).toBe(ItemType.device)
+    expect(result.current.state.values.itemType).toEqual([ItemType.device])
   })
 })

--- a/src/components/items/types/devices/forms/useDeviceForm.tsx
+++ b/src/components/items/types/devices/forms/useDeviceForm.tsx
@@ -13,7 +13,7 @@ interface DeviceFormOptions {
 
 const defaultFormValues: DeviceData = {
   id: NullUuid,
-  itemType: ItemType.device,
+  itemType: [ItemType.device],
   name: "",
   cost: 0,
   quantity: 1,

--- a/src/components/items/types/devices/forms/useProgramForm.test.tsx
+++ b/src/components/items/types/devices/forms/useProgramForm.test.tsx
@@ -8,6 +8,6 @@ import { useProgramForm } from "./useProgramForm.tsx"
 describe("useProgramForm", () => {
   it("always defaults to ItemType.program", () => {
     const { result } = renderHook(() => useProgramForm({ onSubmit: vi.fn() }))
-    expect(result.current.state.values.itemType).toBe(ItemType.program)
+    expect(result.current.state.values.itemType).toEqual([ItemType.program])
   })
 })

--- a/src/components/items/types/devices/forms/useProgramForm.tsx
+++ b/src/components/items/types/devices/forms/useProgramForm.tsx
@@ -17,7 +17,7 @@ interface ProgramFormOptions {
 
 const defaultFormValues: ProgramData = {
   id: NullUuid,
-  itemType: ItemType.program,
+  itemType: [ItemType.program],
   name: "",
   cost: 0,
   quantity: 1,

--- a/src/components/items/types/implants/dialogs/implantFormDialog.test.tsx
+++ b/src/components/items/types/implants/dialogs/implantFormDialog.test.tsx
@@ -21,7 +21,7 @@ describe("ImplantFormDialog", () => {
     // Assert
     const savedItem = await ctrl.result()
     await waitFor(() => {
-      expect(savedItem?.itemType).toBe(ItemType.implant)
+      expect(savedItem?.itemType).toEqual([ItemType.implant])
     })
   })
 })

--- a/src/components/items/types/implants/forms/useImplantForm.test.tsx
+++ b/src/components/items/types/implants/forms/useImplantForm.test.tsx
@@ -8,6 +8,6 @@ import { useImplantForm } from "./useImplantForm.tsx"
 describe("useImplantForm", () => {
   it("always defaults to ItemType.implant", () => {
     const { result } = renderHook(() => useImplantForm({ onSubmit: vi.fn() }))
-    expect(result.current.state.values.itemType).toBe(ItemType.implant)
+    expect(result.current.state.values.itemType).toEqual([ItemType.implant])
   })
 })

--- a/src/components/items/types/implants/forms/useImplantForm.tsx
+++ b/src/components/items/types/implants/forms/useImplantForm.tsx
@@ -16,7 +16,7 @@ interface ImplantFormOptions {
 }
 
 const defaultFormValues: ImplantData = {
-  itemType: ItemType.implant,
+  itemType: [ItemType.implant],
   id: NullUuid,
   name: "",
   cost: 0,

--- a/src/components/items/types/implants/implantItemList.test.tsx
+++ b/src/components/items/types/implants/implantItemList.test.tsx
@@ -19,7 +19,7 @@ import { ImplantItemList } from "./implantItemList.tsx"
 
 function makeImplant(overrides: Partial<ImplantData> & Pick<ImplantData, "id" | "name">): ImplantData {
   return {
-    itemType: ItemType.implant,
+    itemType: [ItemType.implant],
     implantType: ImplantType.cyberware,
     essenceCost: 1,
     cost: 0,

--- a/src/components/items/types/licenses/forms/useLicenseForm.tsx
+++ b/src/components/items/types/licenses/forms/useLicenseForm.tsx
@@ -15,7 +15,7 @@ interface LicenseFormOptions {
 
 const defaultValues: LicenseData = {
   ...itemDefaults,
-  itemType: ItemType.license,
+  itemType: [ItemType.license],
   id: NullUuid,
   name: "",
   rating: 1,

--- a/src/components/items/types/licenses/forms/useSinForm.tsx
+++ b/src/components/items/types/licenses/forms/useSinForm.tsx
@@ -12,7 +12,7 @@ interface SinFormOptions {
 
 const defaultValues: SinData = {
   ...itemDefaults,
-  itemType: ItemType.sin,
+  itemType: [ItemType.sin],
   id: NullUuid,
   name: "",
   rating: 1,

--- a/src/components/items/types/vehicles/forms/useVehicleForm.tsx
+++ b/src/components/items/types/vehicles/forms/useVehicleForm.tsx
@@ -15,7 +15,7 @@ interface VehicleFormOptions {
 
 const defaultFormValues = {
   id: NullUuid,
-  itemType: ItemType.vehicle as typeof ItemType.vehicle,
+  itemType: [ItemType.vehicle],
   vehicleCategory: VehicleCategory.vehicle,
   vehicleType: "",
   model: "",
@@ -62,7 +62,7 @@ export const vehicleFormOpts = formOptions({
 function toVehicleData(values: VehicleFormState): VehicleData {
   return {
     id: values.id,
-    itemType: ItemType.vehicle,
+    itemType: [ItemType.vehicle],
     vehicleCategory: values.vehicleCategory,
     vehicleType: values.vehicleType,
     ...(values.model && { model: values.model }),

--- a/src/components/items/types/weapons/dialogs/weaponFormDialog.test.tsx
+++ b/src/components/items/types/weapons/dialogs/weaponFormDialog.test.tsx
@@ -31,7 +31,7 @@ describe("WeaponFormDialog", () => {
     // Assert
     const savedItem = await ctrl.result()
     await waitFor(() => {
-      expect(savedItem?.itemType).toBe(ItemType.weapon)
+      expect(savedItem?.itemType).toEqual([ItemType.weapon])
     })
   })
 })

--- a/src/components/items/types/weapons/forms/useWeaponForm.test.tsx
+++ b/src/components/items/types/weapons/forms/useWeaponForm.test.tsx
@@ -8,6 +8,6 @@ import { useWeaponForm } from "./useWeaponForm.tsx"
 describe("useWeaponForm", () => {
   it("always defaults to ItemType.weapon", () => {
     const { result } = renderHook(() => useWeaponForm({ onSubmit: vi.fn() }))
-    expect(result.current.state.values.itemType).toBe(ItemType.weapon)
+    expect(result.current.state.values.itemType).toEqual([ItemType.weapon])
   })
 })

--- a/src/components/items/types/weapons/forms/useWeaponForm.tsx
+++ b/src/components/items/types/weapons/forms/useWeaponForm.tsx
@@ -19,7 +19,7 @@ interface WeaponFormOptions {
 // can handle melee, firearms, thrown, and projectile weapons.
 const defaultFormValues = {
   id: NullUuid,
-  itemType: ItemType.weapon,
+  itemType: [ItemType.weapon],
   name: "",
   weaponType: WeaponType.firearm,
   dmg: "",
@@ -80,7 +80,7 @@ export const weaponFormOpts = formOptions({
 function toWeaponData(values: WeaponFormState): WeaponData {
   const base = {
     id: values.id,
-    itemType: ItemType.weapon as typeof ItemType.weapon,
+    itemType: [ItemType.weapon],
     name: values.name,
     weaponType: values.weaponType,
     dmg: values.dmgType === "custom" ? values.dmg : String(values.dmgValue),

--- a/src/components/items/useGearStore.ts
+++ b/src/components/items/useGearStore.ts
@@ -9,6 +9,7 @@ import { useMemo } from "react"
 import { useCharacterSheetContext } from "#/components/character/sheet/characterSheetProvider.tsx"
 import { NullUuid } from "#/lib/uuidUtils.ts"
 import type { ItemData } from "#/system/itemData.ts"
+import type { ItemType } from "#/system/itemType.ts"
 
 import { selectAllGear } from "./gearSelectors.ts"
 
@@ -172,8 +173,8 @@ export function useGearStore() {
  * Subscribes to the gear Record; re-renders when any gear changes.
  * The React Compiler memoizes the filter result based on the stable `gear` reference.
  */
-export function useGearByType<TItem extends ItemData>(itemType: string): TItem[] {
-  return useGearFilter((item): item is TItem => item.itemType === itemType)
+export function useGearByType<TItem extends ItemData>(itemType: ItemType): TItem[] {
+  return useGearFilter((item): item is TItem => item.itemType.includes(itemType))
 }
 
 export function useGearFilter<TReturn extends ItemData>(filter: (item: ItemData) => item is TReturn): TReturn[] {

--- a/src/components/system/damage/useWoundModifier.test.tsx
+++ b/src/components/system/damage/useWoundModifier.test.tsx
@@ -120,7 +120,7 @@ describe("useWoundModifier", () => {
     // Arrange — 6 physical damage, HPT rating 1 from gear → floor((6-1)/3) = floor(5/3) = 1
     const [painBlocker] = createItem({
       name: "Pain Editor",
-      itemType: ItemType.implant,
+      itemType: [ItemType.implant],
       equipped: true,
       effects: [
         { type: GameEffectType.highPainTolerance, target: DamageTrackKey.physical, value: 1 },
@@ -144,7 +144,7 @@ describe("useWoundModifier", () => {
     // Arrange — 6 physical damage, gear not equipped → floor(6/3) = 2
     const [painBlocker] = createItem({
       name: "Pain Editor",
-      itemType: ItemType.implant,
+      itemType: [ItemType.implant],
       equipped: false,
       effects: [
         { type: GameEffectType.highPainTolerance, target: DamageTrackKey.physical, value: 1 },
@@ -168,7 +168,7 @@ describe("useWoundModifier", () => {
     // Arrange — HPT +1 quality + HPT +1 gear = offset 2; 5 physical → floor((5-2)/3) = floor(1) = 1
     const [painBlocker] = createItem({
       name: "Pain Editor",
-      itemType: ItemType.implant,
+      itemType: [ItemType.implant],
       effects: [
         { type: GameEffectType.highPainTolerance, target: DamageTrackKey.physical, value: 1 },
       ],

--- a/src/components/system/gameEffects/useGameEffects.test.tsx
+++ b/src/components/system/gameEffects/useGameEffects.test.tsx
@@ -59,7 +59,7 @@ describe("selectAllGameEffects", () => {
     // Arrange
     const [synapticBooster] = createItem({
       name: "Synaptic Booster",
-      itemType: ItemType.implant,
+      itemType: [ItemType.implant],
       equipped: true,
       effects: [{ type: GameEffectType.initiativeBonus, value: 1 }],
     })
@@ -79,7 +79,7 @@ describe("selectAllGameEffects", () => {
     // Arrange
     const [synapticBooster] = createItem({
       name: "Synaptic Booster",
-      itemType: ItemType.implant,
+      itemType: [ItemType.implant],
       equipped: false,
       effects: [{ type: GameEffectType.initiativeBonus, value: 1 }],
     })
@@ -170,7 +170,7 @@ describe("selectAllGameEffects", () => {
     // Arrange
     const [implant] = createItem({
       name: "Wired Reflexes",
-      itemType: ItemType.implant,
+      itemType: [ItemType.implant],
       equipped: true,
       effects: [{ type: GameEffectType.initiativeBonus, value: 1 }],
     })
@@ -262,7 +262,7 @@ describe("selectGameEffectsByType", () => {
     // Arrange
     const [implant] = createItem({
       name: "Wired Reflexes",
-      itemType: ItemType.implant,
+      itemType: [ItemType.implant],
       equipped: true,
       effects: [{ type: GameEffectType.initiativeBonus, value: 1 }],
     })

--- a/src/system/gear/armorData.ts
+++ b/src/system/gear/armorData.ts
@@ -8,7 +8,6 @@ import { ItemType } from "#/system/itemType.ts"
 import { SourceDataSchema } from "#/system/sourceData.ts"
 
 export interface ArmorData extends ItemData {
-  itemType: ItemType.armor
   ballistic: number
   impact: number
   damage?: {
@@ -20,7 +19,7 @@ export interface ArmorData extends ItemData {
 export const ArmorDataSchema = z.object({
   id: z.uuid() as z.ZodType<UUID>,
   name: z.string(),
-  itemType: z.literal(ItemType.armor),
+  itemType: z.array(z.nativeEnum(ItemType)).min(1),
 
   description: z.string().optional(),
   cost: z.number().optional(),
@@ -56,5 +55,5 @@ export const ArmorDataSchema = z.object({
 }) satisfies z.ZodType<ArmorData>
 
 export function isArmorData(item: ItemData): item is ArmorData {
-  return item.itemType === ItemType.armor
+  return item.itemType.includes(ItemType.armor)
 }

--- a/src/system/gear/credstickData.ts
+++ b/src/system/gear/credstickData.ts
@@ -29,11 +29,10 @@ export const CredstickTypeLabel: Record<CredstickType, string> = {
 export const CredstickPurchaseCost = 25
 
 export interface CredstickData extends ItemData {
-  itemType: ItemType.credstick
   credstickType: CredstickType
   balance: number
 }
 
 export function isCredstickData(item: ItemData): item is CredstickData {
-  return item.itemType === ItemType.credstick
+  return item.itemType.includes(ItemType.credstick)
 }

--- a/src/system/gear/deviceData.ts
+++ b/src/system/gear/deviceData.ts
@@ -1,9 +1,6 @@
 import type { ItemData } from "#/system/itemData.ts"
-import type { ItemType } from "#/system/itemType.ts"
 
 export interface DeviceData extends ItemData {
-  itemType: ItemType.device
-
   deviceType?: "commlink" | "other"
   /** Custom label shown when deviceType is "other" */
   customDeviceType?: string

--- a/src/system/gear/implantData.ts
+++ b/src/system/gear/implantData.ts
@@ -35,7 +35,6 @@ export enum ImplantLocation {
 }
 
 export interface ImplantData extends ItemData {
-  itemType: ItemType.implant
   implantType?: ImplantType | string
 
   grade?: ImplantGrade
@@ -48,5 +47,5 @@ export interface ImplantData extends ItemData {
 }
 
 export function isImplant(item: ItemData): item is ImplantData {
-  return item.itemType === ItemType.implant
+  return item.itemType.includes(ItemType.implant)
 }

--- a/src/system/gear/licenseData.ts
+++ b/src/system/gear/licenseData.ts
@@ -2,10 +2,9 @@ import type { ItemData } from "#/system/itemData.ts"
 import { ItemType } from "#/system/itemType.ts"
 
 export interface LicenseData extends ItemData {
-  itemType: ItemType.license
   rating: "real" | number
 }
 
 export function isLicenseData(item: ItemData): item is LicenseData {
-  return item.itemType === ItemType.license
+  return item.itemType.includes(ItemType.license)
 }

--- a/src/system/gear/programData.ts
+++ b/src/system/gear/programData.ts
@@ -1,5 +1,4 @@
 import type { ItemData } from "#/system/itemData.ts"
-import type { ItemType } from "#/system/itemType.ts"
 
 export enum ProgramType {
   attack = "attack",
@@ -20,7 +19,6 @@ export enum ProgramType {
 }
 
 export interface ProgramData extends ItemData {
-  itemType: ItemType.program
   rating: number
   programType: ProgramType
 }

--- a/src/system/gear/sinData.ts
+++ b/src/system/gear/sinData.ts
@@ -2,10 +2,9 @@ import type { ItemData } from "#/system/itemData.ts"
 import { ItemType } from "#/system/itemType.ts"
 
 export interface SinData extends ItemData {
-  itemType: ItemType.sin
   rating: "real" | number
 }
 
 export function isSinData(item: ItemData): item is SinData {
-  return item.itemType === ItemType.sin
+  return item.itemType.includes(ItemType.sin)
 }

--- a/src/system/gear/softwareData.ts
+++ b/src/system/gear/softwareData.ts
@@ -1,7 +1,5 @@
 import type { ItemData } from "#/system/itemData.ts"
-import type { ItemType } from "#/system/itemType.ts"
 
 export interface SoftwareData extends ItemData {
-  itemType: ItemType.software
   rating: number
 }

--- a/src/system/gear/vehicleData.ts
+++ b/src/system/gear/vehicleData.ts
@@ -7,7 +7,6 @@ export enum VehicleCategory {
 }
 
 export interface VehicleData extends ItemData {
-  itemType: ItemType.vehicle
   vehicleCategory: VehicleCategory
   vehicleType: string
   model?: string
@@ -31,5 +30,5 @@ export interface VehicleData extends ItemData {
 }
 
 export function isVehicleData(item: ItemData): item is VehicleData {
-  return item.itemType === ItemType.vehicle
+  return item.itemType.includes(ItemType.vehicle)
 }

--- a/src/system/gear/weaponData.ts
+++ b/src/system/gear/weaponData.ts
@@ -31,7 +31,6 @@ export interface WeaponData extends ItemData {
   dmg: string
   dmgType?: "physical" | "stun" | "custom"
   ap?: number
-  itemType: ItemType.weapon
   weaponType: WeaponType
   skill: SkillKey
   attribute?: AttributeKey
@@ -65,14 +64,13 @@ export interface MeleeWeaponData extends WeaponData {
 }
 
 export interface FirearmAccessoryData extends ItemData {
-  itemType: ItemType.firearmAccessory
   enabled?: boolean
   mountPoints: FirearmAttachmentPoint[]
   parentSlot?: FirearmAttachmentPoint
 }
 
 export function isWeaponData(item: ItemData): item is WeaponData {
-  return item.itemType === ItemType.weapon
+  return item.itemType.includes(ItemType.weapon)
 }
 
 export function isFirearmData(item: ItemData): item is FirearmData {

--- a/src/system/itemData.ts
+++ b/src/system/itemData.ts
@@ -11,7 +11,7 @@ import type { SourceData } from "./sourceData.ts"
 export interface ItemData {
   id: UUID
   name: string
-  itemType: ItemType
+  itemType: ItemType[]
 
   description?: string
   cost?: number


### PR DESCRIPTION
Change itemType field from a single ItemType value to an array of
ItemType values to support items with multiple types. Update the
schema validation, type guards, and all usages throughout the
codebase to work with the array format. This allows for more
flexible item categorization.