### PR TITLE
feat: expand spell drain modifier range limits

### DIFF
--- a/src/components/character/spells/form/spellFormFields.tsx
+++ b/src/components/character/spells/form/spellFormFields.tsx
@@ -96,8 +96,8 @@ export const SpellFormFields: FC<SpellFormFieldsProps> = ({ form }) => {
                 {(field) => (
                   <field.CounterField
                     label={drainType === SpellDrainType.Fixed ? "Value" : "Mod"}
-                    min={drainType === SpellDrainType.Fixed ? 1 : -4}
-                    max={drainType === SpellDrainType.Force ? 4 : undefined}
+                    min={drainType === SpellDrainType.Fixed ? 1 : -9}
+                    max={drainType === SpellDrainType.Force ? 9 : undefined}
                   />
                 )}
               </form.AppField>


### PR DESCRIPTION
Increase the minimum drain modifier from -4 to -9 and maximum
from 4 to 9 to allow for a wider range of spell drain values
in the character spell form.