### PR TITLE
fix(spirits): prevent dialog reuse from overwriting existing spirits

### DIFF
--- a/src/components/character/spirits/spiritList.tsx
+++ b/src/components/character/spirits/spiritList.tsx
@@ -22,9 +22,13 @@ export const SpiritList: FC = () => {
 
   const [dialogOpen, setDialogOpen] = useState(false)
   const [editingSpirit, setEditingSpirit] = useState<SpiritData | undefined>()
+  // Bumped on each Add so the dialog remounts between successive new spirits
+  // (otherwise useSpiritForm reuses the same generated id and the save overwrites).
+  const [addCounter, setAddCounter] = useState(0)
 
   const handleAdd = () => {
     setEditingSpirit(undefined)
+    setAddCounter((n) => n + 1)
     setDialogOpen(true)
   }
 
@@ -66,7 +70,7 @@ export const SpiritList: FC = () => {
       </Stack>
 
       <SpiritFormDialog
-        key={editingSpirit?.id ?? "new"}
+        key={editingSpirit?.id ?? `new-${addCounter}`}
         open={dialogOpen}
         spirit={editingSpirit}
         onClose={handleClose}

--- a/src/components/items/card/itemCardTitle.tsx
+++ b/src/components/items/card/itemCardTitle.tsx
@@ -6,5 +6,5 @@ interface ItemCardTitleProps {
 }
 
 export const ItemCardTitle: FC<ItemCardTitleProps> = ({ children }) => (
-  <Typography sx={{ flexGrow: 1 }}>{children}</Typography>
+  <Typography component="div" sx={{ flexGrow: 1 }}>{children}</Typography>
 )


### PR DESCRIPTION
## Summary

- The Spirits list rendered `<SpiritFormDialog key={editingSpirit?.id ?? "new"}>`. On repeated **Summon Spirit** clicks, `editingSpirit` stayed `undefined`, so the key stayed the literal string `"new"` and the dialog never remounted between sessions. `useSpiritForm` cached the UUID it generated at first mount in `defaultValues`, so the second submit reused the first spirit's id and `SpiritsStore.save` upserted by id, overwriting the original.
- Fix: bump a per-Add counter in `spiritList.tsx` so the dialog key becomes `new-${n}` on each Add. The dialog remounts, `useSpiritForm` runs again, and each new spirit gets a fresh id. Edit flow is unchanged (still keyed by the spirit's real id).
- Drive-by: render `ItemCardTitle` with `component="div"` to fix a `<p> cannot contain <p>/<div>` hydration warning surfaced during verification. The title's `Typography` defaulted to `<p>`, but `spiritItemCard` injects a `Stack` (div) + `Typography variant="body1"` (p) into the title slot. All other `ItemCard.Title` consumers pass plain string children, so the swap is visually a no-op for them.

## Changes

- `src/components/character/spirits/spiritList.tsx` — add `addCounter` state, bump on `handleAdd`, use `new-${addCounter}` as the fallback key.
- `src/components/items/card/itemCardTitle.tsx` — pass `component="div"` to the wrapping `Typography`.

## Test plan

- [x] `yarn lint` — clean (eslint + tsc)
- [x] `yarn test:unit` — 983/983 pass across 126 files
- [x] Manual repro: open Hexen → Spirits tab → **Summon Spirit** → Save (defaults). Click **Summon Spirit** again → Save (defaults). Two `Nascent Shade` cards now appear in the list (previously the second save overwrote the first). No `<p> cannot be a descendant of <p>` / `<div>` warnings in the browser console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)