### PR TITLE
feat: add focus and bonding terminology to context

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -235,6 +235,12 @@ all currently **activated** foci ≤ Magic attribute. Bonded-but-inactive foci d
 app surfaces a violation as a warning chip, not a hard block.
 _Avoid_: focus cap, foci cap, bonded foci limit (the limit applies to activated foci, not bonded ones)
 
+**Foci Force Limit**:
+The cap on the total Force of foci a Runner can have bonded at one time. Rule: sum of Force
+ratings of all bonded foci ≤ Magic × 5 (SR4A p.199). Applies regardless of activation state —
+bonding a new focus that would push the total over the cap is prohibited.
+_Avoid_: bonded foci cap, total force cap (the limit applies to combined Force, not count)
+
 **Sustaining Focus**:
 A Focus subtype that holds one `Sustained` spell active so the caster does not need to maintain
 concentration. Linked to a specific spell via `slottedSpellId`; the spell category
@@ -369,34 +375,6 @@ _Avoid_: editor, creator, creation mode
 The play-time mode for an existing Runner. Used to track damage, roll dice, spend Edge, and
 manage active resources during a session. Accessed via `src/components/character/`.
 _Avoid_: sheet view, player view, read mode
-
-### Configuration & House Rules
-
-**House Rules**:
-A per-character record of optional rule overrides that alter game mechanics (e.g. wound modifier
-interval, encumbrance toggle). Stored on `RunnerData.houseRules` so different characters can
-represent different campaigns with different rule variants. At runtime, house rules are resolved
-via a three-layer merge: `{ ...sr4eDefaults, ...gmConfig.houseRules, ...character.houseRules }`.
-Adding a new rule requires only a new key in the `HouseRules` interface and a default in
-`defaultHouseRules` — no migration, because the `useHouseRulesStore` selector spreads defaults
-first.
-_(Not yet implemented — see issues #288–#291)_
-_Avoid_: options, settings (too generic), preferences
-
-**GameConfig**:
-A GM-managed campaign configuration stub containing a `name` and `Partial<HouseRules>`. Exported
-and imported as YAML. The GM layer sits between SR4e defaults and character-level overrides in
-the three-layer merge. An empty `houseRules: {}` means "run stock SR4e." Future fields (campaign
-metadata, allowed gear lists) will slot in here when the **Game** feature ships.
-_(Not yet implemented — see issue #289)_
-_Avoid_: campaign config, GM settings
-
-**House Rule Source**:
-The origin layer of a resolved house rule value. One of `"sr4e"` (no override — built-in
-default), `"gm"` (set by `GameConfig`), or `"you"` (character-level override). Displayed as a
-labeled badge next to each toggle in the Settings tab so the Player knows where the current
-value comes from.
-_Avoid_: rule origin, source label
 
 ### Infrastructure
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -370,6 +370,34 @@ The play-time mode for an existing Runner. Used to track damage, roll dice, spen
 manage active resources during a session. Accessed via `src/components/character/`.
 _Avoid_: sheet view, player view, read mode
 
+### Configuration & House Rules
+
+**House Rules**:
+A per-character record of optional rule overrides that alter game mechanics (e.g. wound modifier
+interval, encumbrance toggle). Stored on `RunnerData.houseRules` so different characters can
+represent different campaigns with different rule variants. At runtime, house rules are resolved
+via a three-layer merge: `{ ...sr4eDefaults, ...gmConfig.houseRules, ...character.houseRules }`.
+Adding a new rule requires only a new key in the `HouseRules` interface and a default in
+`defaultHouseRules` — no migration, because the `useHouseRulesStore` selector spreads defaults
+first.
+_(Not yet implemented — see issues #288–#291)_
+_Avoid_: options, settings (too generic), preferences
+
+**GameConfig**:
+A GM-managed campaign configuration stub containing a `name` and `Partial<HouseRules>`. Exported
+and imported as YAML. The GM layer sits between SR4e defaults and character-level overrides in
+the three-layer merge. An empty `houseRules: {}` means "run stock SR4e." Future fields (campaign
+metadata, allowed gear lists) will slot in here when the **Game** feature ships.
+_(Not yet implemented — see issue #289)_
+_Avoid_: campaign config, GM settings
+
+**House Rule Source**:
+The origin layer of a resolved house rule value. One of `"sr4e"` (no override — built-in
+default), `"gm"` (set by `GameConfig`), or `"you"` (character-level override). Displayed as a
+labeled badge next to each toggle in the Settings tab so the Player knows where the current
+value comes from.
+_Avoid_: rule origin, source label
+
 ### Infrastructure
 
 **CharacterMeta**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -225,15 +225,15 @@ inactive)
 **Activate** / **Activation**:
 A play-time action that switches a bonded Focus on or off. Only bonded foci can be activated.
 Activation is toggled via a UI action on the focus item card in the Viewer; it does not cost
-Karma. Only activated foci contribute effects and count toward the **Active Foci Limit**.
-Stored as `ItemData.equipped` — the existing field that gates `GameEffect` application.
+Karma. Only activated foci contribute effects. Stored as `ItemData.equipped` — the existing
+field that gates `GameEffect` application.
 _Avoid_: bond (activation is free and reversible; bonding is permanent and costs Karma)
 
-**Active Foci Limit**:
-The cap on how many foci a Runner can have activated simultaneously. Rule: sum of ratings of
-all currently **activated** foci ≤ Magic attribute. Bonded-but-inactive foci do not count. The
-app surfaces a violation as a warning chip, not a hard block.
-_Avoid_: focus cap, foci cap, bonded foci limit (the limit applies to activated foci, not bonded ones)
+**Bonded Foci Limit**:
+The cap on how many foci a Runner can have bonded simultaneously. Rule: count of bonded foci
+≤ Magic attribute (SR4A p.199). Bonding an additional focus past the cap is prohibited
+regardless of activation state. The app surfaces a violation as a warning chip, not a hard block.
+_Avoid_: active foci limit, focus cap, foci cap (the limit applies to bonded foci, not activated ones)
 
 **Foci Force Limit**:
 The cap on the total Force of foci a Runner can have bonded at one time. Rule: sum of Force

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -205,6 +205,43 @@ A Technomancer's equivalent of a spell — a matrix effect compiled from Resonan
 **Tradition**:
 A magical discipline that governs a Magician's drain resistance attribute and available spirits.
 
+**Focus**:
+A magical item that a Runner can own, bond, and activate. Owning a focus has no mechanical
+effect on its own — a focus must first be **bonded** (a permanent Karma expenditure) before it
+can be **activated** (a play-time toggle). Only activated foci contribute `GameEffect` entries
+to dice pools or sustain spells. Focus subtypes include Power, Spellcasting, Summoning,
+Banishing, Centering, Sustaining, and Weapon.
+_(Not yet implemented — see issue #282)_
+_Avoid_: fetish, magical tool
+
+**Bond** / **Bonding**:
+A one-time Karma expenditure that permanently links a Focus to a Runner. Bonding is a
+prerequisite for activation — a focus cannot be activated until it has been bonded. Recorded as
+a `bondFocus` ImprovementEntry. Karma spent on bonding is permanently lost if the Focus is
+subsequently lost, destroyed, or un-bonded.
+_Avoid_: activate, attune (bonding is not the same as activating — a bonded focus can still be
+inactive)
+
+**Activate** / **Activation**:
+A play-time action that switches a bonded Focus on or off. Only bonded foci can be activated.
+Activation is toggled via a UI action on the focus item card in the Viewer; it does not cost
+Karma. Only activated foci contribute effects and count toward the **Active Foci Limit**.
+Stored as `ItemData.equipped` — the existing field that gates `GameEffect` application.
+_Avoid_: bond (activation is free and reversible; bonding is permanent and costs Karma)
+
+**Active Foci Limit**:
+The cap on how many foci a Runner can have activated simultaneously. Rule: sum of ratings of
+all currently **activated** foci ≤ Magic attribute. Bonded-but-inactive foci do not count. The
+app surfaces a violation as a warning chip, not a hard block.
+_Avoid_: focus cap, foci cap, bonded foci limit (the limit applies to activated foci, not bonded ones)
+
+**Sustaining Focus**:
+A Focus subtype that holds one `Sustained` spell active so the caster does not need to maintain
+concentration. Linked to a specific spell via `slottedSpellId`; the spell category
+(`spellCategory`) is fixed at item creation and restricts which spells can be slotted. The
+slotted spell still appears in the Runner's spell list.
+_Avoid_: spell holder
+
 **Commlink**:
 A Runner's personal matrix device and network hub. Has four hardware stats — **Response**,
 **System**, **Firewall**, and **Signal** — that substitute for attributes in matrix tests.


### PR DESCRIPTION
- Added definitions for Focus, Bond/Bonding, Activate/Activation, Active Foci Limit, and Sustaining Focus to CONTEXT.md glossary
- Clarified distinction between bonding (permanent Karma cost) and activation (reversible play-time toggle)
- Defined Active Foci Limit constraint based on Magic attribute