### PR TITLE
fix(magic): drop redundant prefix from Conjuring specializations

### DIFF
--- a/src/system/magic/spiritData.ts
+++ b/src/system/magic/spiritData.ts
@@ -52,6 +52,22 @@ export const SpiritTypeLabels: Record<SpiritType, string> = {
   [SpiritType.watcher]: "Watcher",
 }
 
+// Plural form used for Conjuring (Summoning/Binding/Banishing) specializations
+// where the skill targets a category of spirits rather than a single one.
+export const SpiritTypePluralLabels: Record<SpiritType, string> = {
+  [SpiritType.wind]: "Spirits of Air",
+  [SpiritType.beast]: "Spirits of Beasts",
+  [SpiritType.earth]: "Spirits of Earth",
+  [SpiritType.fire]: "Spirits of Fire",
+  [SpiritType.guidance]: "Guidance Spirits",
+  [SpiritType.guardian]: "Guardian Spirits",
+  [SpiritType.man]: "Spirits of Man",
+  [SpiritType.plant]: "Plant Spirits",
+  [SpiritType.task]: "Task Spirits",
+  [SpiritType.water]: "Spirits of Water",
+  [SpiritType.watcher]: "Watchers",
+}
+
 export interface SpiritData {
   id: UUID
   name: string

--- a/src/system/skills/skillList.ts
+++ b/src/system/skills/skillList.ts
@@ -1,6 +1,6 @@
 import { AttributeKey } from "#/system/attributeKey.ts"
 import { MagicAwakeningTypes, TechAwakeningTypes } from "#/system/awakeningType.ts"
-import { SpiritType, SpiritTypeLabels } from "#/system/magic/spiritData.ts"
+import { SpiritType, SpiritTypePluralLabels } from "#/system/magic/spiritData.ts"
 
 import { SkillCategory } from "./skillCategory.ts"
 import { SkillGroupKey } from "./skillGroupKey.ts"
@@ -8,7 +8,7 @@ import type { SkillInfo } from "./skillInfo.ts"
 import { SkillKey } from "./skillKey.ts"
 
 const spiritTypeSpecializations = Object.values(SpiritType).map(
-  (spiritType) => `Spirits of ${SpiritTypeLabels[spiritType]}`,
+  (spiritType) => SpiritTypePluralLabels[spiritType],
 )
 
 export const skillList: Record<SkillKey, SkillInfo> = {


### PR DESCRIPTION
## Summary
- The Conjuring spec generator built labels as `Spirits of ${SpiritTypeLabels[type]}`, producing redundant strings like **"Spirits of Spirit of Fire"** in the karma-spend dialog (and "Spirits of Watcher", "Spirits of Guardian Spirit", etc.).
- Added `SpiritTypePluralLabels` in `spiritData.ts` so each spirit category owns its plural form matching SR4A wording ("Spirits of Fire", "Guardian Spirits", "Watchers", ...). `skillList.ts` now consumes that map directly.
- `SpiritTypeLabels` (singular) is left untouched — it's still consumed correctly by `traditionData`, `summoningDicePool`, `spiritItemCard`, and the spirit form fields.

## Test plan
- [x] `yarn lint`
- [x] `yarn test:unit` (126 files, 983 tests pass)
- [ ] Open a mage character's karma-spend dialog → Conjuring (Summoning/Binding/Banishing) → confirm specialization options read "Spirits of Fire", "Guardian Spirits", "Watchers", etc. instead of "Spirits of Spirit of Fire".

🤖 Generated with [Claude Code](https://claude.com/claude-code)