### PR TITLE
Fix inverted skill filter in Learn New Skill dialog

### DIFF
--- a/src/components/runner/skills/activeSkills/dialogs/activeSkillFormDialog.test.tsx
+++ b/src/components/runner/skills/activeSkills/dialogs/activeSkillFormDialog.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, screen, within } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { DialogCtrl } from "#/components/ui/dialog/dialogCtrl.ts"
+import { AwakeningType } from "#/system/awakeningType.ts"
+import type { ActiveSkillData } from "#/system/skills/activeSkillData"
+import { SkillKey } from "#/system/skills/skillKey.ts"
+import { renderWithProviders } from "#testUtils/renderUtils.tsx"
+
+import { ActiveSkillFormDialog } from "./activeSkillFormDialog.tsx"
+
+function openSkillDropdown() {
+  // The "Skill" select is the first combobox in the dialog (no accessible name is
+  // wired up on the underlying MUI Select, so we can't query by name here).
+  fireEvent.mouseDown(screen.getAllByRole("combobox")[0])
+}
+
+describe("ActiveSkillFormDialog", () => {
+  it("lists unknown skills and excludes ones already known or disabled", () => {
+    // Arrange
+    const ctrl = new DialogCtrl<ActiveSkillData>()
+    ctrl.open()
+    const disabledSkills = new Set<string>([SkillKey.pistols])
+
+    // Act
+    renderWithProviders(<ActiveSkillFormDialog ctrl={ctrl} disabledSkills={disabledSkills} />)
+    openSkillDropdown()
+
+    // Assert: a skill not in disabledSkills is offered, the disabled one is not
+    const listbox = screen.getByRole("listbox")
+    expect(within(listbox).queryByText(SkillKey.automatics)).not.toBeNull()
+    expect(within(listbox).queryByText(SkillKey.pistols)).toBeNull()
+  })
+
+  it("excludes skills the runner's awakening type can never learn", () => {
+    // Arrange
+    const ctrl = new DialogCtrl<ActiveSkillData>()
+    ctrl.open()
+
+    // Act: a Mundane runner can't learn the Technomancer-only skill "compiling"
+    renderWithProviders(<ActiveSkillFormDialog ctrl={ctrl} />, {
+      updateRunnerData: (sheet) => {
+        sheet.biology.awakening = AwakeningType.Mundane
+      },
+    })
+    openSkillDropdown()
+
+    // Assert
+    const listbox = screen.getByRole("listbox")
+    expect(within(listbox).queryByText(SkillKey.compiling)).toBeNull()
+    expect(within(listbox).queryByText(SkillKey.automatics)).not.toBeNull()
+  })
+})

--- a/src/components/runner/skills/activeSkills/dialogs/activeSkillFormDialog.tsx
+++ b/src/components/runner/skills/activeSkills/dialogs/activeSkillFormDialog.tsx
@@ -42,7 +42,7 @@ type ActiveSkillFormData = {
   specialization: string
 }
 
-const ActiveSkillFormDialog: FC<ActiveSkillFormDialogProps> = ({
+export const ActiveSkillFormDialog: FC<ActiveSkillFormDialogProps> = ({
   ctrl,
   skill,
   disabledSkills,
@@ -116,7 +116,7 @@ const ActiveSkillFormDialog: FC<ActiveSkillFormDialogProps> = ({
                   label="Skill"
                   size="small"
                   value={field.state.value ?? ""}
-                  filterOption={(key) => disabledSkills?.has(key) ?? true}
+                  filterOption={(key) => !disabledSkills?.has(key)}
                   onChange={(e) => field.handleChange(e.target.value)}
                   onBlur={() => field.handleBlur()}
                 />


### PR DESCRIPTION
The Skill dropdown's filterOption predicate kept entries when
disabledSkills.has(key) was true, so it showed already-known/queued
skills and hid everything else instead of the reverse. Awakening-based
restrictions (e.g. non-Technomancers can't learn compiling) were
already handled correctly upstream via selectAllowedActiveSkills.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013pJRdGiiQDjgDE6d3Yr4wt