### PR TITLE
fix(items): render ItemCard wrapper as div to avoid nested-button warning

### DIFF
--- a/src/components/items/card/itemCardRoot.tsx
+++ b/src/components/items/card/itemCardRoot.tsx
@@ -2,7 +2,7 @@ import Box from "@mui/material/Box"
 import ButtonBase from "@mui/material/ButtonBase"
 import Stack from "@mui/material/Stack"
 import type { SxProps } from "@mui/material/styles"
-import type { FC, PropsWithChildren, ReactElement, ReactNode } from "react"
+import type { ElementType, FC, PropsWithChildren, ReactElement, ReactNode } from "react"
 import { Children, isValidElement } from "react"
 
 import { ItemCardAction } from "./itemCardAction.tsx"
@@ -41,11 +41,12 @@ export const ItemCardRoot: FC<ItemCardRootProps> = ({ onClick, children, variant
 
   const hasMiddleRow = statMetas.length > 0 || sourceMetas.length > 0
 
-  const Wrapper: FC<PropsWithChildren<{ onClick?: () => void, sx: SxProps }>> = onClick ? ButtonBase : Box
+  const Wrapper: FC<PropsWithChildren<{ onClick?: () => void, sx: SxProps, component?: ElementType }>> = onClick ? ButtonBase : Box
 
   return (
     <Stack direction="column" sx={{ gap: 0 }}>
       <Wrapper
+        component="div"
         onClick={onClick}
         sx={{
           padding: 1,


### PR DESCRIPTION
## Summary

`ItemCardRoot`'s outer wrapper used MUI `ButtonBase` (which renders as a `<button>`) whenever the card had an `onClick`. Inside that wrapper, the icon-action slot renders MUI `IconButton`s (also `<button>`), so React was logging the hydration warning *"In HTML, `<button>` cannot be a descendant of `<button>`"* for every armor, implant, and program card with a delete/edit icon.

Fix: pass `component="div"` to `ButtonBase` so it renders as a `<div role="button">` with `tabIndex={0}` and MUI's built-in keyboard handlers — ripple, focus styles, and Enter/Space activation are preserved, but nested `<button>`s are now legal HTML. The existing `stopPropagation` handler on the icon-actions stack still isolates icon clicks from the card-level `onEdit`.

## Changes

- `src/components/items/card/itemCardRoot.tsx` — widen the inferred `Wrapper` type to accept `component?: ElementType`, and pass `component="div"` on the wrapper element.

## Test plan

- [x] `yarn lint` — clean (eslint + tsc)
- [x] `yarn test:unit` — 982/982 pass
- [x] Manual: navigate to a character with cyberware (Artemis), expand the **Cyberware** accordion on the Gear page. 11 implant cards render as `<div role="button">` containing legal `<button>` IconButtons; zero `<button> <button>` nesting in the DOM; no hydration warning in console. Same `ItemCardRoot` code path is used by armor (builder), implants, and programs/devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)