### PR TITLE
Make active skills list responsive with 1-3 columns

### DIFF
--- a/src/components/runner/skills/activeSkills/activeSkillsList.tsx
+++ b/src/components/runner/skills/activeSkills/activeSkillsList.tsx
@@ -1,3 +1,4 @@
+import Box from "@mui/material/Box"
 import InputAdornment from "@mui/material/InputAdornment"
 import Stack from "@mui/material/Stack"
 import TextField from "@mui/material/TextField"
@@ -131,7 +132,7 @@ export const ActiveSkillsList: FC = () => {
         </ToggleButtonGroup>
       </Stack>
 
-      <Stack>
+      <Box>
         {visibleSkills.length === 0 && (
           <Typography
 
@@ -142,19 +143,27 @@ export const ActiveSkillsList: FC = () => {
           </Typography>
         )}
 
-        {groupedSkills.map(([group, groupSkills]) => (
-          <Fragment key={group}>
-            <Label label={group} />
-            {groupSkills.map((skill) => (
-              <ActiveSkillsListItem
-                key={skill.key}
-                skillKey={skill.key}
-                rating={skill.rating}
-              />
-            ))}
-          </Fragment>
-        ))}
-      </Stack>
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: { xs: "1fr", md: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" },
+            columnGap: 2,
+          }}
+        >
+          {groupedSkills.map(([group, groupSkills]) => (
+            <Fragment key={group}>
+              <Label label={group} sx={{ gridColumn: "1 / -1" }} />
+              {groupSkills.map((skill) => (
+                <ActiveSkillsListItem
+                  key={skill.key}
+                  skillKey={skill.key}
+                  rating={skill.rating}
+                />
+              ))}
+            </Fragment>
+          ))}
+        </Box>
+      </Box>
     </>
   )
 }

--- a/src/components/runner/skills/activeSkills/activeSkillsList.tsx
+++ b/src/components/runner/skills/activeSkills/activeSkillsList.tsx
@@ -148,6 +148,7 @@ export const ActiveSkillsList: FC = () => {
             display: "grid",
             gridTemplateColumns: { xs: "1fr", md: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" },
             columnGap: 2,
+            rowGap: 1,
           }}
         >
           {groupedSkills.map(([group, groupSkills]) => (


### PR DESCRIPTION
Lays skills out in a CSS grid that scales from a single column on
narrow screens to two columns at medium width and three on wide
screens, with group labels spanning the full row.