### PR TITLE
Add Legwork button and dialog to contacts list

### DIFF
--- a/src/components/runner/contacts/contactsList.test.tsx
+++ b/src/components/runner/contacts/contactsList.test.tsx
@@ -74,14 +74,26 @@ describe("ContactsList", () => {
     // Arrange
     const store = renderWithContacts([fixer])
 
-    // Act: the remove icon button has no accessible name.
-    const removeButton = screen.getAllByRole("button").find((button) => button.textContent === "")
-    fireEvent.click(removeButton!)
+    // Act
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }))
     fireEvent.click(await screen.findByRole("button", { name: "Remove" }))
 
     // Assert: state updated...
     await waitFor(() => expect(store.state.contacts).toHaveLength(0))
     // ...and the UI re-rendered off that same state.
     expect(screen.queryByText("Mr. Johnson")).toBeNull()
+  })
+
+  it("opens the legwork dialog with the GM and Player test information", async () => {
+    // Arrange
+    renderWithContacts([fixer])
+
+    // Act
+    fireEvent.click(screen.getByRole("button", { name: "Legwork" }))
+    const dialog = await screen.findByRole("dialog", { name: "Legwork: Mr. Johnson" })
+
+    // Assert
+    expect(within(dialog).getByText("Contact Knowledge Test: Connection + Connection")).toBeDefined()
+    expect(within(dialog).getByText("Legwork Test: Charisma + Etiquette + Loyalty")).toBeDefined()
   })
 })

--- a/src/components/runner/contacts/contactsList.test.tsx
+++ b/src/components/runner/contacts/contactsList.test.tsx
@@ -84,7 +84,7 @@ describe("ContactsList", () => {
     expect(screen.queryByText("Mr. Johnson")).toBeNull()
   })
 
-  it("opens the legwork dialog with the GM and Player test information", async () => {
+  it("opens the legwork dialog with the GM and Player dice pools", async () => {
     // Arrange
     renderWithContacts([fixer])
 
@@ -92,8 +92,14 @@ describe("ContactsList", () => {
     fireEvent.click(screen.getByRole("button", { name: "Legwork" }))
     const dialog = await screen.findByRole("dialog", { name: "Legwork: Mr. Johnson" })
 
-    // Assert
-    expect(within(dialog).getByText("Contact Knowledge Test: Connection + Connection")).toBeDefined()
-    expect(within(dialog).getByText("Legwork Test: Charisma + Etiquette + Loyalty")).toBeDefined()
+    // Assert: GM pool is Connection + Connection
+    expect(within(dialog).getByText("Contact Knowledge Test")).toBeDefined()
+    expect(within(dialog).getAllByText("Connection")).toHaveLength(2)
+
+    // Assert: Player pool is Charisma + Etiquette + Loyalty
+    expect(within(dialog).getByText("Legwork Test")).toBeDefined()
+    expect(within(dialog).getByText("CHA")).toBeDefined()
+    expect(within(dialog).getByText("Etiquette")).toBeDefined()
+    expect(within(dialog).getByText("Loyalty")).toBeDefined()
   })
 })

--- a/src/components/runner/contacts/contactsList.test.tsx
+++ b/src/components/runner/contacts/contactsList.test.tsx
@@ -6,6 +6,7 @@ import { RunnerDataStore } from "#/components/runner/sheet/runnerDataStore.ts"
 import { RunnerStoreProvider } from "#/components/runner/sheet/runnerStoreProvider.tsx"
 import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
 import type { ContactData } from "#/system/contactData.ts"
+import { FavourDirection } from "#/system/favourData.ts"
 import { runnerDataFactory } from "#/system/runnerData.factory.ts"
 
 import { ContactsList } from "./contactsList.tsx"
@@ -68,6 +69,38 @@ describe("ContactsList", () => {
     expect(store.state.contacts[0].id).not.toBe("")
     // ...and the UI re-rendered off that same state.
     expect(await screen.findByText("Fixer Sam")).toBeDefined()
+  })
+
+  it("adding a knowledge skill and a favour on the contact form persists both", async () => {
+    // Arrange
+    const store = renderWithContacts([])
+
+    // Act
+    fireEvent.click(screen.getByRole("button", { name: /add contact/i }))
+    const dialog = await screen.findByRole("dialog", { name: "Add Contact" })
+    fireEvent.change(within(dialog).getByLabelText(/^name/i), {
+      target: { value: "Fixer Sam" },
+    })
+
+    fireEvent.click(within(dialog).getByRole("button", { name: /add skill/i }))
+    fireEvent.change(within(dialog).getByLabelText(/^skill/i), {
+      target: { value: "Street Gangs" },
+    })
+
+    fireEvent.click(within(dialog).getByRole("button", { name: /add favour/i }))
+    fireEvent.change(within(dialog).getByLabelText(/^description/i), {
+      target: { value: "Owes for a smuggling run" },
+    })
+
+    fireEvent.click(within(dialog).getByRole("button", { name: /save/i }))
+
+    // Assert
+    await waitFor(() => expect(store.state.contacts).toHaveLength(1))
+    const [contact] = store.state.contacts
+    expect(contact.knowledgeSkills).toEqual([{ name: "Street Gangs", rating: 1 }])
+    expect(contact.favours).toEqual([
+      { description: "Owes for a smuggling run", direction: FavourDirection.contactOwes },
+    ])
   })
 
   it("removing a contact, once confirmed, dispatches removeContact and updates the store", async () => {

--- a/src/components/runner/contacts/contactsList.tsx
+++ b/src/components/runner/contacts/contactsList.tsx
@@ -10,6 +10,7 @@ import { useRunnerStoreDispatch } from "#/stores/runner/runnerStore.dispatch.ts"
 import type { ContactData } from "#/system/contactData.ts"
 
 import { ContactRow } from "./contactsListItem.tsx"
+import { useLegworkInfoDialog } from "./dialogs/legworkInfoDialog.tsx"
 import { useContactFormDialog } from "./form/contactFormDialog.tsx"
 
 interface ContactsListProps {
@@ -23,6 +24,7 @@ export const ContactsList: FC<ContactsListProps> = ({
 }) => {
   const confirmDialog = useConfirmDialog()
   const contactFormDialog = useContactFormDialog()
+  const legworkInfoDialog = useLegworkInfoDialog()
   const dispatch = useRunnerStoreDispatch()
 
   const onRemove = async (contact: ContactData) => {
@@ -48,6 +50,7 @@ export const ContactsList: FC<ContactsListProps> = ({
           key={contact.id}
           contact={contact}
           onClick={() => contactFormDialog.open({ contact })}
+          onLegwork={() => legworkInfoDialog.open({ contact })}
           onRemove={() => onRemove(contact)}
         />
       ))}
@@ -64,6 +67,7 @@ export const ContactsList: FC<ContactsListProps> = ({
 
       {confirmDialog.dialog}
       {contactFormDialog.dialog}
+      {legworkInfoDialog.dialog}
     </Stack>
   )
 }

--- a/src/components/runner/contacts/contactsListItem.tsx
+++ b/src/components/runner/contacts/contactsListItem.tsx
@@ -2,7 +2,7 @@ import Chip from "@mui/material/Chip"
 import IconButton from "@mui/material/IconButton"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
-import { RiDeleteBin6Line } from "@remixicon/react"
+import { RiDeleteBin6Line, RiSearchLine } from "@remixicon/react"
 import type { FC } from "react"
 
 import type { ContactData } from "#/system/contactData.ts"
@@ -10,12 +10,14 @@ import type { ContactData } from "#/system/contactData.ts"
 interface ContactRowProps {
   contact: ContactData
   onClick: () => void
+  onLegwork?: () => void
   onRemove?: () => void
 }
 
 export const ContactRow: FC<ContactRowProps> = ({
   contact,
   onClick,
+  onLegwork,
   onRemove,
 }) => {
   return (
@@ -35,10 +37,25 @@ export const ContactRow: FC<ContactRowProps> = ({
         <Stack direction="row">
           <Typography sx={{ flexGrow: 1 }}>{contact.name}</Typography>
 
+          {onLegwork && (
+            <IconButton
+              size="small"
+              color="secondary"
+              aria-label="Legwork"
+              onClick={(e) => {
+                e.stopPropagation()
+                onLegwork()
+              }}
+            >
+              <RiSearchLine size={16} />
+            </IconButton>
+          )}
+
           {onRemove && (
             <IconButton
               size="small"
               color="error"
+              aria-label="Remove"
               onClick={(e) => {
                 e.stopPropagation()
                 onRemove()

--- a/src/components/runner/contacts/dialogs/legworkInfoDialog.tsx
+++ b/src/components/runner/contacts/dialogs/legworkInfoDialog.tsx
@@ -7,11 +7,16 @@ import TableRow from "@mui/material/TableRow"
 import Typography from "@mui/material/Typography"
 import type { FC } from "react"
 
+import { DicePool } from "#/components/system/dicePool/dicePool.tsx"
+import { createDicePool } from "#/components/system/dicePool/dicePoolData.tsx"
+import { useActiveSkillDiceGroup, useAttrDiceGroup } from "#/components/system/dicePool/useDiceGroup.ts"
 import type { ControlledDialogProps } from "#/components/ui/dialog/controlledDialogProps.ts"
 import { ControlledDialog, Dialog } from "#/components/ui/dialog/dialog.tsx"
 import { useDialog } from "#/components/ui/dialog/useDialog.tsx"
 import { Label } from "#/components/ui/text/label.tsx"
+import { AttributeKey } from "#/system/attributeKey.ts"
 import type { ContactData } from "#/system/contactData.ts"
+import { SkillKey } from "#/system/skills/skillKey.ts"
 
 const hitLevels: [string, string][] = [
   ["0 hits", "Nothing relevant"],
@@ -27,6 +32,17 @@ interface LegworkInfoDialogProps extends ControlledDialogProps<void> {
 }
 
 const LegworkInfoDialog: FC<LegworkInfoDialogProps> = ({ ctrl, contact }) => {
+  const gmPool = createDicePool("legwork.gm", "Contact Knowledge Test", [
+    { name: "Connection", size: contact.connection },
+    { name: "Connection", size: contact.connection },
+  ])
+
+  const playerPool = createDicePool("legwork.player", "Legwork Test", [
+    useAttrDiceGroup(AttributeKey.charisma),
+    useActiveSkillDiceGroup(SkillKey.etiquette),
+    { name: "Loyalty", size: contact.loyalty },
+  ])
+
   return (
     <ControlledDialog ctrl={ctrl} maxWidth="sm">
       <Dialog.Title>{`Legwork: ${contact.name}`}</Dialog.Title>
@@ -34,7 +50,7 @@ const LegworkInfoDialog: FC<LegworkInfoDialogProps> = ({ ctrl, contact }) => {
         <Stack sx={{ gap: 1.5 }}>
           <Stack sx={{ gap: 0.5 }}>
             <Label label="GM" variant="outlined" />
-            <Typography>Contact Knowledge Test: Connection + Connection</Typography>
+            <DicePool name={gmPool.name} groups={gmPool.groups} />
             <Typography color="text.secondary">
               Each hit is how much the contact knows.
             </Typography>
@@ -42,7 +58,7 @@ const LegworkInfoDialog: FC<LegworkInfoDialogProps> = ({ ctrl, contact }) => {
 
           <Stack sx={{ gap: 0.5 }}>
             <Label label="Player" variant="outlined" />
-            <Typography>Legwork Test: Charisma + Etiquette + Loyalty</Typography>
+            <DicePool name={playerPool.name} groups={playerPool.groups} />
             <Typography color="text.secondary">
               Each hit is how much the contact will offer for free.
             </Typography>

--- a/src/components/runner/contacts/dialogs/legworkInfoDialog.tsx
+++ b/src/components/runner/contacts/dialogs/legworkInfoDialog.tsx
@@ -1,0 +1,76 @@
+import Button from "@mui/material/Button"
+import Stack from "@mui/material/Stack"
+import Table from "@mui/material/Table"
+import TableBody from "@mui/material/TableBody"
+import TableCell from "@mui/material/TableCell"
+import TableRow from "@mui/material/TableRow"
+import Typography from "@mui/material/Typography"
+import type { FC } from "react"
+
+import type { ControlledDialogProps } from "#/components/ui/dialog/controlledDialogProps.ts"
+import { ControlledDialog, Dialog } from "#/components/ui/dialog/dialog.tsx"
+import { useDialog } from "#/components/ui/dialog/useDialog.tsx"
+import { Label } from "#/components/ui/text/label.tsx"
+import type { ContactData } from "#/system/contactData.ts"
+
+const hitLevels: [string, string][] = [
+  ["0 hits", "Nothing relevant"],
+  ["1", "Common knowledge"],
+  ["2", "Specific public knowledge"],
+  ["3", "Some non-public information"],
+  ["4", "Specific non-public information"],
+  ["5+", "Exact details"],
+]
+
+interface LegworkInfoDialogProps extends ControlledDialogProps<void> {
+  contact: ContactData
+}
+
+const LegworkInfoDialog: FC<LegworkInfoDialogProps> = ({ ctrl, contact }) => {
+  return (
+    <ControlledDialog ctrl={ctrl} maxWidth="sm">
+      <Dialog.Title>{`Legwork: ${contact.name}`}</Dialog.Title>
+      <Dialog.Content>
+        <Stack sx={{ gap: 1.5 }}>
+          <Stack sx={{ gap: 0.5 }}>
+            <Label label="GM" variant="outlined" />
+            <Typography>Contact Knowledge Test: Connection + Connection</Typography>
+            <Typography color="text.secondary">
+              Each hit is how much the contact knows.
+            </Typography>
+          </Stack>
+
+          <Stack sx={{ gap: 0.5 }}>
+            <Label label="Player" variant="outlined" />
+            <Typography>Legwork Test: Charisma + Etiquette + Loyalty</Typography>
+            <Typography color="text.secondary">
+              Each hit is how much the contact will offer for free.
+            </Typography>
+          </Stack>
+
+          <Table size="small">
+            <TableBody>
+              {hitLevels.map(([hits, description]) => (
+                <TableRow key={hits}>
+                  <TableCell sx={{ whiteSpace: "nowrap" }}>{hits}</TableCell>
+                  <TableCell>{description}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Stack>
+      </Dialog.Content>
+      <Dialog.Actions>
+        <Button onClick={() => ctrl.close()}>Close</Button>
+      </Dialog.Actions>
+    </ControlledDialog>
+  )
+}
+
+interface UseLegworkInfoDialogProps {
+  contact: ContactData
+}
+
+export const useLegworkInfoDialog = () => useDialog<void, UseLegworkInfoDialogProps>(
+  (ctrl, props) => <LegworkInfoDialog ctrl={ctrl} contact={props.contact} />,
+)

--- a/src/components/runner/contacts/dialogs/legworkInfoDialog.tsx
+++ b/src/components/runner/contacts/dialogs/legworkInfoDialog.tsx
@@ -64,16 +64,19 @@ const LegworkInfoDialog: FC<LegworkInfoDialogProps> = ({ ctrl, contact }) => {
             </Typography>
           </Stack>
 
-          <Table size="small">
-            <TableBody>
-              {hitLevels.map(([hits, description]) => (
-                <TableRow key={hits}>
-                  <TableCell sx={{ whiteSpace: "nowrap" }}>{hits}</TableCell>
-                  <TableCell>{description}</TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+          <Stack sx={{ gap: 0.5 }}>
+            <Label label="Hits" variant="outlined" />
+            <Table size="small">
+              <TableBody>
+                {hitLevels.map(([hits, description]) => (
+                  <TableRow key={hits}>
+                    <TableCell sx={{ whiteSpace: "nowrap" }}>{hits}</TableCell>
+                    <TableCell>{description}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Stack>
         </Stack>
       </Dialog.Content>
       <Dialog.Actions>

--- a/src/components/runner/contacts/form/contactFormFields.tsx
+++ b/src/components/runner/contacts/form/contactFormFields.tsx
@@ -1,12 +1,27 @@
+import Button from "@mui/material/Button"
+import FormControl from "@mui/material/FormControl"
+import IconButton from "@mui/material/IconButton"
+import InputLabel from "@mui/material/InputLabel"
+import MenuItem from "@mui/material/MenuItem"
+import Select from "@mui/material/Select"
 import Stack from "@mui/material/Stack"
+import TextField from "@mui/material/TextField"
+import { RiAddLine, RiDeleteBin6Line } from "@remixicon/react"
 import { z } from "zod"
 
 import { createRatingOptions } from "#/components/system/ratings/ratingUtils.ts"
+import { Label } from "#/components/ui/text/label.tsx"
 import { withFieldGroup } from "#/integrations/tanstackForm/useAppForm.ts"
+import { FavourDirection } from "#/system/favourData.ts"
 
 import { contactFormOpts } from "./useContactForm.tsx"
 
 const ratingOptions = createRatingOptions({ min: 1, max: 6 })
+
+const favourDirectionOptions: { value: FavourDirection, label: string }[] = [
+  { value: FavourDirection.contactOwes, label: "Contact owes" },
+  { value: FavourDirection.runnerOwes, label: "Runner owes" },
+]
 
 export const ContactFormFields = withFieldGroup({
   ...contactFormOpts,
@@ -58,6 +73,112 @@ export const ContactFormFields = withFieldGroup({
               rows={2}
             />
           )}
+        </group.AppField>
+
+        <group.AppField name="knowledgeSkills">
+          {(field) => {
+            const skills = field.state.value ?? []
+            return (
+              <Stack sx={{ gap: 0.5 }}>
+                <Label label="Knowledge Skills" variant="outlined" />
+
+                {skills.map((skill, index) => (
+                  <Stack key={index} direction="row" sx={{ gap: 1, alignItems: "flex-start" }}>
+                    <TextField
+                      label="Skill"
+                      size="small"
+                      fullWidth
+                      value={skill.name}
+                      onChange={(e) => field.replaceValue(index, { ...skill, name: e.target.value })}
+                    />
+                    <FormControl size="small" sx={{ minWidth: 90 }}>
+                      <InputLabel>Rating</InputLabel>
+                      <Select
+                        value={skill.rating}
+                        label="Rating"
+                        onChange={(e) => field.replaceValue(index, { ...skill, rating: Number(e.target.value) })}
+                      >
+                        {ratingOptions.map((option) => (
+                          <MenuItem key={option.value} value={Number(option.value)}>{option.label}</MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                    <IconButton
+                      size="small"
+                      color="error"
+                      aria-label="Remove skill"
+                      onClick={() => field.removeValue(index)}
+                    >
+                      <RiDeleteBin6Line size={16} />
+                    </IconButton>
+                  </Stack>
+                ))}
+
+                <Button
+                  variant="outlined"
+                  color="secondary"
+                  size="small"
+                  startIcon={<RiAddLine />}
+                  onClick={() => field.pushValue({ name: "", rating: 1 })}
+                >
+                  Add Skill
+                </Button>
+              </Stack>
+            )
+          }}
+        </group.AppField>
+
+        <group.AppField name="favours">
+          {(field) => {
+            const favours = field.state.value ?? []
+            return (
+              <Stack sx={{ gap: 0.5 }}>
+                <Label label="Favours" variant="outlined" />
+
+                {favours.map((favour, index) => (
+                  <Stack key={index} direction="row" sx={{ gap: 1, alignItems: "flex-start" }}>
+                    <TextField
+                      label="Description"
+                      size="small"
+                      fullWidth
+                      value={favour.description}
+                      onChange={(e) => field.replaceValue(index, { ...favour, description: e.target.value })}
+                    />
+                    <FormControl size="small" sx={{ minWidth: 140 }}>
+                      <InputLabel>Direction</InputLabel>
+                      <Select
+                        value={favour.direction}
+                        label="Direction"
+                        onChange={(e) => field.replaceValue(index, { ...favour, direction: e.target.value as FavourDirection })}
+                      >
+                        {favourDirectionOptions.map((option) => (
+                          <MenuItem key={option.value} value={option.value}>{option.label}</MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                    <IconButton
+                      size="small"
+                      color="error"
+                      aria-label="Remove favour"
+                      onClick={() => field.removeValue(index)}
+                    >
+                      <RiDeleteBin6Line size={16} />
+                    </IconButton>
+                  </Stack>
+                ))}
+
+                <Button
+                  variant="outlined"
+                  color="secondary"
+                  size="small"
+                  startIcon={<RiAddLine />}
+                  onClick={() => field.pushValue({ description: "", direction: FavourDirection.contactOwes })}
+                >
+                  Add Favour
+                </Button>
+              </Stack>
+            )
+          }}
         </group.AppField>
       </>
     )

--- a/src/components/runner/contacts/form/useContactForm.tsx
+++ b/src/components/runner/contacts/form/useContactForm.tsx
@@ -10,6 +10,8 @@ const defaultValues: ContactData = {
   connection: 1,
   loyalty: 1,
   notes: "",
+  knowledgeSkills: [],
+  favours: [],
 }
 
 export const contactFieldMap = createFieldMap(defaultValues)

--- a/src/system/contactData.ts
+++ b/src/system/contactData.ts
@@ -1,5 +1,7 @@
 import type { UUID } from "node:crypto"
 
+import type { KnowledgeSkillData } from "./skills/knowledgeSkillData.ts"
+
 export interface ContactData {
   id: UUID
   name: string
@@ -10,4 +12,6 @@ export interface ContactData {
   role?: string
 
   notes?: string
+
+  knowledgeSkills?: KnowledgeSkillData[]
 }

--- a/src/system/contactData.ts
+++ b/src/system/contactData.ts
@@ -1,5 +1,6 @@
 import type { UUID } from "node:crypto"
 
+import type { FavourData } from "./favourData.ts"
 import type { KnowledgeSkillData } from "./skills/knowledgeSkillData.ts"
 
 export interface ContactData {
@@ -14,4 +15,5 @@ export interface ContactData {
   notes?: string
 
   knowledgeSkills?: KnowledgeSkillData[]
+  favours?: FavourData[]
 }

--- a/src/system/favourData.ts
+++ b/src/system/favourData.ts
@@ -1,0 +1,9 @@
+export enum FavourDirection {
+  contactOwes = "contactOwes",
+  runnerOwes = "runnerOwes",
+}
+
+export interface FavourData {
+  description: string
+  direction: FavourDirection
+}


### PR DESCRIPTION
## Summary
- Add a "Legwork" icon button to each contact row in the contacts list
- Opens a `LegworkInfoDialog` showing the GM Contact Knowledge Test (`Connection + Connection`, hits = how much the contact knows) and the Player Legwork Test (`Charisma + Etiquette + Loyalty`, hits = how much the contact will offer for free), plus the shared hit-level reference table (0 → Nothing relevant … 5+ → Exact details)
- Extend `ContactData` with an optional `knowledgeSkills?: KnowledgeSkillData[]` field, reusing the existing `KnowledgeSkillData` type (`{ name, rating, specialization? }`) already used for runner knowledge skills

## Test plan
- [x] `yarn lint` (eslint + tsc) passes
- [x] `yarn vitest run src/components/runner/contacts` passes, including a new test asserting the Legwork dialog opens with the correct test descriptions


---
_Generated by [Claude Code](https://claude.ai/code/session_01QFqbToDvB71X3MxBvjeU51)_