### PR TITLE
Show damage formula reminder in spell cast dialog

### DIFF
--- a/src/components/runner/spells/spellCastDialog.tsx
+++ b/src/components/runner/spells/spellCastDialog.tsx
@@ -55,6 +55,13 @@ const SpellCastDialog: FC<SpellCastDialogProps> = ({ ctrl, spell }) => {
                 <Typography sx={{ textAlign: "center" }}>
                   {spell.damage}
                 </Typography>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ display: "block", textAlign: "center", fontStyle: "italic" }}
+                >
+                  DV = Force
+                </Typography>
               </Grid>
             )}
             <Grid size={1}>


### PR DESCRIPTION
Combat spells' Damage Value always equals Force, but nothing in the
cast dialog surfaced that. Add a small reminder under the Damage cell
for spells that deal damage.