### PR TITLE
feat: GameConfigProvider — mount GM config context at app root

### DIFF
--- a/src/components/gameConfig/gameConfigProvider.test.tsx
+++ b/src/components/gameConfig/gameConfigProvider.test.tsx
@@ -1,0 +1,113 @@
+import { act, cleanup, render, renderHook, waitFor } from "@testing-library/react"
+import type { FC, PropsWithChildren } from "react"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { saveGameConfig } from "#/gameConfig/gameConfigUtils.ts"
+import { createMemoryStorage } from "#/lib/storage/providers/memoryStorageProvider.ts"
+import type { GameConfig } from "#/system/gameConfig.ts"
+import { defaultGameConfig } from "#/system/gameConfig.ts"
+
+import { GameConfigProvider, useGameConfig } from "./gameConfigProvider.tsx"
+
+afterEach(() => cleanup())
+
+const persistedConfig: GameConfig = {
+  name: "Seattle Sprawl",
+  featureFlags: { optionalRules: { encumbranceEnabled: false } },
+}
+
+function makeWrapper(storage = createMemoryStorage()): FC<PropsWithChildren> {
+  const Wrapper: FC<PropsWithChildren> = ({ children }) => (
+    <GameConfigProvider storage={storage}>{children}</GameConfigProvider>
+  )
+  Wrapper.displayName = "TestGameConfigWrapper"
+  return Wrapper
+}
+
+describe("GameConfigProvider", () => {
+  it("renders children", () => {
+    // Arrange & Act
+    const { getByText } = render(
+      <GameConfigProvider storage={createMemoryStorage()}>
+        <div>child</div>
+      </GameConfigProvider>,
+    )
+
+    // Assert
+    expect(getByText("child")).toBeDefined()
+  })
+
+  it("starts with defaultGameConfig before storage resolves", () => {
+    // Arrange
+    const wrapper = makeWrapper()
+
+    // Act
+    const { result } = renderHook(() => useGameConfig(), { wrapper })
+
+    // Assert
+    expect(result.current.config).toEqual(defaultGameConfig)
+  })
+
+  it("loads a persisted config from storage on mount", async () => {
+    // Arrange
+    const storage = createMemoryStorage()
+    await saveGameConfig(storage, persistedConfig)
+
+    // Act
+    const { result } = renderHook(() => useGameConfig(), { wrapper: makeWrapper(storage) })
+
+    // Assert — wait for the async load effect to populate state
+    await waitFor(() => {
+      expect(result.current.config).toEqual(persistedConfig)
+    })
+  })
+
+  it("keeps defaultGameConfig when no config has been saved", async () => {
+    // Arrange
+    const storage = createMemoryStorage()
+
+    // Act
+    const { result } = renderHook(() => useGameConfig(), { wrapper: makeWrapper(storage) })
+
+    // Assert — give the effect a chance to run; state must stay at default
+    await waitFor(() => {
+      expect(result.current.config).toEqual(defaultGameConfig)
+    })
+  })
+
+  it("setConfig updates context state and persists to storage", async () => {
+    // Arrange
+    const storage = createMemoryStorage()
+    const { result } = renderHook(() => useGameConfig(), { wrapper: makeWrapper(storage) })
+
+    // Act
+    act(() => {
+      result.current.setConfig(persistedConfig)
+    })
+
+    // Assert — context value reflects the new config
+    expect(result.current.config).toEqual(persistedConfig)
+
+    // Assert — and storage was updated
+    await waitFor(async () => {
+      const raw = await storage.getItem("game-config")
+      expect(raw).toEqual(persistedConfig)
+    })
+  })
+
+  it("useGameConfig throws when used outside the provider", () => {
+    // Arrange — silence React's expected error log; restore in finally so a
+    // failed assertion can't leak the override to other tests.
+    const originalError = console.error
+    console.error = () => {}
+
+    try {
+      // Act & Assert
+      expect(() => renderHook(() => useGameConfig())).toThrow(
+        /useGameConfig must be used within GameConfigProvider/,
+      )
+    } finally {
+      console.error = originalError
+    }
+  })
+})

--- a/src/components/gameConfig/gameConfigProvider.test.tsx
+++ b/src/components/gameConfig/gameConfigProvider.test.tsx
@@ -26,9 +26,12 @@ function makeWrapper(storage = createMemoryStorage()): FC<PropsWithChildren> {
 
 describe("GameConfigProvider", () => {
   it("renders children", () => {
-    // Arrange & Act
+    // Arrange
+    const storage = createMemoryStorage()
+
+    // Act
     const { getByText } = render(
-      <GameConfigProvider storage={createMemoryStorage()}>
+      <GameConfigProvider storage={storage}>
         <div>child</div>
       </GameConfigProvider>,
     )

--- a/src/components/gameConfig/gameConfigProvider.test.tsx
+++ b/src/components/gameConfig/gameConfigProvider.test.tsx
@@ -95,6 +95,34 @@ describe("GameConfigProvider", () => {
     })
   })
 
+  it("does not let an in-flight load overwrite a consumer setConfig", async () => {
+    // Arrange — storage has a stale value that will be returned by the
+    // async load on mount. The consumer immediately overrides it with a
+    // newer value before that load resolves.
+    const storage = createMemoryStorage()
+    await saveGameConfig(storage, persistedConfig)
+
+    const newerConfig: GameConfig = {
+      name: "Newer Config",
+      featureFlags: { optionalRules: { encumbranceEnabled: true } },
+    }
+
+    // Act — render starts the in-flight load; setConfig fires before it resolves.
+    const { result } = renderHook(() => useGameConfig(), { wrapper: makeWrapper(storage) })
+    act(() => {
+      result.current.setConfig(newerConfig)
+    })
+
+    // Flush any pending microtasks so the load's .then would have a chance
+    // to (incorrectly, pre-fix) overwrite the consumer's value.
+    await act(async () => {
+      await new Promise<void>((resolve) => setTimeout(resolve, 0))
+    })
+
+    // Assert — the consumer's value must stick.
+    expect(result.current.config).toEqual(newerConfig)
+  })
+
   it("useGameConfig throws when used outside the provider", () => {
     // Arrange — silence React's expected error log; restore in finally so a
     // failed assertion can't leak the override to other tests.

--- a/src/components/gameConfig/gameConfigProvider.tsx
+++ b/src/components/gameConfig/gameConfigProvider.tsx
@@ -1,0 +1,67 @@
+import type { FC, PropsWithChildren } from "react"
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react"
+
+import { loadGameConfig, saveGameConfig } from "#/gameConfig/gameConfigUtils.ts"
+import { OutOfContextError } from "#/lib/errors/outOfContextError.ts"
+import type { AsyncJsonStorage } from "#/lib/storage/asyncStorage.ts"
+import { LocalStorageProvider } from "#/lib/storage/providers/localStorageProvider.ts"
+import type { GameConfig } from "#/system/gameConfig.ts"
+import { defaultGameConfig } from "#/system/gameConfig.ts"
+
+interface GameConfigContextValue {
+  config: GameConfig
+  setConfig: (config: GameConfig) => void
+}
+
+const GameConfigContext = createContext<GameConfigContextValue | null>(null)
+
+interface GameConfigProviderProps extends PropsWithChildren {
+  /**
+   * Optional storage injection point. Defaults to the app's
+   * {@link LocalStorageProvider}. Tests pass an in-memory storage so each
+   * suite gets isolation.
+   */
+  storage?: AsyncJsonStorage
+}
+
+/**
+ * Mounts the GM-layer GameConfig at the app root. Loads the persisted
+ * config from {@link AsyncJsonStorage} on mount (falling back to
+ * {@link defaultGameConfig}) and persists any updates made via the
+ * exposed `setConfig`.
+ */
+export const GameConfigProvider: FC<GameConfigProviderProps> = ({ children, storage: storageProp }) => {
+  const [storage] = useState<AsyncJsonStorage>(() => storageProp ?? LocalStorageProvider.getStorage())
+  const [config, setConfigState] = useState<GameConfig>(defaultGameConfig)
+
+  useEffect(() => {
+    let cancelled = false
+    void loadGameConfig(storage).then((loaded) => {
+      if (cancelled || loaded === null) return
+      setConfigState(loaded)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [storage])
+
+  const setConfig = useCallback(
+    (newConfig: GameConfig) => {
+      setConfigState(newConfig)
+      void saveGameConfig(storage, newConfig)
+    },
+    [storage],
+  )
+
+  const value = useMemo<GameConfigContextValue>(() => ({ config, setConfig }), [config, setConfig])
+
+  return <GameConfigContext.Provider value={value}>{children}</GameConfigContext.Provider>
+}
+
+export function useGameConfig(): GameConfigContextValue {
+  const ctx = useContext(GameConfigContext)
+  if (!ctx) {
+    throw new OutOfContextError("useGameConfig", "GameConfigProvider")
+  }
+  return ctx
+}

--- a/src/components/gameConfig/gameConfigProvider.tsx
+++ b/src/components/gameConfig/gameConfigProvider.tsx
@@ -43,10 +43,14 @@ export const GameConfigProvider: FC<GameConfigProviderProps> = ({ children, stor
   useEffect(() => {
     const token = ++loadTokenRef.current
     let cancelled = false
-    void loadGameConfig(storage).then((loaded) => {
-      if (cancelled || loaded === null || loadTokenRef.current !== token) return
-      setConfigState(loaded)
-    })
+    loadGameConfig(storage)
+      .then((loaded) => {
+        if (cancelled || loaded === null || loadTokenRef.current !== token) return
+        setConfigState(loaded)
+      })
+      .catch((error: unknown) => {
+        console.error("Failed to load game config.", error)
+      })
     return () => {
       cancelled = true
     }
@@ -56,7 +60,9 @@ export const GameConfigProvider: FC<GameConfigProviderProps> = ({ children, stor
     (newConfig: GameConfig) => {
       loadTokenRef.current++
       setConfigState(newConfig)
-      void saveGameConfig(storage, newConfig)
+      saveGameConfig(storage, newConfig).catch((error: unknown) => {
+        console.error("Failed to save game config.", error)
+      })
     },
     [storage],
   )

--- a/src/components/gameConfig/gameConfigProvider.tsx
+++ b/src/components/gameConfig/gameConfigProvider.tsx
@@ -1,5 +1,5 @@
 import type { FC, PropsWithChildren } from "react"
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react"
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react"
 
 import { loadGameConfig, saveGameConfig } from "#/gameConfig/gameConfigUtils.ts"
 import { OutOfContextError } from "#/lib/errors/outOfContextError.ts"
@@ -33,11 +33,18 @@ interface GameConfigProviderProps extends PropsWithChildren {
 export const GameConfigProvider: FC<GameConfigProviderProps> = ({ children, storage: storageProp }) => {
   const [storage] = useState<AsyncJsonStorage>(() => storageProp ?? LocalStorageProvider.getStorage())
   const [config, setConfigState] = useState<GameConfig>(defaultGameConfig)
+  // Load-version token bumped on every consumer `setConfig`. The async load
+  // only applies its result if its captured token still matches — prevents a
+  // stale storage value from clobbering a newer config a consumer set while
+  // the load was in flight. The `cancelled` flag handles unmount/storage
+  // changes separately.
+  const loadTokenRef = useRef(0)
 
   useEffect(() => {
+    const token = ++loadTokenRef.current
     let cancelled = false
     void loadGameConfig(storage).then((loaded) => {
-      if (cancelled || loaded === null) return
+      if (cancelled || loaded === null || loadTokenRef.current !== token) return
       setConfigState(loaded)
     })
     return () => {
@@ -47,6 +54,7 @@ export const GameConfigProvider: FC<GameConfigProviderProps> = ({ children, stor
 
   const setConfig = useCallback(
     (newConfig: GameConfig) => {
+      loadTokenRef.current++
       setConfigState(newConfig)
       void saveGameConfig(storage, newConfig)
     },

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import { createRoot } from "react-dom/client"
 import { CharacterManagerProvider } from "./character/characterManagerContext.tsx"
 import { DialogApi } from "./components/dialogs/api/dialogApi.tsx"
 import { DialogApiProvider } from "./components/dialogs/api/dialogApiProvider.tsx"
+import { GameConfigProvider } from "./components/gameConfig/gameConfigProvider.tsx"
 import TanStackQueryProvider from "./integrations/tanstackQuery/rootProvider.tsx"
 import { getRouter } from "./router.ts"
 import { theme } from "./theme.ts"
@@ -23,12 +24,14 @@ createRoot(rootElement).render(
   <React.StrictMode>
     <ThemeProvider theme={theme} defaultMode="dark">
       <TanStackQueryProvider>
-        <CharacterManagerProvider>
-          <DialogApiProvider dialogApi={dialogApi}>
-            <CssBaseline />
-            <RouterProvider router={router} />
-          </DialogApiProvider>
-        </CharacterManagerProvider>
+        <GameConfigProvider>
+          <CharacterManagerProvider>
+            <DialogApiProvider dialogApi={dialogApi}>
+              <CssBaseline />
+              <RouterProvider router={router} />
+            </DialogApiProvider>
+          </CharacterManagerProvider>
+        </GameConfigProvider>
       </TanStackQueryProvider>
     </ThemeProvider>
   </React.StrictMode>,

--- a/testUtils/setup.ts
+++ b/testUtils/setup.ts
@@ -1,5 +1,6 @@
 import { setImmediate } from "node:timers"
 
+import { cleanup } from "@testing-library/react"
 import type { DetachedWindowAPI } from "happy-dom"
 import { afterEach } from "vitest"
 
@@ -8,22 +9,28 @@ type HappyDOMWindow = Window & { happyDOM?: DetachedWindowAPI }
 const flushSetImmediate = () => new Promise<void>((resolve) => setImmediate(resolve))
 
 afterEach(async () => {
-  // React's scheduler queues work via Node's setImmediate. In the happy-dom
-  // environment, setImmediate callbacks that fire after window teardown throw
-  // "window is not defined". Awaiting multiple setImmediate cycles ensures all
-  // previously-queued callbacks — including any work React schedules during
-  // the first flush — have run before the environment is torn down.
+  // Unmount any mounted React trees first. Most test files already register
+  // their own `afterEach(cleanup)`, but RTL's auto-cleanup runs at an
+  // ambiguous point in the hook chain on some setups. Calling it explicitly
+  // here makes the teardown order deterministic: unmount → drain scheduler →
+  // cancel browser timers. cleanup() is a no-op if there are no trees left.
+  cleanup()
+
+  // React's scheduler queues unmount-triggered work via Node's setImmediate.
+  // happy-dom tears down `window` after the test file completes; any
+  // setImmediate that escapes the queue throws "window is not defined" when
+  // it fires. Each flush drains the queue at this moment AND lets React
+  // schedule any follow-up work (which the next flush drains). Three rounds
+  // covers React 18's two-pass scheduling plus any final commit work.
+  await flushSetImmediate()
   await flushSetImmediate()
   await flushSetImmediate()
 
   // MUI's `react-transition-group` schedules `setTimeout`-backed callbacks
-  // (Dialog/Fade transitions) that can outlive the test that opened them.
-  // setImmediate flushes don't drain delayed setTimeouts, so when a later
-  // test file is torn down and `window` goes away, those callbacks fire and
-  // throw "window is not defined" — which Vitest reports as an unhandled
-  // error and fails the run. `window.happyDOM.abort()` cancels pending
-  // browser-scheduled async tasks (setTimeout/setInterval/requestAnimationFrame)
-  // tied to the current window before teardown.
+  // (Dialog/Fade transitions). setImmediate flushes don't drain delayed
+  // setTimeouts, so those callbacks survive teardown and throw the same
+  // "window is not defined" error. `window.happyDOM.abort()` cancels pending
+  // browser-scheduled async tasks (setTimeout/setInterval/requestAnimationFrame).
   const win = globalThis.window as HappyDOMWindow | undefined
   if (typeof win?.happyDOM?.abort === "function") {
     await win.happyDOM.abort()

--- a/testUtils/setup.ts
+++ b/testUtils/setup.ts
@@ -1,6 +1,9 @@
 import { setImmediate } from "node:timers"
 
+import type { DetachedWindowAPI } from "happy-dom"
 import { afterEach } from "vitest"
+
+type HappyDOMWindow = Window & { happyDOM?: DetachedWindowAPI }
 
 const flushSetImmediate = () => new Promise<void>((resolve) => setImmediate(resolve))
 
@@ -12,4 +15,17 @@ afterEach(async () => {
   // the first flush — have run before the environment is torn down.
   await flushSetImmediate()
   await flushSetImmediate()
+
+  // MUI's `react-transition-group` schedules `setTimeout`-backed callbacks
+  // (Dialog/Fade transitions) that can outlive the test that opened them.
+  // setImmediate flushes don't drain delayed setTimeouts, so when a later
+  // test file is torn down and `window` goes away, those callbacks fire and
+  // throw "window is not defined" — which Vitest reports as an unhandled
+  // error and fails the run. `window.happyDOM.abort()` cancels pending
+  // browser-scheduled async tasks (setTimeout/setInterval/requestAnimationFrame)
+  // tied to the current window before teardown.
+  const win = globalThis.window as HappyDOMWindow | undefined
+  if (typeof win?.happyDOM?.abort === "function") {
+    await win.happyDOM.abort()
+  }
 })


### PR DESCRIPTION
## Summary

Implements #289 — mounts the runtime home for the GM layer of the
three-layer house rules merge.

- `GameConfigProvider` at `src/components/gameConfig/gameConfigProvider.tsx`
  - Loads via `loadGameConfig` on mount, falls back to `defaultGameConfig`
  - `setConfig` updates context state and persists via `saveGameConfig`
  - Optional `storage` prop for test injection (defaults to `LocalStorageProvider`)
- `useGameConfig()` returns `{ config, setConfig }`; throws `OutOfContextError` outside provider
- Mounted in `src/main.tsx` alongside `CharacterManagerProvider`

Stacked on #297 — depends on the `HouseRules` / `GameConfig` types and
storage helpers added there.

## Test plan

- [x] `yarn lint` clean
- [x] `yarn test` — 1293/1293 passing (provider test cases: renders
      children, defaults before storage resolves, loads persisted config,
      preserves default when storage empty, setConfig updates + persists,
      throws outside provider)

Closes #289

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #298 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #297
<!-- GitButler Footer Boundary Bottom -->