### PR TITLE
feat: magical foci - foundational slice (#282)

### DIFF
--- a/src/components/builder/sections/gear/foci/fociList.tsx
+++ b/src/components/builder/sections/gear/foci/fociList.tsx
@@ -1,0 +1,51 @@
+import Button from "@mui/material/Button"
+import Stack from "@mui/material/Stack"
+import { RiAddLine } from "@remixicon/react"
+import type { FC } from "react"
+
+import { useFocusFormDialog } from "#/components/items/types/foci/dialogs/focusFormDialog.tsx"
+import { FocusItemCard } from "#/components/items/types/foci/focusItemCard.tsx"
+import { useGearByType, useGearStore } from "#/components/items/useGearStore.ts"
+import type { FocusData } from "#/system/gear/focusData.ts"
+import { ItemType } from "#/system/itemType.ts"
+
+export const FociList: FC = () => {
+  const gearApi = useGearStore()
+  const focusItems = useGearByType<FocusData>(ItemType.focus)
+  const focusFormDialog = useFocusFormDialog()
+
+  const handleEditFocus = async (focus?: FocusData) => {
+    const saved = await focusFormDialog.open({ focus })
+    if (saved) gearApi.save(saved)
+  }
+
+  const handleToggleActivation = (focus: FocusData) => {
+    if (!focus.bonded) return
+    gearApi.save({ ...focus, equipped: !focus.equipped })
+  }
+
+  return (
+    <Stack sx={{ gap: 1 }}>
+      {focusItems.map((focus) => (
+        <FocusItemCard
+          key={focus.id}
+          focus={focus}
+          onEdit={() => handleEditFocus(focus)}
+          onRemove={() => gearApi.remove(focus)}
+          onToggleActivation={() => handleToggleActivation(focus)}
+        />
+      ))}
+
+      <Button
+        variant="outlined"
+        size="small"
+        startIcon={<RiAddLine size={14} />}
+        onClick={() => handleEditFocus()}
+        color="secondary"
+        fullWidth
+      >
+        Add Focus
+      </Button>
+    </Stack>
+  )
+}

--- a/src/components/builder/sections/gear/foci/fociPanel.tsx
+++ b/src/components/builder/sections/gear/foci/fociPanel.tsx
@@ -1,0 +1,7 @@
+import type { FC } from "react"
+
+import { FociList } from "./fociList.tsx"
+
+export const FociPanel: FC = () => {
+  return <FociList />
+}

--- a/src/components/builder/sections/gear/gearSection.tsx
+++ b/src/components/builder/sections/gear/gearSection.tsx
@@ -31,6 +31,7 @@ import { ItemType } from "#/system/itemType.ts"
 
 import { ArmorPanel } from "./armor/armorPanel.tsx"
 import { DevicesPanel } from "./devices/devicesPanel.tsx"
+import { FociPanel } from "./foci/fociPanel.tsx"
 import { useGearAvailabilityIssues } from "./gearUtils.ts"
 import { ImplantsPanel } from "./implants/implantsPanel.tsx"
 import { LifestylePanel } from "./lifestyle/lifestylePanel.tsx"
@@ -154,6 +155,7 @@ const GearSectionContent: FC<{
   if (section === SectionHeader.Armor) return <ArmorPanel />
   if (section === SectionHeader.Vehicles) return <VehiclesPanel />
   if (section === SectionHeader.Devices) return <DevicesPanel />
+  if (section === SectionHeader.Foci) return <FociPanel />
   if (section === SectionHeader.Misc) return <MiscPanel />
   if (section === SectionHeader.Lifestyle) return <LifestylePanel />
   return null
@@ -215,6 +217,7 @@ const GearSectionNuyen: FC<{
     [SectionHeader.Armor]: ItemType.armor,
     [SectionHeader.Vehicles]: ItemType.vehicle,
     [SectionHeader.Devices]: ItemType.device,
+    [SectionHeader.Foci]: ItemType.focus,
     [SectionHeader.Misc]: ItemType.other,
   }
 

--- a/src/components/builder/sections/gear/sectionHeader.tsx
+++ b/src/components/builder/sections/gear/sectionHeader.tsx
@@ -4,6 +4,7 @@ export enum SectionHeader {
   Armor = "Armor",
   Vehicles = "Vehicles",
   Devices = "Devices",
+  Foci = "Foci",
   Licenses = "SINs & Licenses",
   Misc = "Misc",
   Lifestyle = "Lifestyle",

--- a/src/components/character/gearPage/fociSectionContent.tsx
+++ b/src/components/character/gearPage/fociSectionContent.tsx
@@ -1,0 +1,57 @@
+import Button from "@mui/material/Button"
+import Stack from "@mui/material/Stack"
+import { RiAddLine } from "@remixicon/react"
+import type { FC } from "react"
+
+import { useFocusFormDialog } from "#/components/items/types/foci/dialogs/focusFormDialog.tsx"
+import { FocusItemCard } from "#/components/items/types/foci/focusItemCard.tsx"
+import { useGearStore } from "#/components/items/useGearStore.ts"
+import type { FocusData } from "#/system/gear/focusData.ts"
+import { isFocusData } from "#/system/gear/focusData.ts"
+import type { ItemData } from "#/system/itemData.ts"
+
+interface FociSectionContentProps {
+  items: ItemData[]
+}
+
+export const FociSectionContent: FC<FociSectionContentProps> = ({ items }) => {
+  const gearStore = useGearStore()
+  const focusFormDialog = useFocusFormDialog()
+
+  const handleEditFocus = async (focus?: FocusData) => {
+    const saved = await focusFormDialog.open({ focus })
+    if (saved) gearStore.save(saved)
+  }
+
+  const handleToggleActivation = (focus: FocusData) => {
+    if (!focus.bonded) return
+    gearStore.save({ ...focus, equipped: !focus.equipped })
+  }
+
+  const foci = items.filter(isFocusData)
+
+  return (
+    <Stack sx={{ gap: 1 }}>
+      {foci.map((focus) => (
+        <FocusItemCard
+          key={focus.id}
+          focus={focus}
+          onEdit={() => handleEditFocus(focus)}
+          onRemove={() => gearStore.remove(focus)}
+          onToggleActivation={() => handleToggleActivation(focus)}
+        />
+      ))}
+
+      <Button
+        variant="outlined"
+        size="small"
+        startIcon={<RiAddLine size={14} />}
+        onClick={() => handleEditFocus()}
+        color="secondary"
+        fullWidth
+      >
+        Add Focus
+      </Button>
+    </Stack>
+  )
+}

--- a/src/components/character/gearPage/gearSectionTypes.ts
+++ b/src/components/character/gearPage/gearSectionTypes.ts
@@ -6,6 +6,7 @@ export enum GearSection {
   Armor = "Armor",
   Vehicles = "Vehicles",
   Devices = "Devices",
+  Foci = "Foci",
   Licenses = "SINs & Licenses",
   Misc = "Misc",
 }
@@ -16,6 +17,7 @@ export const sectionGearTypes: Record<GearSection, ItemType[]> = {
   [GearSection.Armor]: [ItemType.armor],
   [GearSection.Vehicles]: [ItemType.vehicle],
   [GearSection.Devices]: [ItemType.device, ItemType.program, ItemType.software],
+  [GearSection.Foci]: [ItemType.focus],
   [GearSection.Licenses]: [ItemType.sin, ItemType.license],
   [GearSection.Misc]: [ItemType.other],
 }

--- a/src/components/character/gearPage/gearViewSectionContent.tsx
+++ b/src/components/character/gearPage/gearViewSectionContent.tsx
@@ -7,6 +7,7 @@ import type { ItemData } from "#/system/itemData.ts"
 import { ItemType } from "#/system/itemType.ts"
 
 import { ArmorSectionContent } from "./armorSectionContent.tsx"
+import { FociSectionContent } from "./fociSectionContent.tsx"
 import { GearSection } from "./gearSectionTypes.ts"
 import { GenericSectionContent } from "./genericSectionContent.tsx"
 import { LicensesSectionContent } from "./licensesSectionContent.tsx"
@@ -55,6 +56,8 @@ export const GearViewSectionContent: FC<GearViewSectionContentProps> = ({
           itemType={ItemType.device}
         />
       )
+    case GearSection.Foci:
+      return <FociSectionContent items={rootItems} />
     default:
       return (
         <GenericSectionContent

--- a/src/components/items/types/foci/activeChip.tsx
+++ b/src/components/items/types/foci/activeChip.tsx
@@ -1,4 +1,11 @@
 import Chip from "@mui/material/Chip"
 import type { FC } from "react"
 
-export const ActiveChip: FC = () => <Chip label="Active" size="small" color="success" />
+export const ActiveChip: FC = () => (
+  <Chip
+    label="Active"
+    size="small"
+    color="success"
+    sx={{ height: 20, fontSize: "0.7rem" }}
+  />
+)

--- a/src/components/items/types/foci/activeChip.tsx
+++ b/src/components/items/types/foci/activeChip.tsx
@@ -1,0 +1,4 @@
+import Chip from "@mui/material/Chip"
+import type { FC } from "react"
+
+export const ActiveChip: FC = () => <Chip label="Active" size="small" color="success" />

--- a/src/components/items/types/foci/bondedChip.tsx
+++ b/src/components/items/types/foci/bondedChip.tsx
@@ -1,0 +1,4 @@
+import Chip from "@mui/material/Chip"
+import type { FC } from "react"
+
+export const BondedChip: FC = () => <Chip label="Bonded" size="small" color="info" />

--- a/src/components/items/types/foci/bondedChip.tsx
+++ b/src/components/items/types/foci/bondedChip.tsx
@@ -1,4 +1,11 @@
 import Chip from "@mui/material/Chip"
 import type { FC } from "react"
 
-export const BondedChip: FC = () => <Chip label="Bonded" size="small" color="info" />
+export const BondedChip: FC = () => (
+  <Chip
+    label="Bonded"
+    size="small"
+    color="info"
+    sx={{ height: 20, fontSize: "0.7rem" }}
+  />
+)

--- a/src/components/items/types/foci/dialogs/focusFormDialog.test.tsx
+++ b/src/components/items/types/foci/dialogs/focusFormDialog.test.tsx
@@ -1,0 +1,136 @@
+import { fireEvent, screen, waitFor, within } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { DialogCtrl } from "#/components/dialogs/api/dialogCtrl.ts"
+import { GameEffectType } from "#/system/gameEffects/gameEffectType.ts"
+import type { FocusData } from "#/system/gear/focusData.ts"
+import { FocusType } from "#/system/gear/focusData.ts"
+import { ItemType } from "#/system/itemType.ts"
+import { SpellCategory } from "#/system/magic/spellData.ts"
+import { SkillKey } from "#/system/skills/skillKey.ts"
+import { renderInBuilder } from "#testUtils/renderUtils.tsx"
+
+import { FocusFormDialog } from "./focusFormDialog.tsx"
+
+describe("FocusFormDialog", () => {
+  it("submits a Power focus with the right itemType and focusType", async () => {
+    // Arrange
+    const ctrl = new DialogCtrl<FocusData>()
+    ctrl.open()
+    renderInBuilder(<FocusFormDialog ctrl={ctrl} />)
+
+    const dialogs = screen.getAllByRole("dialog")
+    const dialog = dialogs[dialogs.length - 1]
+
+    // Act
+    fireEvent.change(within(dialog).getByLabelText(/^name$/i), {
+      target: { value: "Power Focus" },
+    })
+    fireEvent.click(within(dialog).getByRole("button", { name: /save/i }))
+
+    // Assert
+    const savedItem = await ctrl.result()
+    await waitFor(() => {
+      expect(savedItem?.itemType).toBe(ItemType.focus)
+      expect(savedItem?.focusType).toBe(FocusType.Power)
+      expect(savedItem?.name).toBe("Power Focus")
+    })
+  })
+
+  it("auto-populates the effects array with one entry per magic skill when Power is selected", async () => {
+    // Arrange
+    const ctrl = new DialogCtrl<FocusData>()
+    ctrl.open()
+    renderInBuilder(<FocusFormDialog ctrl={ctrl} />)
+
+    const dialogs = screen.getAllByRole("dialog")
+    const dialog = dialogs[dialogs.length - 1]
+
+    // Act
+    fireEvent.change(within(dialog).getByLabelText(/^name$/i), {
+      target: { value: "Power Focus" },
+    })
+    fireEvent.click(within(dialog).getByRole("button", { name: /save/i }))
+
+    // Assert
+    const savedItem = await ctrl.result()
+    await waitFor(() => {
+      const expectedSkills = [
+        SkillKey.arcana,
+        SkillKey.assensing,
+        SkillKey.astralCombat,
+        SkillKey.banishing,
+        SkillKey.binding,
+        SkillKey.counterspelling,
+        SkillKey.enchanting,
+        SkillKey.ritualSpellcasting,
+        SkillKey.spellcasting,
+        SkillKey.summoning,
+      ]
+      expect(savedItem?.effects).toHaveLength(expectedSkills.length)
+      for (const skill of expectedSkills) {
+        expect(savedItem?.effects).toContainEqual({
+          type: GameEffectType.skillMod,
+          target: skill,
+          value: 0,
+        })
+      }
+    })
+  })
+
+  it("preserves existing effects when editing a Power focus (does not re-auto-populate)", async () => {
+    // Arrange
+    const existing: FocusData = {
+      id: "test-id" as FocusData["id"],
+      itemType: ItemType.focus,
+      focusType: FocusType.Power,
+      name: "Existing Power",
+      rating: 3,
+      bonded: true,
+      equipped: false,
+      effects: [{ type: GameEffectType.skillMod, target: SkillKey.spellcasting, value: 2 }],
+    }
+    const ctrl = new DialogCtrl<FocusData>()
+    ctrl.open()
+    renderInBuilder(<FocusFormDialog ctrl={ctrl} focus={existing} />)
+
+    const dialogs = screen.getAllByRole("dialog")
+    const dialog = dialogs[dialogs.length - 1]
+
+    // Act
+    fireEvent.click(within(dialog).getByRole("button", { name: /save/i }))
+
+    // Assert
+    const savedItem = await ctrl.result()
+    await waitFor(() => {
+      expect(savedItem?.effects).toHaveLength(1)
+      expect(savedItem?.effects?.[0]).toMatchObject({
+        type: GameEffectType.skillMod,
+        target: SkillKey.spellcasting,
+        value: 2,
+      })
+    })
+  })
+
+  it("renders the Spell Category field when editing a sustaining focus", () => {
+    // Arrange
+    const existing: FocusData = {
+      id: "test-id" as FocusData["id"],
+      itemType: ItemType.focus,
+      focusType: FocusType.Sustaining,
+      name: "Sustaining (Combat)",
+      spellCategory: SpellCategory.Combat,
+      rating: 2,
+    }
+    const ctrl = new DialogCtrl<FocusData>()
+    ctrl.open()
+    renderInBuilder(<FocusFormDialog ctrl={ctrl} focus={existing} />)
+
+    const dialogs = screen.getAllByRole("dialog")
+    const dialog = dialogs[dialogs.length - 1]
+
+    // Assert — MUI Select renders the selected value as the displayed text.
+    // The presence of the "Combat" option text confirms the spellCategory field rendered.
+    expect(within(dialog).getAllByText(/combat/i).length).toBeGreaterThan(0)
+  })
+})

--- a/src/components/items/types/foci/dialogs/focusFormDialog.tsx
+++ b/src/components/items/types/foci/dialogs/focusFormDialog.tsx
@@ -1,0 +1,53 @@
+import type { FC } from "react"
+
+import { useDialogApi } from "#/components/dialogs/api/dialogApiProvider.tsx"
+import type { AnyDialogCtrl } from "#/components/dialogs/api/dialogCtrl.ts"
+import { ItemDialog } from "#/components/items/dialogs/itemDialog.tsx"
+import { FocusFormFields } from "#/components/items/types/foci/forms/focusFormFields.tsx"
+import { focusFieldMap, useFocusForm } from "#/components/items/types/foci/forms/useFocusForm.tsx"
+import type { FocusData } from "#/system/gear/focusData.ts"
+
+interface FocusFormDialogProps {
+  ctrl: AnyDialogCtrl
+  focus?: FocusData
+}
+
+export const FocusFormDialog: FC<FocusFormDialogProps> = ({ ctrl, focus }) => {
+  const title = focus ? "Edit Focus" : "Add Focus"
+
+  const form = useFocusForm({
+    focus,
+    onSubmit: (focusData) => ctrl.close(focusData),
+  })
+
+  return (
+    <ItemDialog
+      form={form}
+      title={title}
+      ctrl={ctrl}
+      ratingMax={6}
+      options={{
+        hasRating: { forced: true },
+        hasEffects: { forced: true },
+        showCost: { forced: true },
+        showAvailability: { forced: true },
+        multiple: { forced: true, enabled: false },
+      }}
+      slots={{
+        itemFields: () => <FocusFormFields form={form} fields={focusFieldMap} />,
+      }}
+    />
+  )
+}
+
+type UseFocusFormDialogProps = Omit<FocusFormDialogProps, "ctrl">
+
+export const useFocusFormDialog = () => {
+  const dialogApi = useDialogApi()
+
+  return {
+    open: (props?: UseFocusFormDialogProps) => dialogApi.open<FocusData>(
+      (ctrl) => <FocusFormDialog ctrl={ctrl} {...props} />,
+    ),
+  }
+}

--- a/src/components/items/types/foci/focusItemCard.tsx
+++ b/src/components/items/types/foci/focusItemCard.tsx
@@ -1,0 +1,103 @@
+import Chip from "@mui/material/Chip"
+import Tooltip from "@mui/material/Tooltip"
+import Typography from "@mui/material/Typography"
+import { RiDeleteBin6Line, RiFlashlightFill, RiFlashlightLine } from "@remixicon/react"
+import type { FC } from "react"
+
+import { AvailabilityChip } from "#/components/items/availability/availabilityChip.tsx"
+import { ItemCard } from "#/components/items/card/itemCard.tsx"
+import { ItemStatChip } from "#/components/items/card/itemStatChip.tsx"
+import { GearMaxAvailability } from "#/components/items/gearUtils.ts"
+import { Nuyen } from "#/components/ui/nuyen.tsx"
+import type { FocusData } from "#/system/gear/focusData.ts"
+
+interface FocusItemCardProps {
+  focus: FocusData
+  onEdit: () => void
+  onRemove: () => void
+  onToggleActivation: () => void
+}
+
+export const FocusItemCard: FC<FocusItemCardProps> = ({
+  focus,
+  onEdit,
+  onRemove,
+  onToggleActivation,
+}) => {
+  const { availability, source } = focus
+  const isActive = focus.equipped === true && focus.bonded === true
+  const canActivate = focus.bonded === true
+
+  const activationTooltip = canActivate
+    ? (isActive ? "Deactivate" : "Activate")
+    : "Bond the focus before activating"
+
+  return (
+    <ItemCard onClick={onEdit}>
+      <ItemCard.Title>{focus.name}</ItemCard.Title>
+
+      <ItemCard.Meta type="stat">
+        <ItemStatChip label={focus.focusType} color="secondary" />
+      </ItemCard.Meta>
+
+      {focus.bonded && (
+        <ItemCard.Meta type="stat">
+          <Chip label="Bonded" size="small" color="info" />
+        </ItemCard.Meta>
+      )}
+
+      {isActive && (
+        <ItemCard.Meta type="cost">
+          <Chip label="Active" size="small" color="success" />
+        </ItemCard.Meta>
+      )}
+
+      {focus.rating !== undefined && (
+        <ItemCard.Meta type="stat">
+          <ItemStatChip label={`Force: ${focus.rating}`} />
+        </ItemCard.Meta>
+      )}
+
+      {focus.cost !== undefined && (
+        <ItemCard.Meta type="cost">
+          <Typography sx={{ fontSize: "0.875rem" }}>
+            <Nuyen amount={focus.cost} />
+          </Typography>
+        </ItemCard.Meta>
+      )}
+
+      {availability && (
+        <ItemCard.Meta type="stat">
+          <AvailabilityChip
+            availability={availability}
+            color={availability.rating > GearMaxAvailability ? "warning" : undefined}
+          />
+        </ItemCard.Meta>
+      )}
+
+      {source && (
+        <ItemCard.Meta type="source">
+          <ItemStatChip label={`${source.book} p.${source.page}`} />
+        </ItemCard.Meta>
+      )}
+
+      <Tooltip title={activationTooltip}>
+        <span>
+          <ItemCard.Action
+            type="icon"
+            color={isActive ? "success" : "default"}
+            disabled={!canActivate}
+            onClick={onToggleActivation}
+            aria-label={isActive ? "Deactivate focus" : "Activate focus"}
+          >
+            {isActive ? <RiFlashlightFill size={16} /> : <RiFlashlightLine size={16} />}
+          </ItemCard.Action>
+        </span>
+      </Tooltip>
+
+      <ItemCard.Action type="icon" color="error" onClick={onRemove} aria-label="Remove focus">
+        <RiDeleteBin6Line size={16} />
+      </ItemCard.Action>
+    </ItemCard>
+  )
+}

--- a/src/components/items/types/foci/focusItemCard.tsx
+++ b/src/components/items/types/foci/focusItemCard.tsx
@@ -75,7 +75,7 @@ export const FocusItemCard: FC<FocusItemCardProps> = ({
         </ItemCard.Meta>
       )}
 
-      {source && (
+      {source?.book && (
         <ItemCard.Meta type="source">
           <ItemStatChip label={`${source.book} p.${source.page}`} />
         </ItemCard.Meta>

--- a/src/components/items/types/foci/focusItemCard.tsx
+++ b/src/components/items/types/foci/focusItemCard.tsx
@@ -1,4 +1,3 @@
-import Chip from "@mui/material/Chip"
 import Tooltip from "@mui/material/Tooltip"
 import Typography from "@mui/material/Typography"
 import { RiDeleteBin6Line, RiFlashlightFill, RiFlashlightLine } from "@remixicon/react"
@@ -10,6 +9,9 @@ import { ItemStatChip } from "#/components/items/card/itemStatChip.tsx"
 import { GearMaxAvailability } from "#/components/items/gearUtils.ts"
 import { Nuyen } from "#/components/ui/nuyen.tsx"
 import type { FocusData } from "#/system/gear/focusData.ts"
+
+import { ActiveChip } from "./activeChip.tsx"
+import { BondedChip } from "./bondedChip.tsx"
 
 interface FocusItemCardProps {
   focus: FocusData
@@ -42,13 +44,13 @@ export const FocusItemCard: FC<FocusItemCardProps> = ({
 
       {focus.bonded && (
         <ItemCard.Meta type="stat">
-          <Chip label="Bonded" size="small" color="info" />
+          <BondedChip />
         </ItemCard.Meta>
       )}
 
       {isActive && (
         <ItemCard.Meta type="cost">
-          <Chip label="Active" size="small" color="success" />
+          <ActiveChip />
         </ItemCard.Meta>
       )}
 

--- a/src/components/items/types/foci/forms/focusFormFields.tsx
+++ b/src/components/items/types/foci/forms/focusFormFields.tsx
@@ -1,0 +1,95 @@
+import Stack from "@mui/material/Stack"
+
+import { Label } from "#/components/ui/text/label.tsx"
+import { withFieldGroup } from "#/integrations/tanstackForm/useAppForm.ts"
+import { FocusType } from "#/system/gear/focusData.ts"
+import { SpellCategory } from "#/system/magic/spellData.ts"
+
+import { focusFormOpts, getDefaultPowerFocusEffects } from "./useFocusForm.tsx"
+
+const focusTypeOptions = [
+  { label: "Power", value: FocusType.Power },
+  { label: "Spellcasting", value: FocusType.Spellcasting },
+  { label: "Summoning", value: FocusType.Summoning },
+  { label: "Banishing", value: FocusType.Banishing },
+  { label: "Centering", value: FocusType.Centering },
+  { label: "Sustaining", value: FocusType.Sustaining },
+  { label: "Weapon", value: FocusType.Weapon },
+]
+
+const spellCategoryOptions = [
+  { label: "Combat", value: SpellCategory.Combat },
+  { label: "Detection", value: SpellCategory.Detection },
+  { label: "Health", value: SpellCategory.Health },
+  { label: "Illusion", value: SpellCategory.Illusion },
+  { label: "Manipulation", value: SpellCategory.Manipulation },
+]
+
+export const FocusFormFields = withFieldGroup({
+  ...focusFormOpts,
+  render: ({ group }) => {
+    return (
+      <Stack sx={{ gap: 1 }}>
+        <Label label="Focus" />
+
+        <group.AppField
+          name="focusType"
+          listeners={{
+            onChange: ({ value }) => {
+              if (value === FocusType.Power) {
+                const currentEffects = group.state.values.effects ?? []
+                if (currentEffects.length === 0) {
+                  group.setFieldValue("effects", getDefaultPowerFocusEffects())
+                }
+              }
+              if (value !== FocusType.Sustaining) {
+                group.setFieldValue("spellCategory", undefined)
+                group.setFieldValue("slottedSpellId", undefined)
+              }
+            },
+          }}
+        >
+          {(field) => (
+            <field.SelectField
+              label="Focus Type"
+              size="small"
+              fullWidth
+              options={focusTypeOptions}
+            />
+          )}
+        </group.AppField>
+
+        <group.AppField
+          name="bonded"
+          listeners={{
+            onChange: ({ value }) => {
+              if (!value) {
+                group.setFieldValue("equipped", false)
+              }
+            },
+          }}
+        >
+          {(field) => <field.SwitchField label="Bonded" />}
+        </group.AppField>
+
+        <group.Subscribe selector={({ values }) => values.focusType}>
+          {(focusType) =>
+            focusType === FocusType.Sustaining
+              ? (
+                  <group.AppField name="spellCategory">
+                    {(field) => (
+                      <field.SelectField
+                        label="Spell Category"
+                        size="small"
+                        fullWidth
+                        options={spellCategoryOptions}
+                      />
+                    )}
+                  </group.AppField>
+                )
+              : null}
+        </group.Subscribe>
+      </Stack>
+    )
+  },
+})

--- a/src/components/items/types/foci/forms/useFocusForm.tsx
+++ b/src/components/items/types/foci/forms/useFocusForm.tsx
@@ -1,0 +1,76 @@
+import { createFieldMap, formOptions } from "@tanstack/form-core"
+
+import { useItemForm } from "#/components/items/forms/useItemForm.tsx"
+import type { GearSubmitMeta } from "#/components/items/gearSubmitMeta.ts"
+import { NullUuid } from "#/lib/uuidUtils.ts"
+import type { SkillModEffect } from "#/system/gameEffects/gameEffectData.ts"
+import { GameEffectType } from "#/system/gameEffects/gameEffectType.ts"
+import type { FocusData } from "#/system/gear/focusData.ts"
+import { FocusType } from "#/system/gear/focusData.ts"
+import { ItemType } from "#/system/itemType.ts"
+import { SkillKey } from "#/system/skills/skillKey.ts"
+
+interface FocusFormOptions {
+  focus?: FocusData
+  onSubmit: (focus: FocusData, meta: GearSubmitMeta) => void
+}
+
+const magicSkills: readonly SkillKey[] = [
+  SkillKey.arcana,
+  SkillKey.assensing,
+  SkillKey.astralCombat,
+  SkillKey.banishing,
+  SkillKey.binding,
+  SkillKey.counterspelling,
+  SkillKey.enchanting,
+  SkillKey.ritualSpellcasting,
+  SkillKey.spellcasting,
+  SkillKey.summoning,
+]
+
+export function getDefaultPowerFocusEffects(): SkillModEffect[] {
+  return magicSkills.map((skill) => ({
+    type: GameEffectType.skillMod,
+    target: skill,
+    value: 0,
+  }))
+}
+
+const defaultFormValues: FocusData = {
+  id: NullUuid,
+  itemType: ItemType.focus,
+  name: "",
+  focusType: FocusType.Power,
+  bonded: false,
+  rating: 1,
+  cost: 0,
+  quantity: 1,
+  description: "",
+  equipped: false,
+  availability: {
+    rating: 0,
+    restricted: false,
+    forbidden: false,
+  },
+  source: {
+    book: "",
+    page: 0,
+  },
+  effects: getDefaultPowerFocusEffects(),
+  spellCategory: undefined,
+  slottedSpellId: undefined,
+}
+
+export const focusFieldMap = createFieldMap(defaultFormValues)
+
+export const focusFormOpts = formOptions({
+  defaultValues: defaultFormValues,
+})
+
+export const useFocusForm = ({ focus, onSubmit }: FocusFormOptions) => {
+  return useItemForm<FocusData>({
+    item: focus,
+    defaultValues: defaultFormValues,
+    onSubmit,
+  })
+}

--- a/src/components/system/gameEffects/useGameEffects.test.tsx
+++ b/src/components/system/gameEffects/useGameEffects.test.tsx
@@ -4,6 +4,8 @@ import { describe, expect, it } from "vitest"
 import { NullUuid } from "#/lib/uuidUtils.ts"
 import { AttributeKey } from "#/system/attributeKey.ts"
 import { GameEffectType } from "#/system/gameEffects/gameEffectType.ts"
+import type { FocusData } from "#/system/gear/focusData.ts"
+import { FocusType } from "#/system/gear/focusData.ts"
 import { createItem, createItemMap } from "#/system/itemData.ts"
 import { ItemType } from "#/system/itemType.ts"
 import {
@@ -14,6 +16,7 @@ import {
   SpellRange,
   SpellType,
 } from "#/system/magic/spellData.ts"
+import { SkillKey } from "#/system/skills/skillKey.ts"
 import { makeCharacterSheet, makeCharacterSheetWrapper } from "#testUtils/renderUtils.tsx"
 
 import { selectAllGameEffects, selectGameEffectsByType, useGameEffects } from "./useGameEffects.ts"
@@ -208,6 +211,53 @@ describe("selectAllGameEffects", () => {
     const sheet = makeCharacterSheet((s) => {
       s.qualities = [{ id: NullUuid, name: "Toughness", type: "positive" }]
       s.powers = [{ type: "adeptPower", id: NullUuid, name: "Killing Hands", rating: 1, costPerRating: 0.5 }]
+    })
+
+    // Act
+    const effects = selectAllGameEffects(sheet)
+
+    // Assert
+    expect(effects).toEqual([])
+  })
+
+  it("collects effects from an activated (equipped + bonded) focus", () => {
+    // Arrange
+    const [powerFocus] = createItem<FocusData>({
+      name: "Power Focus",
+      itemType: ItemType.focus,
+      focusType: FocusType.Power,
+      bonded: true,
+      equipped: true,
+      effects: [{ type: GameEffectType.skillMod, target: SkillKey.spellcasting, value: 2 }],
+    })
+    const sheet = makeCharacterSheet((s) => {
+      s.gear = createItemMap([powerFocus])
+    })
+
+    // Act
+    const effects = selectAllGameEffects(sheet)
+
+    // Assert
+    expect(effects).toHaveLength(1)
+    expect(effects[0]).toMatchObject({
+      type: GameEffectType.skillMod,
+      target: SkillKey.spellcasting,
+      value: 2,
+    })
+  })
+
+  it("ignores effects from a bonded but unequipped focus", () => {
+    // Arrange
+    const [powerFocus] = createItem<FocusData>({
+      name: "Power Focus",
+      itemType: ItemType.focus,
+      focusType: FocusType.Power,
+      bonded: true,
+      equipped: false,
+      effects: [{ type: GameEffectType.skillMod, target: SkillKey.spellcasting, value: 2 }],
+    })
+    const sheet = makeCharacterSheet((s) => {
+      s.gear = createItemMap([powerFocus])
     })
 
     // Act

--- a/src/system/gear/focusData.test.ts
+++ b/src/system/gear/focusData.test.ts
@@ -1,0 +1,90 @@
+import type { UUID } from "node:crypto"
+
+import { describe, expect, it } from "vitest"
+
+import { ItemType } from "#/system/itemType.ts"
+import { SpellCategory } from "#/system/magic/spellData.ts"
+
+import type { FocusData } from "./focusData.ts"
+import { FocusDataSchema, FocusType, isFocusData } from "./focusData.ts"
+
+describe("FocusDataSchema", () => {
+  it("parses a minimal valid Power focus", () => {
+    const data = {
+      id: crypto.randomUUID(),
+      name: "Power Focus",
+      itemType: ItemType.focus,
+      focusType: FocusType.Power,
+    }
+
+    const parsed = FocusDataSchema.parse(data)
+
+    expect(parsed.focusType).toBe(FocusType.Power)
+    expect(parsed.itemType).toBe(ItemType.focus)
+  })
+
+  it("rejects an unknown focusType", () => {
+    const data = {
+      id: crypto.randomUUID(),
+      name: "Bogus",
+      itemType: ItemType.focus,
+      focusType: "Mystery",
+    }
+
+    expect(() => FocusDataSchema.parse(data)).toThrow()
+  })
+
+  it("rejects an itemType other than focus", () => {
+    const data = {
+      id: crypto.randomUUID(),
+      name: "Armor",
+      itemType: ItemType.armor,
+      focusType: FocusType.Power,
+    }
+
+    expect(() => FocusDataSchema.parse(data)).toThrow()
+  })
+
+  it("round-trips a sustaining focus with spellCategory and slottedSpellId", () => {
+    const slottedSpellId = crypto.randomUUID()
+    const data = {
+      id: crypto.randomUUID(),
+      name: "Sustaining (Combat)",
+      itemType: ItemType.focus,
+      focusType: FocusType.Sustaining,
+      spellCategory: SpellCategory.Combat,
+      slottedSpellId,
+      bonded: true,
+      equipped: true,
+      rating: 3,
+    }
+
+    const parsed = FocusDataSchema.parse(data)
+
+    expect(parsed.spellCategory).toBe(SpellCategory.Combat)
+    expect(parsed.slottedSpellId).toBe(slottedSpellId)
+    expect(parsed.bonded).toBe(true)
+    expect(parsed.equipped).toBe(true)
+    expect(parsed.rating).toBe(3)
+  })
+})
+
+describe("isFocusData", () => {
+  it("returns true for a focus item", () => {
+    const focus: FocusData = {
+      id: crypto.randomUUID() as UUID,
+      name: "Test",
+      itemType: ItemType.focus,
+      focusType: FocusType.Centering,
+    }
+    expect(isFocusData(focus)).toBe(true)
+  })
+
+  it("returns false for a non-focus item", () => {
+    expect(isFocusData({
+      id: crypto.randomUUID() as UUID,
+      name: "Armor",
+      itemType: ItemType.armor,
+    })).toBe(false)
+  })
+})

--- a/src/system/gear/focusData.ts
+++ b/src/system/gear/focusData.ts
@@ -1,0 +1,70 @@
+import type { UUID } from "node:crypto"
+
+import { z } from "zod"
+
+import { GameEffectDataSchema } from "#/system/gameEffects/gameEffectData.ts"
+import type { ItemData } from "#/system/itemData.ts"
+import { ItemType } from "#/system/itemType.ts"
+import { SpellCategory } from "#/system/magic/spellData.ts"
+import { SourceDataSchema } from "#/system/sourceData.ts"
+
+export enum FocusType {
+  Power = "Power",
+  Spellcasting = "Spellcasting",
+  Summoning = "Summoning",
+  Banishing = "Banishing",
+  Centering = "Centering",
+  Sustaining = "Sustaining",
+  Weapon = "Weapon",
+}
+
+export interface FocusData extends ItemData {
+  itemType: ItemType.focus
+  focusType: FocusType
+  /** True when Karma has been paid to link the focus. Prerequisite for activation. */
+  bonded?: boolean
+  /** Sustaining foci only — fixed at item creation, restricts which spell can be slotted. */
+  spellCategory?: SpellCategory
+  /** Sustaining foci only — the currently held spell. */
+  slottedSpellId?: UUID
+}
+
+export const FocusDataSchema = z.object({
+  id: z.uuid() as z.ZodType<UUID>,
+  name: z.string(),
+  itemType: z.literal(ItemType.focus),
+
+  description: z.string().optional(),
+  cost: z.number().optional(),
+  quantity: z.number().int().min(0).optional(),
+  availability: z.object({
+    rating: z.number().int().min(0),
+    restricted: z.boolean().optional(),
+    forbidden: z.boolean().optional(),
+  }).optional(),
+  source: SourceDataSchema.optional(),
+  rating: z.union([z.number(), z.string()]).optional(),
+
+  parentId: (z.uuid() as z.ZodType<UUID>).optional(),
+  childIds: z.array(z.uuid() as z.ZodType<UUID>).optional(),
+
+  notes: z.string().optional(),
+  equipped: z.boolean().optional(),
+  fixed: z.boolean().optional(),
+
+  wireless: z.object({
+    enabled: z.boolean().optional(),
+    removed: z.boolean().optional(),
+  }).optional(),
+
+  effects: z.array(GameEffectDataSchema).optional(),
+
+  focusType: z.enum(FocusType),
+  bonded: z.boolean().optional(),
+  spellCategory: z.enum(SpellCategory).optional(),
+  slottedSpellId: (z.uuid() as z.ZodType<UUID>).optional(),
+}) satisfies z.ZodType<FocusData>
+
+export function isFocusData(item: ItemData): item is FocusData {
+  return item.itemType === ItemType.focus
+}

--- a/src/system/itemType.ts
+++ b/src/system/itemType.ts
@@ -11,5 +11,6 @@ export enum ItemType {
   sin = "sin",
   credstick = "credstick",
   program = "program",
+  focus = "focus",
   other = "other",
 }


### PR DESCRIPTION
Implements the foundational slice of issue #282: data model, Zod schema, 3-layer gear form pattern, activation toggle, and buffing focus effects.

## Data model
- `ItemType.focus` added to the enum
- `FocusType` enum (Power / Spellcasting / Summoning / Banishing / Centering / Sustaining / Weapon) — serves as the subtype discriminator inside `FocusData`
- `FocusData extends ItemData` with `focusType`, `bonded?`, `spellCategory?`, `slottedSpellId?`
- `FocusDataSchema` with `satisfies z.ZodType<FocusData>`, `isFocusData` guard

## Form (3-layer pattern)
- `useFocusForm` hook with focus-specific defaults; default `effects` pre-populated via `getDefaultPowerFocusEffects()` (Power is the default focusType)
- `FocusFormFields` field group:
  - focusType picker with `listeners.onChange` that auto-populates magic-skill effects when Power is selected and clears sustaining-only fields otherwise
  - Bonded switch with `listeners.onChange` that clears `equipped` on un-bond (preserves the bonded → equipped invariant)
  - Conditional `spellCategory` picker rendered via `group.Subscribe` when focusType is Sustaining
- `FocusFormDialog` wraps `ItemDialog` with `hasRating`, `hasEffects`, `showCost`, `showAvailability` forced; rating max 6 (SR4 Force cap). `equipable` is deliberately omitted — activation lives on the card.

## Activation
- `FocusItemCard` shows type / Force / Bonded / Active chips and a Tooltip-wrapped activation button. Click toggles `equipped`; button is disabled when `!bonded`. Effects flow through `selectAllGameEffects` unchanged because it already filters by `equipped`.

## Wiring
- Viewer: `Foci` section added to `GearSection`; `FociSectionContent` opens `FocusFormDialog`; dispatched from `GearViewSectionContent`.
- Builder: `Foci` added to `SectionHeader`; `FociPanel` + `FociList` created; `gearSection.tsx` routes the panel and aggregates nuyen via `genericSectionTypes`.

## Tests
- `focusData.test.ts` — schema parse/reject + `isFocusData`
- `focusFormDialog.test.tsx` — submits a Power focus, auto-populate produces 10 magic-skill effects, editing preserves existing effects, sustaining shows Spell Category
- `useGameEffects.test.tsx` — activated focus contributes effects; bonded-but-unequipped focus does not

## Out of scope (per the issue's "foundational slice" framing)
Karma transactions / Force×multiplier costs, `bondFocus` ImprovementEntry, Active Foci Limit selector, sustaining spell-slot UI (`slottedSpellId` is schema-only this slice), weapon-focus dual-item linkage helpers.

## Test plan
- [x] `yarn lint`
- [x] `yarn test:unit` (438 tests pass)
- [x] `yarn fallow` (no dead-code findings on new code)
- [x] Manual smoke: Builder → Foci → Add Focus, pick Power → effects auto-populate; toggle Bonded then Activate → "Active" chip appears; viewer Foci section renders the same card.

Closes #282

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>