### PR TITLE
fix: disable swipe gesture while a dialog is open

### DIFF
--- a/src/components/dice/diceTrayApi.ts
+++ b/src/components/dice/diceTrayApi.ts
@@ -1,5 +1,6 @@
 import { produce } from "immer"
 
+import { markOverlayClosed, markOverlayOpened } from "#/components/ui/dialog/openOverlayTracker.ts"
 import type { CompatStore } from "#/integrations/reduxToolkit/compatStore.ts"
 import { createCompatStore } from "#/integrations/reduxToolkit/compatStore.ts"
 import { selectWasRolled } from "#/system/dice/diceRoller.selectors.ts"
@@ -198,15 +199,32 @@ export class DiceTrayApi {
   }
 
   open(): void {
+    if (!this.store.get().open) {
+      markOverlayOpened()
+    }
     this.store.setState(produce((state) => {
       state.open = true
     }))
   }
 
   close(): void {
+    if (this.store.get().open) {
+      markOverlayClosed()
+    }
     this.store.setState(produce((state) => {
       state.open = false
     }))
+  }
+
+  /**
+   * Release overlay-tracking state without changing `store.open`. Call from
+   * an unmount cleanup so a tray left open when its provider unmounts doesn't
+   * permanently count as "open".
+   */
+  dispose(): void {
+    if (this.store.get().open) {
+      markOverlayClosed()
+    }
   }
 
   reset(): void {

--- a/src/components/dice/diceTrayProvider.tsx
+++ b/src/components/dice/diceTrayProvider.tsx
@@ -1,4 +1,5 @@
 import type { FC, PropsWithChildren } from "react"
+import { useEffect } from "react"
 
 import type { DiceTrayApi } from "./diceTrayApi.ts"
 import { DiceTrayContext } from "./diceTrayContext.ts"
@@ -22,6 +23,8 @@ interface DiceTrayProviderProps extends PropsWithChildren {
  * ```
  */
 export const DiceTrayProvider: FC<DiceTrayProviderProps> = ({ diceTrayApi, children }) => {
+  useEffect(() => () => diceTrayApi.dispose(), [diceTrayApi])
+
   return (
     <DiceTrayContext.Provider value={diceTrayApi}>
       {children}

--- a/src/components/ui/dialog/dialogCtrl.test.ts
+++ b/src/components/ui/dialog/dialogCtrl.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { DialogCtrl } from "./dialogCtrl.ts"
+import { isAnyOverlayOpen } from "./openOverlayTracker.ts"
 
 describe("DialogCtrl", () => {
   it("result() resolves with the value passed to close()", async () => {
@@ -77,5 +78,35 @@ describe("DialogCtrl", () => {
 
     await expect(first).resolves.toBeUndefined()
     await expect(second).resolves.toBe("second-result")
+  })
+
+  it("open() marks the shared overlay tracker open; close() clears it", () => {
+    const baseline = isAnyOverlayOpen()
+    const ctrl = new DialogCtrl<void>()
+
+    ctrl.open()
+    expect(isAnyOverlayOpen()).toBe(true)
+
+    ctrl.close()
+    expect(isAnyOverlayOpen()).toBe(baseline)
+  })
+
+  it("dispose() clears overlay tracking for a dialog left open without close()", () => {
+    const baseline = isAnyOverlayOpen()
+    const ctrl = new DialogCtrl<void>()
+
+    ctrl.open()
+    expect(isAnyOverlayOpen()).toBe(true)
+
+    ctrl.dispose()
+    expect(isAnyOverlayOpen()).toBe(baseline)
+  })
+
+  it("dispose() is a safe no-op when the dialog is already closed", () => {
+    const baseline = isAnyOverlayOpen()
+    const ctrl = new DialogCtrl<void>()
+
+    ctrl.dispose()
+    expect(isAnyOverlayOpen()).toBe(baseline)
   })
 })

--- a/src/components/ui/dialog/dialogCtrl.ts
+++ b/src/components/ui/dialog/dialogCtrl.ts
@@ -1,5 +1,7 @@
 import { createCompatStore } from "#/integrations/reduxToolkit/compatStore.ts"
 
+import { markOverlayClosed, markOverlayOpened } from "./openOverlayTracker.ts"
+
 /**
  * Controls the lifecycle of a single dialog. Created locally via `useDialogCtrl()`
  * (or internally by `useDialog()`) and handed to `ControlledDialog`, or spread via
@@ -32,6 +34,9 @@ export class DialogCtrl<TReturn> {
     this.promise = promise
     this.resolve = resolve
     this.savedValue = undefined
+    if (!this.store.getState().open) {
+      markOverlayOpened()
+    }
     this.store.setState(() => ({ open: true }))
     return this.promise
   }
@@ -55,12 +60,27 @@ export class DialogCtrl<TReturn> {
       this.savedValue = value
     }
     this.resolve(this.savedValue)
+    if (this.store.getState().open) {
+      markOverlayClosed()
+    }
     this.store.setState(() => ({ open: false }))
   }
 
   /** Resolves when the dialog is closed. */
   result(): Promise<TReturn | undefined> {
     return this.promise
+  }
+
+  /**
+   * Release overlay-tracking state without resolving the result promise. Call
+   * from an unmount cleanup so a dialog torn down without an explicit
+   * `close()` (e.g. its page unmounts from navigating away) doesn't
+   * permanently count as "open".
+   */
+  dispose(): void {
+    if (this.store.getState().open) {
+      markOverlayClosed()
+    }
   }
 }
 

--- a/src/components/ui/dialog/openOverlayTracker.test.ts
+++ b/src/components/ui/dialog/openOverlayTracker.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+
+import { isAnyOverlayOpen, markOverlayClosed, markOverlayOpened } from "./openOverlayTracker.ts"
+
+describe("openOverlayTracker", () => {
+  it("starts with no overlay open", () => {
+    expect(isAnyOverlayOpen()).toBe(false)
+  })
+
+  it("reports open after markOverlayOpened() and closed after a matching markOverlayClosed()", () => {
+    markOverlayOpened()
+    expect(isAnyOverlayOpen()).toBe(true)
+
+    markOverlayClosed()
+    expect(isAnyOverlayOpen()).toBe(false)
+  })
+
+  it("stays open while any of several overlays remains open", () => {
+    markOverlayOpened()
+    markOverlayOpened()
+
+    markOverlayClosed()
+    expect(isAnyOverlayOpen()).toBe(true)
+
+    markOverlayClosed()
+    expect(isAnyOverlayOpen()).toBe(false)
+  })
+
+  it("does not go negative when closed more times than opened", () => {
+    markOverlayClosed()
+    markOverlayClosed()
+    expect(isAnyOverlayOpen()).toBe(false)
+
+    markOverlayOpened()
+    expect(isAnyOverlayOpen()).toBe(true)
+    markOverlayClosed()
+  })
+})

--- a/src/components/ui/dialog/openOverlayTracker.ts
+++ b/src/components/ui/dialog/openOverlayTracker.ts
@@ -1,0 +1,19 @@
+/**
+ * App-wide count of currently-open dialogs/overlays (`DialogCtrl`-backed dialogs,
+ * the dice tray, ...). Lets gesture handlers like `SwipeSurface` check "is
+ * anything open right now" without needing a dedicated context wired through
+ * every route.
+ */
+let openCount = 0
+
+export function markOverlayOpened(): void {
+  openCount++
+}
+
+export function markOverlayClosed(): void {
+  openCount = Math.max(0, openCount - 1)
+}
+
+export function isAnyOverlayOpen(): boolean {
+  return openCount > 0
+}

--- a/src/components/ui/dialog/useDialogCtrl.ts
+++ b/src/components/ui/dialog/useDialogCtrl.ts
@@ -1,8 +1,9 @@
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 import { DialogCtrl } from "./dialogCtrl.ts"
 
 export function useDialogCtrl<TReturn>() {
   const [ctrl] = useState(() => new DialogCtrl<TReturn>())
+  useEffect(() => () => ctrl.dispose(), [ctrl])
   return ctrl
 }

--- a/src/components/ui/swipeSurface.test.tsx
+++ b/src/components/ui/swipeSurface.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { markOverlayClosed, markOverlayOpened } from "./dialog/openOverlayTracker.ts"
+import { SwipeSurface } from "./swipeSurface.tsx"
+
+function swipe(element: Element, fromX: number, toX: number) {
+  fireEvent.touchStart(element, { touches: [{ clientX: fromX, clientY: 0 }] })
+  fireEvent.touchEnd(element, { changedTouches: [{ clientX: toX, clientY: 0 }] })
+}
+
+describe("SwipeSurface", () => {
+  it("fires onSwipeRightToLeft when swiping right-to-left", () => {
+    const onSwipeRightToLeft = vi.fn()
+    render(
+      <SwipeSurface onSwipeRightToLeft={onSwipeRightToLeft}>
+        <div>content</div>
+      </SwipeSurface>,
+    )
+
+    swipe(screen.getByText("content"), 200, 100)
+
+    expect(onSwipeRightToLeft).toHaveBeenCalledTimes(1)
+  })
+
+  it("fires onSwipeLeftToRight when swiping left-to-right", () => {
+    const onSwipeLeftToRight = vi.fn()
+    render(
+      <SwipeSurface onSwipeLeftToRight={onSwipeLeftToRight}>
+        <div>content</div>
+      </SwipeSurface>,
+    )
+
+    swipe(screen.getByText("content"), 100, 200)
+
+    expect(onSwipeLeftToRight).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not fire swipe callbacks while a dialog is open", () => {
+    const onSwipeRightToLeft = vi.fn()
+    const onSwipeLeftToRight = vi.fn()
+    render(
+      <SwipeSurface onSwipeRightToLeft={onSwipeRightToLeft} onSwipeLeftToRight={onSwipeLeftToRight}>
+        <div>content</div>
+      </SwipeSurface>,
+    )
+    const element = screen.getByText("content")
+
+    markOverlayOpened()
+    swipe(element, 200, 100)
+    swipe(element, 100, 200)
+    markOverlayClosed()
+
+    expect(onSwipeRightToLeft).not.toHaveBeenCalled()
+    expect(onSwipeLeftToRight).not.toHaveBeenCalled()
+
+    // Sanity check: swiping works again once the dialog closes.
+    swipe(element, 200, 100)
+    expect(onSwipeRightToLeft).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/ui/swipeSurface.tsx
+++ b/src/components/ui/swipeSurface.tsx
@@ -2,6 +2,8 @@ import Box from "@mui/material/Box"
 import type { FC, ReactNode, TouchEvent as ReactTouchEvent } from "react"
 import { useCallback, useRef } from "react"
 
+import { isAnyOverlayOpen } from "./dialog/openOverlayTracker.ts"
+
 const SWIPE_MIN_DISTANCE = 50
 
 interface SwipeSurfaceProps {
@@ -14,6 +16,11 @@ export const SwipeSurface: FC<SwipeSurfaceProps> = ({ onSwipeRightToLeft, onSwip
   const touchStartRef = useRef<{ x: number, y: number } | null>(null)
 
   const handleTouchStart = useCallback((event: ReactTouchEvent) => {
+    if (isAnyOverlayOpen()) {
+      touchStartRef.current = null
+      return
+    }
+
     const touch = event.touches[0]
     if (touch) {
       touchStartRef.current = { x: touch.clientX, y: touch.clientY }
@@ -23,6 +30,11 @@ export const SwipeSurface: FC<SwipeSurfaceProps> = ({ onSwipeRightToLeft, onSwip
   const handleTouchEnd = useCallback(
     (event: ReactTouchEvent) => {
       if (!touchStartRef.current) return
+
+      if (isAnyOverlayOpen()) {
+        touchStartRef.current = null
+        return
+      }
 
       const touch = event.changedTouches[0]
       if (!touch) {


### PR DESCRIPTION
## Summary

- `SwipeSurface` fired tab-navigation callbacks on any left/right swipe, even while a dialog was open, which changed the active tab **and** tore down the dialog's page — destroying its local open state (looked like the dialog was force-closed).
- Added a shared `openOverlayTracker` module tracking a simple app-wide "is any dialog/overlay open" count.
- `DialogCtrl` (the base for ~25 dialogs) and `DiceTrayApi` (dice tray) now increment/decrement that tracker on `open()`/`close()`.
- `SwipeSurface` now skips its swipe callbacks while any overlay is open.
- Each ctrl also releases its tracked state on unmount (`dispose()`, wired via `useDialogCtrl`'s cleanup and `DiceTrayProvider`'s cleanup) so a dialog torn down without an explicit `close()` (e.g. navigating away via the nav tabs) can't permanently disable swipe gestures.

## Test plan

- [x] `yarn tsc` — no errors
- [x] `yarn eslint` — no errors
- [x] `yarn vitest run` — 697 tests passed, including new tests for `openOverlayTracker`, `DialogCtrl` overlay tracking/dispose, and `SwipeSurface` swipe-suppression while a dialog is open
