### PR TITLE
Fix legwork dice pool total showing concatenated digits instead of sum

### DIFF
--- a/src/components/runner/contacts/form/useContactForm.tsx
+++ b/src/components/runner/contacts/form/useContactForm.tsx
@@ -32,6 +32,11 @@ export const useContactForm = (options: ContactFormOptions) => {
       ...defaultValues,
       ...options.contact,
     },
-    onSubmit: ({ value }) => options.onSubmit(value),
+    onSubmit: ({ value }) => options.onSubmit({
+      ...value,
+      // SelectField stores values as strings, so ratings need converting back to numbers
+      connection: Number(value.connection),
+      loyalty: Number(value.loyalty),
+    }),
   })
 }

--- a/src/components/system/dicePool/dicePoolData.tsx
+++ b/src/components/system/dicePool/dicePoolData.tsx
@@ -17,6 +17,6 @@ export const getPoolSize = (groups: DiceGroupList): number => {
 
   return Math.max(
     1,
-    diceGroups.reduce((sum, group) => sum + group.size, 0),
+    diceGroups.reduce((sum, group) => sum + Number(group.size), 0),
   )
 }


### PR DESCRIPTION
## Summary

The legwork dialog's dice pool totals (e.g. GM's "Contact Knowledge Test" showing `44` instead of `8` for two Connection 4 dice) were wrong because contact `connection`/`loyalty` ratings are picked via a string-valued `SelectField` but were never converted back to numbers on save. `getPoolSize`'s `sum + group.size` reduce then silently did string concatenation (`"4" + "4"` → `"44"`) instead of addition, and `Math.max` coerced the mangled string back into a number, producing the odd totals seen in the screenshot.

- `useContactForm.tsx`: convert `connection`/`loyalty` to `Number(...)` on submit, matching the existing pattern used for skill ratings in `activeSkillFormDialog.tsx`.
- `dicePoolData.tsx`: `getPoolSize` now coerces each group's `size` to `Number` before summing, so the total is correct even for already-saved contacts with string-typed ratings.

## Test plan
- [x] `yarn tsc` — no errors
- [x] `yarn vitest run` — 699 tests passing
- [x] `yarn lint` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_018CxUBju4BySQeCTqjVzQw6)_