### PR TITLE
Standardize karma displays on KarmaChip/KarmaValue

### DIFF
--- a/src/components/runner/karma/karmaSection.tsx
+++ b/src/components/runner/karma/karmaSection.tsx
@@ -1,13 +1,13 @@
 import Button from "@mui/material/Button"
 import Grid from "@mui/material/Grid"
 import Stack from "@mui/material/Stack"
-import Typography from "@mui/material/Typography"
 import type { FC } from "react"
 
 import { Label } from "#/components/ui/text/label.tsx"
 import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
 
 import { useAddKarmaDialog } from "./addKarmaDialog.tsx"
+import { KarmaValue } from "./karmaValue.tsx"
 import { useSpendKarmaDialog } from "./spendKarmaDialog.tsx"
 
 export const KarmaSection: FC = () => {
@@ -30,18 +30,14 @@ export const KarmaSection: FC = () => {
         <Grid size={1}>
           <Stack sx={{ gap: 1, alignItems: "center" }}>
             <Label label="Current" />
-            <Typography sx={{ fontWeight: "bold" }}>
-              {currentKarma}
-            </Typography>
+            <KarmaValue amount={currentKarma} sx={{ fontWeight: "bold" }} />
           </Stack>
         </Grid>
 
         <Grid size={1}>
           <Stack sx={{ gap: 1, alignItems: "center" }}>
             <Label label="Total Earned" />
-            <Typography sx={{ fontWeight: "bold" }}>
-              {totalKarma}
-            </Typography>
+            <KarmaValue amount={totalKarma} sx={{ fontWeight: "bold" }} />
           </Stack>
         </Grid>
 

--- a/src/components/runner/karma/karmaValue.tsx
+++ b/src/components/runner/karma/karmaValue.tsx
@@ -1,13 +1,15 @@
 // fallow-ignore-file
 import Stack from "@mui/material/Stack"
-import type { SxProps, Theme } from "@mui/material/styles"
+import type { SxProps } from "@mui/material/styles"
 import type { FC } from "react"
+
+import { mergeSx } from "#/integrations/mui/muiUtils.ts"
 
 import { KarmaIcon } from "./karmaIcon.tsx"
 
 interface KarmaValueProps {
   amount: number
-  sx?: SxProps<Theme>
+  sx?: SxProps
 }
 
 export const KarmaValue: FC<KarmaValueProps> = ({
@@ -15,7 +17,7 @@ export const KarmaValue: FC<KarmaValueProps> = ({
   sx,
 }) => {
   return (
-    <Stack direction="row" sx={[{ alignItems: "center", gap: 0.5 }, ...(Array.isArray(sx) ? sx : [sx])]}>
+    <Stack direction="row" sx={mergeSx({ alignItems: "center", gap: 0.5 }, sx)}>
       {amount} <KarmaIcon size={12} />
     </Stack>
   )

--- a/src/components/runner/karma/karmaValue.tsx
+++ b/src/components/runner/karma/karmaValue.tsx
@@ -1,18 +1,21 @@
 // fallow-ignore-file
 import Stack from "@mui/material/Stack"
+import type { SxProps, Theme } from "@mui/material/styles"
 import type { FC } from "react"
 
 import { KarmaIcon } from "./karmaIcon.tsx"
 
 interface KarmaValueProps {
   amount: number
+  sx?: SxProps<Theme>
 }
 
 export const KarmaValue: FC<KarmaValueProps> = ({
   amount,
+  sx,
 }) => {
   return (
-    <Stack direction="row" sx={{ alignItems: "center", gap: 0.5 }}>
+    <Stack direction="row" sx={[{ alignItems: "center", gap: 0.5 }, ...(Array.isArray(sx) ? sx : [sx])]}>
       {amount} <KarmaIcon size={12} />
     </Stack>
   )

--- a/src/components/runner/karma/runnerImprovements/improvementActiveSkillRow.tsx
+++ b/src/components/runner/karma/runnerImprovements/improvementActiveSkillRow.tsx
@@ -10,6 +10,8 @@ import Typography from "@mui/material/Typography"
 import { RiCheckLine, RiFlashlightLine, RiStarLine } from "@remixicon/react"
 import type { FC } from "react"
 
+import { KarmaChip } from "#/components/runner/karma/karmaChip.tsx"
+import { KarmaValue } from "#/components/runner/karma/karmaValue.tsx"
 import type { SkillKey } from "#/system/skills/skillKey.ts"
 
 interface ImprovementActiveSkillRowProps {
@@ -76,8 +78,8 @@ export const ImprovementActiveSkillRow: FC<ImprovementActiveSkillRowProps> = ({
           {isAtMax
             ? <Chip label="Max" size="small" />
             : (
-                <Chip
-                  label={`${improveCost}k`}
+                <KarmaChip
+                  amount={improveCost}
                   size="small"
                   color={isImproveQueued ? "success" : canAffordImprove ? "default" : "warning"}
                 />
@@ -97,7 +99,16 @@ export const ImprovementActiveSkillRow: FC<ImprovementActiveSkillRowProps> = ({
               />
             </Tooltip>
           )}
-          <Tooltip title={isSpecQueued ? "Remove specialization" : `Specialization (${specCost}k)`}>
+          <Tooltip
+            title={isSpecQueued
+              ? "Remove specialization"
+              : (
+                  <Stack direction="row" sx={{ alignItems: "center", gap: 0.5 }}>
+                    Specialization
+                    <KarmaValue amount={specCost} />
+                  </Stack>
+                )}
+          >
             <span>
               <IconButton
                 size="small"

--- a/src/components/runner/karma/runnerImprovements/improvementAttributeList.tsx
+++ b/src/components/runner/karma/runnerImprovements/improvementAttributeList.tsx
@@ -10,6 +10,7 @@ import { RiCheckLine } from "@remixicon/react"
 import type { FC } from "react"
 
 import { useActiveAttributes } from "#/components/runner/attributes/hooks/useActiveAttributes.ts"
+import { KarmaChip } from "#/components/runner/karma/karmaChip.tsx"
 import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
 import { AttributeLabels } from "#/system/attributeKey.ts"
 import { getAttributeCap } from "#/system/karma/improvements/improvementCaps.ts"
@@ -79,8 +80,8 @@ export const ImprovementAttributeList: FC<ImprovementAttributeListProps> = () =>
                   <Stack direction="row" sx={{ alignItems: "center", gap: 0.5 }}>
                     {isAtMax && <Chip label="Max" size="small" />}
                     {!isAtMax && (
-                      <Chip
-                        label={`${karmaCost}k`}
+                      <KarmaChip
+                        amount={karmaCost}
                         size="small"
                         color={queuedEntry ? "success" : canAfford ? "default" : "warning"}
                       />

--- a/src/components/runner/karma/runnerImprovements/improvementKnowledgeSkillList.tsx
+++ b/src/components/runner/karma/runnerImprovements/improvementKnowledgeSkillList.tsx
@@ -12,6 +12,8 @@ import Typography from "@mui/material/Typography"
 import { RiAddLine, RiCheckLine, RiLightbulbLine, RiStarLine } from "@remixicon/react"
 import type { FC } from "react"
 
+import { KarmaChip } from "#/components/runner/karma/karmaChip.tsx"
+import { KarmaValue } from "#/components/runner/karma/karmaValue.tsx"
 import {
   useKnowledgeSkillDialog,
 } from "#/components/runner/skills/knowledgeSkills/dialogs/knowledgeSkillEditDialog.tsx"
@@ -151,8 +153,8 @@ export const ImprovementKnowledgeSkillList: FC = () => {
                       {isAtMax
                         ? <Chip label="Max" size="small" />
                         : (
-                            <Chip
-                              label={`${karmaCost}k`}
+                            <KarmaChip
+                              amount={karmaCost}
                               size="small"
                               color={queuedEntry ? "success" : canAffordImprove ? "default" : "warning"}
                             />
@@ -172,7 +174,16 @@ export const ImprovementKnowledgeSkillList: FC = () => {
                           />
                         </Tooltip>
                       )}
-                      <Tooltip title={queuedSpec ? "Remove specialization" : `Specialization (${SPEC_COST}k)`}>
+                      <Tooltip
+                        title={queuedSpec
+                          ? "Remove specialization"
+                          : (
+                              <Stack direction="row" sx={{ alignItems: "center", gap: 0.5 }}>
+                                Specialization
+                                <KarmaValue amount={SPEC_COST} />
+                              </Stack>
+                            )}
+                      >
                         <span>
                           <IconButton
                             size="small"

--- a/src/components/runner/karma/runnerImprovements/improvementLanguageSkillList.tsx
+++ b/src/components/runner/karma/runnerImprovements/improvementLanguageSkillList.tsx
@@ -12,6 +12,8 @@ import Typography from "@mui/material/Typography"
 import { RiAddLine, RiChat4Line, RiCheckLine, RiStarLine } from "@remixicon/react"
 import type { FC } from "react"
 
+import { KarmaChip } from "#/components/runner/karma/karmaChip.tsx"
+import { KarmaValue } from "#/components/runner/karma/karmaValue.tsx"
 import {
   useLanguageSkillDialog,
 } from "#/components/runner/skills/knowledgeSkills/dialogs/languageSkillDialog.tsx"
@@ -158,8 +160,8 @@ export const ImprovementLanguageSkillList: FC = () => {
                       {isAtMax
                         ? <Chip label={isNative ? "Native" : "Max"} size="small" />
                         : (
-                            <Chip
-                              label={`${karmaCost}k`}
+                            <KarmaChip
+                              amount={karmaCost}
                               size="small"
                               color={queuedEntry ? "success" : canAffordImprove ? "default" : "warning"}
                             />
@@ -179,7 +181,16 @@ export const ImprovementLanguageSkillList: FC = () => {
                           />
                         </Tooltip>
                       )}
-                      <Tooltip title={queuedSpec ? "Remove lingo" : `Lingo (${LINGO_COST}k)`}>
+                      <Tooltip
+                        title={queuedSpec
+                          ? "Remove lingo"
+                          : (
+                              <Stack direction="row" sx={{ alignItems: "center", gap: 0.5 }}>
+                                Lingo
+                                <KarmaValue amount={LINGO_COST} />
+                              </Stack>
+                            )}
+                      >
                         <span>
                           <IconButton
                             size="small"

--- a/src/components/runner/karma/runnerImprovements/improvementQueuedLearnRow.tsx
+++ b/src/components/runner/karma/runnerImprovements/improvementQueuedLearnRow.tsx
@@ -1,4 +1,3 @@
-import Chip from "@mui/material/Chip"
 import IconButton from "@mui/material/IconButton"
 import ListItem from "@mui/material/ListItem"
 import ListItemText from "@mui/material/ListItemText"
@@ -6,6 +5,8 @@ import Stack from "@mui/material/Stack"
 import Tooltip from "@mui/material/Tooltip"
 import { RiCheckLine, RiDeleteBin6Line } from "@remixicon/react"
 import type { FC, ReactNode } from "react"
+
+import { KarmaChip } from "#/components/runner/karma/karmaChip.tsx"
 
 interface ImprovementQueuedLearnRowProps {
   primary: ReactNode
@@ -33,7 +34,7 @@ export const ImprovementQueuedLearnRow: FC<ImprovementQueuedLearnRowProps> = ({
       divider={!isLastRow}
       secondaryAction={(
         <Stack direction="row" sx={{ alignItems: "center", gap: 0.5 }}>
-          <Chip label={`${cost}k`} size="small" color="success" />
+          <KarmaChip amount={cost} size="small" color="success" />
           <RiCheckLine size={14} style={{ color: "var(--mui-palette-success-main)" }} />
           <Tooltip title="Remove">
             <IconButton size="small" aria-label="Remove queued" onClick={onRemove}>

--- a/src/components/runner/karma/runnerImprovements/improvementSkillGroupList.tsx
+++ b/src/components/runner/karma/runnerImprovements/improvementSkillGroupList.tsx
@@ -11,6 +11,7 @@ import Typography from "@mui/material/Typography"
 import { RiAddLine, RiArrowLeftLine, RiCheckLine } from "@remixicon/react"
 import type { FC } from "react"
 
+import { KarmaChip } from "#/components/runner/karma/karmaChip.tsx"
 import {
   useActiveSkillGroupDialog,
 } from "#/components/runner/skills/activeSkills/dialogs/activeSkillGroupFormDialog.tsx"
@@ -115,8 +116,8 @@ export const ImprovementSkillGroupList: FC<ImprovementSkillGroupListProps> = ({ 
                       {isAtMax
                         ? <Chip label="Max" size="small" />
                         : (
-                            <Chip
-                              label={`${karmaCost}k`}
+                            <KarmaChip
+                              amount={karmaCost}
                               size="small"
                               color={queuedEntry ? "success" : canAfford ? "default" : "warning"}
                             />

--- a/src/components/runner/karma/spendKarmaDialogContent.tsx
+++ b/src/components/runner/karma/spendKarmaDialogContent.tsx
@@ -1,6 +1,5 @@
 import Box from "@mui/material/Box"
 import Button from "@mui/material/Button"
-import Chip from "@mui/material/Chip"
 import Divider from "@mui/material/Divider"
 import Stack from "@mui/material/Stack"
 import Tooltip from "@mui/material/Tooltip"
@@ -10,7 +9,6 @@ import {
   RiFlashlightLine,
   RiHeartPulseLine,
   RiLightbulbLine,
-  RiMedal2Line,
   RiSparklingLine,
 } from "@remixicon/react"
 import type { FC, ReactNode } from "react"
@@ -24,6 +22,8 @@ import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.s
 import { selectHasImprovements, selectImprovementsTotalCost } from "#/system/karma/improvements/improvementSelectors.ts"
 import { applyImprovements } from "#/system/karma/improvements/improvementUtils.ts"
 
+import { KarmaChip } from "./karmaChip.tsx"
+import { KarmaValue } from "./karmaValue.tsx"
 import { ImprovementActiveSkillList } from "./runnerImprovements/improvementActiveSkillList.tsx"
 import { ImprovementAttributeList } from "./runnerImprovements/improvementAttributeList.tsx"
 import { ImprovementKnowledgeSkillList } from "./runnerImprovements/improvementKnowledgeSkillList.tsx"
@@ -177,18 +177,16 @@ const SpendKarmaDialogInner: FC<ControlledDialogProps> = ({ ctrl }) => {
       <Dialog.Actions>
         <Stack direction="row" sx={{ justifyContent: "space-between", width: "100%", alignItems: "center" }}>
           <Stack direction="row" sx={{ gap: 1.5, alignItems: "center" }}>
-            <RiMedal2Line size={16} />
             <Typography variant="caption" color="text.secondary">Remaining</Typography>
-            <Chip
-              label={`${remainingKarma}k`}
-              size="small"
+            <KarmaChip
+              amount={remainingKarma}
               color={isOverBudget ? "error" : karmaCost > 0 ? "primary" : "default"}
             />
             {karmaCost > 0 && (
               <>
                 <Divider orientation="vertical" flexItem />
                 <Typography variant="caption" color="text.secondary">Cost</Typography>
-                <Typography variant="body2" sx={{ fontWeight: "bold" }}>{karmaCost}k</Typography>
+                <KarmaValue amount={karmaCost} sx={{ fontWeight: "bold" }} />
               </>
             )}
           </Stack>


### PR DESCRIPTION
Replace ad-hoc `${cost}k` chip labels and plain-number Typography
throughout the karma UI with the shared KarmaChip/KarmaValue
components, dropping the "k" postfix in favor of the karma icon.
Adds an optional sx prop to KarmaValue so callers can still apply
custom typography styling.