### PR TITLE
Simplify import/export labels, add .sin export extension

### DIFF
--- a/src/components/builder/builderImportButton.tsx
+++ b/src/components/builder/builderImportButton.tsx
@@ -35,7 +35,7 @@ export const BuilderImportButton: FC<BuilderImportButtonProps> = ({ onImport }) 
         startIcon={<UploadIcon />}
         onClick={openFilePicker}
       >
-        Import YAML
+        Import
       </Button>
 
       <Snackbar

--- a/src/components/runner/exportImport/exportRunnerButton.tsx
+++ b/src/components/runner/exportImport/exportRunnerButton.tsx
@@ -18,7 +18,7 @@ export const ExportRunnerButton: FC = () => {
         .replace(/[^a-z0-9]+/g, "-")
         .replace(/^-|-$/g, "")
 
-    downloadTextFile(yamlContent, `${sanitizedName}.yaml`)
+    downloadTextFile(yamlContent, `${sanitizedName}.sin`)
   }
 
   return (
@@ -29,7 +29,7 @@ export const ExportRunnerButton: FC = () => {
       startIcon={<DownloadIcon />}
       onClick={handleExport}
     >
-      Export YAML
+      Export
     </Button>
   )
 }

--- a/src/components/runner/exportImport/importCurrentRunnerButton.tsx
+++ b/src/components/runner/exportImport/importCurrentRunnerButton.tsx
@@ -55,7 +55,7 @@ export const ImportCurrentRunnerButton: FC = () => {
         startIcon={<UploadIcon />}
         onClick={openFilePicker}
       >
-        Import YAML
+        Import
       </Button>
       {confirmDialog.dialog}
       {alertDialog.dialog}

--- a/src/components/runner/exportImport/importRunnerButton.tsx
+++ b/src/components/runner/exportImport/importRunnerButton.tsx
@@ -45,7 +45,7 @@ export const ImportRunnerButton: FC<ImportRunnerButtonProps> = ({ onImported }) 
         startIcon={<UploadIcon />}
         onClick={openFilePicker}
       >
-        Import YAML
+        Import
       </Button>
       {importConflictDialog.dialog}
     </>

--- a/src/components/runner/exportImport/useYamlFileImport.test.tsx
+++ b/src/components/runner/exportImport/useYamlFileImport.test.tsx
@@ -164,7 +164,7 @@ describe("useYamlFileImport", () => {
 
     // Assert
     expect(result.current.inputProps.type).toBe("file")
-    expect(result.current.inputProps.accept).toBe(".yaml,.yml")
+    expect(result.current.inputProps.accept).toBe(".sin,.yaml,.yml")
     expect(result.current.inputProps.ref).toBe(result.current.inputRef)
   })
 })

--- a/src/components/runner/exportImport/useYamlFileImport.ts
+++ b/src/components/runner/exportImport/useYamlFileImport.ts
@@ -45,7 +45,7 @@ function parseYamlContent(yamlContent: string): ParseResult {
  * Shared file input handling for YAML runner imports.
  *
  * Encapsulates the hidden-input + ref + read-and-reset behaviour used by the
- * various "Import YAML" buttons across the app. Callers provide success /
+ * various "Import" buttons across the app. Callers provide success /
  * error handlers, spread `inputProps` onto a hidden file input, and call
  * `openFilePicker` from their own trigger button.
  */
@@ -76,7 +76,7 @@ export function useYamlFileImport({
   const inputProps = {
     ref: inputRef,
     type: "file",
-    accept: ".yaml,.yml",
+    accept: ".sin,.yaml,.yml",
     style: { display: "none" },
     onChange: (event: ChangeEvent<HTMLInputElement>) => { void handleFileChange(event) },
   }


### PR DESCRIPTION
## Summary
- Renamed the "Import YAML" / "Export YAML" buttons to just "Import" / "Export" across the runner export/import buttons and the builder import button.
- Exported runners now download as `.sin` instead of `.yaml`.
- Import file pickers now accept `.sin` in addition to the existing `.yaml`/`.yml`.

## Test plan
- [x] `npx vitest run src/components/runner/exportImport src/components/builder` — all passing, including updated `accept` attribute assertion.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on changed files — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_014U2mXJo1Gpp39cGaexEFeg)_