### PR TITLE
Add GM's toolbox landing page with character select / GM screen switch

### DIFF
--- a/src/components/landing/gmToolList.tsx
+++ b/src/components/landing/gmToolList.tsx
@@ -1,0 +1,35 @@
+import List from "@mui/material/List"
+import ListItem from "@mui/material/ListItem"
+import ListItemButton from "@mui/material/ListItemButton"
+import ListItemIcon from "@mui/material/ListItemIcon"
+import ListItemText from "@mui/material/ListItemText"
+import Paper from "@mui/material/Paper"
+import Tooltip from "@mui/material/Tooltip"
+import Typography from "@mui/material/Typography"
+import { RiBarricadeFill } from "@remixicon/react"
+import { Link } from "@tanstack/react-router"
+import type { FC } from "react"
+
+import { gmToolOrder } from "./gmTools.ts"
+
+export const GmToolList: FC = () => (
+  <Paper>
+    <List disablePadding>
+      {gmToolOrder.map((tool, index) => (
+        <ListItem key={tool.id} divider={index < gmToolOrder.length - 1} disablePadding>
+          <ListItemButton component={Link} to={tool.route.path}>
+            <ListItemText
+              primary={<Typography variant="h2">{tool.label}</Typography>}
+              secondary={<Typography color="text.secondary">{tool.description}</Typography>}
+            />
+            <Tooltip title="Under construction">
+              <ListItemIcon sx={{ minWidth: "auto", color: "warning.main" }}>
+                <RiBarricadeFill />
+              </ListItemIcon>
+            </Tooltip>
+          </ListItemButton>
+        </ListItem>
+      ))}
+    </List>
+  </Paper>
+)

--- a/src/components/landing/gmTools.ts
+++ b/src/components/landing/gmTools.ts
@@ -1,0 +1,41 @@
+import type { AnyRoute } from "@tanstack/react-router"
+
+import { Route as EncounterBuilderRoute } from "#/routes/gm/encounter-builder.tsx"
+import { Route as InitiativeTrackerRoute } from "#/routes/gm/initiative-tracker.tsx"
+import { Route as NpcBuilderRoute } from "#/routes/gm/npc-builder.tsx"
+
+enum GmToolKey {
+  initiativeTracker = "initiativeTracker",
+  encounterBuilder = "encounterBuilder",
+  npcBuilder = "npcBuilder",
+}
+
+export interface GmToolInfo {
+  readonly id: GmToolKey
+  readonly label: string
+  readonly description: string
+  readonly route: AnyRoute
+}
+
+const gmTools: Readonly<Record<GmToolKey, GmToolInfo>> = {
+  [GmToolKey.initiativeTracker]: {
+    id: GmToolKey.initiativeTracker,
+    label: "Initiative Tracker",
+    description: "Track turn order and initiative scores during combat.",
+    route: InitiativeTrackerRoute,
+  },
+  [GmToolKey.encounterBuilder]: {
+    id: GmToolKey.encounterBuilder,
+    label: "Encounter Builder",
+    description: "Assemble and balance encounters ahead of a run.",
+    route: EncounterBuilderRoute,
+  },
+  [GmToolKey.npcBuilder]: {
+    id: GmToolKey.npcBuilder,
+    label: "NPC Builder",
+    description: "Quickly stat out NPCs with a simplified character creator.",
+    route: NpcBuilderRoute,
+  },
+}
+
+export const gmToolOrder = Object.values(gmTools)

--- a/src/components/landing/landingModeSwitch.tsx
+++ b/src/components/landing/landingModeSwitch.tsx
@@ -1,0 +1,23 @@
+import Tab from "@mui/material/Tab"
+import Tabs from "@mui/material/Tabs"
+import { useLocation, useNavigate } from "@tanstack/react-router"
+import type { FC } from "react"
+
+type LandingMode = "characters" | "gm"
+
+export const LandingModeSwitch: FC = () => {
+  const navigate = useNavigate()
+  const { pathname } = useLocation()
+  const mode: LandingMode = pathname.startsWith("/gm") ? "gm" : "characters"
+
+  return (
+    <Tabs
+      value={mode}
+      onChange={(_, value: LandingMode) => navigate({ to: value === "gm" ? "/gm" : "/" })}
+      variant="fullWidth"
+    >
+      <Tab label="Character Select" value="characters" />
+      <Tab label="GM Screen" value="gm" />
+    </Tabs>
+  )
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -12,7 +12,11 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as RunnerIdRouteImport } from './routes/$runnerId'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as NewIndexRouteImport } from './routes/new/index'
+import { Route as GmIndexRouteImport } from './routes/gm/index'
 import { Route as RunnerIdIndexRouteImport } from './routes/$runnerId/index'
+import { Route as GmNpcBuilderRouteImport } from './routes/gm/npc-builder'
+import { Route as GmInitiativeTrackerRouteImport } from './routes/gm/initiative-tracker'
+import { Route as GmEncounterBuilderRouteImport } from './routes/gm/encounter-builder'
 import { Route as RunnerIdVehiclesRouteImport } from './routes/$runnerId/vehicles'
 import { Route as RunnerIdSpritesRouteImport } from './routes/$runnerId/sprites'
 import { Route as RunnerIdSpiritsRouteImport } from './routes/$runnerId/spirits'
@@ -47,10 +51,30 @@ const NewIndexRoute = NewIndexRouteImport.update({
   path: '/new/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const GmIndexRoute = GmIndexRouteImport.update({
+  id: '/gm/',
+  path: '/gm/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const RunnerIdIndexRoute = RunnerIdIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => RunnerIdRoute,
+} as any)
+const GmNpcBuilderRoute = GmNpcBuilderRouteImport.update({
+  id: '/gm/npc-builder',
+  path: '/gm/npc-builder',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const GmInitiativeTrackerRoute = GmInitiativeTrackerRouteImport.update({
+  id: '/gm/initiative-tracker',
+  path: '/gm/initiative-tracker',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const GmEncounterBuilderRoute = GmEncounterBuilderRouteImport.update({
+  id: '/gm/encounter-builder',
+  path: '/gm/encounter-builder',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const RunnerIdVehiclesRoute = RunnerIdVehiclesRouteImport.update({
   id: '/vehicles',
@@ -163,7 +187,11 @@ export interface FileRoutesByFullPath {
   '/$runnerId/spirits': typeof RunnerIdSpiritsRoute
   '/$runnerId/sprites': typeof RunnerIdSpritesRoute
   '/$runnerId/vehicles': typeof RunnerIdVehiclesRoute
+  '/gm/encounter-builder': typeof GmEncounterBuilderRoute
+  '/gm/initiative-tracker': typeof GmInitiativeTrackerRoute
+  '/gm/npc-builder': typeof GmNpcBuilderRoute
   '/$runnerId/': typeof RunnerIdIndexRoute
+  '/gm/': typeof GmIndexRoute
   '/new/': typeof NewIndexRoute
   '/test/theme/typography': typeof TestThemeTypographyRoute
 }
@@ -186,7 +214,11 @@ export interface FileRoutesByTo {
   '/$runnerId/spirits': typeof RunnerIdSpiritsRoute
   '/$runnerId/sprites': typeof RunnerIdSpritesRoute
   '/$runnerId/vehicles': typeof RunnerIdVehiclesRoute
+  '/gm/encounter-builder': typeof GmEncounterBuilderRoute
+  '/gm/initiative-tracker': typeof GmInitiativeTrackerRoute
+  '/gm/npc-builder': typeof GmNpcBuilderRoute
   '/$runnerId': typeof RunnerIdIndexRoute
+  '/gm': typeof GmIndexRoute
   '/new': typeof NewIndexRoute
   '/test/theme/typography': typeof TestThemeTypographyRoute
 }
@@ -211,7 +243,11 @@ export interface FileRoutesById {
   '/$runnerId/spirits': typeof RunnerIdSpiritsRoute
   '/$runnerId/sprites': typeof RunnerIdSpritesRoute
   '/$runnerId/vehicles': typeof RunnerIdVehiclesRoute
+  '/gm/encounter-builder': typeof GmEncounterBuilderRoute
+  '/gm/initiative-tracker': typeof GmInitiativeTrackerRoute
+  '/gm/npc-builder': typeof GmNpcBuilderRoute
   '/$runnerId/': typeof RunnerIdIndexRoute
+  '/gm/': typeof GmIndexRoute
   '/new/': typeof NewIndexRoute
   '/test/theme/typography': typeof TestThemeTypographyRoute
 }
@@ -237,7 +273,11 @@ export interface FileRouteTypes {
     | '/$runnerId/spirits'
     | '/$runnerId/sprites'
     | '/$runnerId/vehicles'
+    | '/gm/encounter-builder'
+    | '/gm/initiative-tracker'
+    | '/gm/npc-builder'
     | '/$runnerId/'
+    | '/gm/'
     | '/new/'
     | '/test/theme/typography'
   fileRoutesByTo: FileRoutesByTo
@@ -260,7 +300,11 @@ export interface FileRouteTypes {
     | '/$runnerId/spirits'
     | '/$runnerId/sprites'
     | '/$runnerId/vehicles'
+    | '/gm/encounter-builder'
+    | '/gm/initiative-tracker'
+    | '/gm/npc-builder'
     | '/$runnerId'
+    | '/gm'
     | '/new'
     | '/test/theme/typography'
   id:
@@ -284,7 +328,11 @@ export interface FileRouteTypes {
     | '/$runnerId/spirits'
     | '/$runnerId/sprites'
     | '/$runnerId/vehicles'
+    | '/gm/encounter-builder'
+    | '/gm/initiative-tracker'
+    | '/gm/npc-builder'
     | '/$runnerId/'
+    | '/gm/'
     | '/new/'
     | '/test/theme/typography'
   fileRoutesById: FileRoutesById
@@ -292,6 +340,10 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   RunnerIdRoute: typeof RunnerIdRouteWithChildren
+  GmEncounterBuilderRoute: typeof GmEncounterBuilderRoute
+  GmInitiativeTrackerRoute: typeof GmInitiativeTrackerRoute
+  GmNpcBuilderRoute: typeof GmNpcBuilderRoute
+  GmIndexRoute: typeof GmIndexRoute
   NewIndexRoute: typeof NewIndexRoute
   TestThemeTypographyRoute: typeof TestThemeTypographyRoute
 }
@@ -319,12 +371,40 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof NewIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/gm/': {
+      id: '/gm/'
+      path: '/gm'
+      fullPath: '/gm/'
+      preLoaderRoute: typeof GmIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/$runnerId/': {
       id: '/$runnerId/'
       path: '/'
       fullPath: '/$runnerId/'
       preLoaderRoute: typeof RunnerIdIndexRouteImport
       parentRoute: typeof RunnerIdRoute
+    }
+    '/gm/npc-builder': {
+      id: '/gm/npc-builder'
+      path: '/gm/npc-builder'
+      fullPath: '/gm/npc-builder'
+      preLoaderRoute: typeof GmNpcBuilderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/gm/initiative-tracker': {
+      id: '/gm/initiative-tracker'
+      path: '/gm/initiative-tracker'
+      fullPath: '/gm/initiative-tracker'
+      preLoaderRoute: typeof GmInitiativeTrackerRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/gm/encounter-builder': {
+      id: '/gm/encounter-builder'
+      path: '/gm/encounter-builder'
+      fullPath: '/gm/encounter-builder'
+      preLoaderRoute: typeof GmEncounterBuilderRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/$runnerId/vehicles': {
       id: '/$runnerId/vehicles'
@@ -504,6 +584,10 @@ const RunnerIdRouteWithChildren = RunnerIdRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   RunnerIdRoute: RunnerIdRouteWithChildren,
+  GmEncounterBuilderRoute: GmEncounterBuilderRoute,
+  GmInitiativeTrackerRoute: GmInitiativeTrackerRoute,
+  GmNpcBuilderRoute: GmNpcBuilderRoute,
+  GmIndexRoute: GmIndexRoute,
   NewIndexRoute: NewIndexRoute,
   TestThemeTypographyRoute: TestThemeTypographyRoute,
 }

--- a/src/routes/gm/encounter-builder.tsx
+++ b/src/routes/gm/encounter-builder.tsx
@@ -1,0 +1,24 @@
+import Stack from "@mui/material/Stack"
+import { createFileRoute } from "@tanstack/react-router"
+
+import { LandingModeSwitch } from "#/components/landing/landingModeSwitch.tsx"
+import { SectionHeader } from "#/components/ui/text/sectionHeader.tsx"
+import { UnderConstruction } from "#/components/ui/underConstruction.tsx"
+
+export const Route = createFileRoute("/gm/encounter-builder")({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  return (
+    <Stack sx={{ gap: 1, padding: 1 }}>
+      <LandingModeSwitch />
+      <SectionHeader>Encounter Builder</SectionHeader>
+
+      <UnderConstruction
+        title="Encounter Builder — Under Construction"
+        description="Assemble and balance encounters ahead of a run. Stay tuned!"
+      />
+    </Stack>
+  )
+}

--- a/src/routes/gm/index.tsx
+++ b/src/routes/gm/index.tsx
@@ -1,0 +1,18 @@
+import Stack from "@mui/material/Stack"
+import { createFileRoute } from "@tanstack/react-router"
+
+import { GmToolList } from "#/components/landing/gmToolList.tsx"
+import { LandingModeSwitch } from "#/components/landing/landingModeSwitch.tsx"
+
+export const Route = createFileRoute("/gm/")({
+  component: GmScreenRoute,
+})
+
+function GmScreenRoute() {
+  return (
+    <Stack sx={{ gap: 1, padding: 1 }}>
+      <LandingModeSwitch />
+      <GmToolList />
+    </Stack>
+  )
+}

--- a/src/routes/gm/initiative-tracker.tsx
+++ b/src/routes/gm/initiative-tracker.tsx
@@ -1,0 +1,24 @@
+import Stack from "@mui/material/Stack"
+import { createFileRoute } from "@tanstack/react-router"
+
+import { LandingModeSwitch } from "#/components/landing/landingModeSwitch.tsx"
+import { SectionHeader } from "#/components/ui/text/sectionHeader.tsx"
+import { UnderConstruction } from "#/components/ui/underConstruction.tsx"
+
+export const Route = createFileRoute("/gm/initiative-tracker")({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  return (
+    <Stack sx={{ gap: 1, padding: 1 }}>
+      <LandingModeSwitch />
+      <SectionHeader>Initiative Tracker</SectionHeader>
+
+      <UnderConstruction
+        title="Initiative Tracker — Under Construction"
+        description="Track turn order and initiative scores during combat. Stay tuned!"
+      />
+    </Stack>
+  )
+}

--- a/src/routes/gm/npc-builder.tsx
+++ b/src/routes/gm/npc-builder.tsx
@@ -1,0 +1,24 @@
+import Stack from "@mui/material/Stack"
+import { createFileRoute } from "@tanstack/react-router"
+
+import { LandingModeSwitch } from "#/components/landing/landingModeSwitch.tsx"
+import { SectionHeader } from "#/components/ui/text/sectionHeader.tsx"
+import { UnderConstruction } from "#/components/ui/underConstruction.tsx"
+
+export const Route = createFileRoute("/gm/npc-builder")({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  return (
+    <Stack sx={{ gap: 1, padding: 1 }}>
+      <LandingModeSwitch />
+      <SectionHeader>NPC Builder</SectionHeader>
+
+      <UnderConstruction
+        title="NPC Builder — Under Construction"
+        description="Quickly stat out NPCs with a simplified character creator. Stay tuned!"
+      />
+    </Stack>
+  )
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,6 +2,7 @@ import Button from "@mui/material/Button"
 import Stack from "@mui/material/Stack"
 import { createFileRoute, useRouter } from "@tanstack/react-router"
 
+import { LandingModeSwitch } from "#/components/landing/landingModeSwitch.tsx"
 import { ImportRunnerButton } from "#/components/runner/exportImport/importRunnerButton.tsx"
 import RunnerRosterList from "#/components/runner/runnerRosterList.tsx"
 import { Artemis } from "#/data/fixtures/artemis.ts"
@@ -28,6 +29,8 @@ function IndexRoute() {
 
   return (
     <Stack sx={{ gap: 1, padding: 1 }}>
+      <LandingModeSwitch />
+
       <Stack direction="row" sx={{ gap: 1 }}>
         <Button
           variant="outlined"


### PR DESCRIPTION
## Summary

- Add a `Character Select` / `GM Screen` tab switch (`LandingModeSwitch`) to the top of the landing page (`/`), matching the existing `RunnerNav` Tabs pattern
- Add a new `/gm` route ("GM Screen") listing the three upcoming GM tools — **Initiative Tracker**, **Encounter Builder**, and **NPC Builder** — each linking out to its own route
- Stub out `/gm/initiative-tracker`, `/gm/encounter-builder`, and `/gm/npc-builder` with the existing `UnderConstruction` component, following the same pattern used for other in-progress sections (e.g. `sprites.tsx`)

The switcher derives its active tab from the current pathname and is shown on `/`, `/gm`, and each stub tool page, so it doubles as a way back to either top-level area.

## Test plan

- [x] `yarn tsc` — clean
- [x] `yarn fix` (eslint + tsc lint) — clean
- [x] `yarn fallow dead-code` — no new findings introduced by this change
- [x] `yarn build` (regenerates `src/routeTree.gen.ts`) — succeeds
- [x] Manually drove the app with a headless browser: verified the switch toggles between Character Select and GM Screen on `/`, that `/gm` lists all three tools with an "under construction" cone icon, and that clicking into Initiative Tracker shows the Under Construction stub with no console errors
