### PR TITLE
Allow Prototype.Item to nest deeply, group by name

### DIFF
--- a/docs/ui/prototype.md
+++ b/docs/ui/prototype.md
@@ -3,16 +3,16 @@
 **Location:** `src/components/ui/prototype/`
 **Import:** `import { Prototype } from "#/components/ui/prototype/prototype.tsx"`
 
-A compound component for switching between several in-progress prototypes/mockups in place. It's designed to be
-dropped in anywhere with minimal layout impact: the selected `Prototype.Item`'s content is wrapped in a thin,
-padding-free border (so removing `Prototype` later leaves the layout essentially unchanged), and a floating
-prev/next bar overlays the page to switch between options.
+A compound component for switching between several in-progress prototypes/mockups in place. `Prototype.Item`s can be
+nested arbitrarily deep inside `Prototype` — they don't need to be direct children — so a prototype can swap out a
+component buried several levels down in an existing layout. A prev/next bar fixed to the bottom of the screen
+switches between prototypes.
 
 ## Slots
 
-| Slot              | Description                                                        |
-|-------------------|----------------------------------------------------------------------|
-| `Prototype.Item`  | One prototype option. Takes a `title` shown in the switcher bar and renders its `children` when selected |
+| Slot              | Description                                                                                                        |
+|-------------------|---------------------------------------------------------------------------------------------------------------------|
+| `Prototype.Item`  | One prototype option. Takes a `name` used both as its unique key and as the label shown in the switcher bar, and renders its `children` when selected |
 
 ## Usage
 
@@ -21,16 +21,21 @@ import { Prototype } from "#/components/ui/prototype/prototype.tsx"
 
 export const CardLayoutPrototypes = () => (
   <Prototype>
-    <Prototype.Item title="Example 1">
-      <ExampleOne />
-    </Prototype.Item>
-    <Prototype.Item title="Example 2">
-      <ExampleTwo />
-    </Prototype.Item>
+    <div>
+      <div>
+        <Prototype.Item name="grid">
+          <GridContent />
+        </Prototype.Item>
+        <Prototype.Item name="list">
+          <ListContent />
+        </Prototype.Item>
+      </div>
+    </div>
   </Prototype>
 )
 ```
 
-The first item is selected by default. Selection is local component state — it resets whenever the `Prototype`
-unmounts. The floating bar shows the current item's position (`1 / 2`) and title between the prev/next buttons, and
-wraps around at either end.
+The `name` prop is the unique key `Prototype.Item`s are grouped by: every item sharing a `name`, however deeply
+nested, is shown or hidden together as one unit. The first `name` encountered (in tree order) is selected by default.
+Selection is local component state — it resets whenever the `Prototype` unmounts. The bottom bar shows the current
+group's position (`1 / 2`) and name between the prev/next buttons, and wraps around at either end.

--- a/src/components/ui/prototype/prototype.test.tsx
+++ b/src/components/ui/prototype/prototype.test.tsx
@@ -8,23 +8,29 @@ import { Prototype } from "./prototype.tsx"
 const renderPrototype = () =>
   render(
     <Prototype>
-      <Prototype.Item title="Example 1">
-        <div>Content one</div>
-      </Prototype.Item>
-      <Prototype.Item title="Example 2">
-        <div>Content two</div>
-      </Prototype.Item>
+      <div>
+        <div>
+          <div>
+            <Prototype.Item name="grid">
+              <div>Grid content</div>
+            </Prototype.Item>
+            <Prototype.Item name="list">
+              <div>List content</div>
+            </Prototype.Item>
+          </div>
+        </div>
+      </div>
     </Prototype>,
     { wrapper: ThemeWrapper },
   )
 
 describe("Prototype", () => {
-  it("shows the first item's content and its position/title in the switcher bar", () => {
+  it("shows the first item's content and its position/name in the switcher bar, however deeply nested", () => {
     renderPrototype()
 
-    expect(screen.getByText("1 / 2 — Example 1")).toBeDefined()
-    expect(screen.getByText("Content one")).toBeDefined()
-    expect(screen.queryByText("Content two")).toBeNull()
+    expect(screen.getByText("1 / 2 — grid")).toBeDefined()
+    expect(screen.getByText("Grid content")).toBeDefined()
+    expect(screen.queryByText("List content")).toBeNull()
   })
 
   it("advances to the next item when the next button is clicked", () => {
@@ -32,9 +38,9 @@ describe("Prototype", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Next prototype" }))
 
-    expect(screen.getByText("2 / 2 — Example 2")).toBeDefined()
-    expect(screen.getByText("Content two")).toBeDefined()
-    expect(screen.queryByText("Content one")).toBeNull()
+    expect(screen.getByText("2 / 2 — list")).toBeDefined()
+    expect(screen.getByText("List content")).toBeDefined()
+    expect(screen.queryByText("Grid content")).toBeNull()
   })
 
   it("wraps around to the last item when going previous from the first item", () => {
@@ -42,8 +48,8 @@ describe("Prototype", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Previous prototype" }))
 
-    expect(screen.getByText("2 / 2 — Example 2")).toBeDefined()
-    expect(screen.getByText("Content two")).toBeDefined()
+    expect(screen.getByText("2 / 2 — list")).toBeDefined()
+    expect(screen.getByText("List content")).toBeDefined()
   })
 
   it("wraps around to the first item when going next from the last item", () => {
@@ -52,7 +58,42 @@ describe("Prototype", () => {
     fireEvent.click(screen.getByRole("button", { name: "Next prototype" }))
     fireEvent.click(screen.getByRole("button", { name: "Next prototype" }))
 
-    expect(screen.getByText("1 / 2 — Example 1")).toBeDefined()
-    expect(screen.getByText("Content one")).toBeDefined()
+    expect(screen.getByText("1 / 2 — grid")).toBeDefined()
+    expect(screen.getByText("Grid content")).toBeDefined()
+  })
+
+  it("groups items sharing the same name and shows/hides them together", () => {
+    render(
+      <Prototype>
+        <div>
+          <Prototype.Item name="grid">
+            <div>Grid header</div>
+          </Prototype.Item>
+        </div>
+        <div>
+          <div>
+            <Prototype.Item name="grid">
+              <div>Grid footer</div>
+            </Prototype.Item>
+            <Prototype.Item name="list">
+              <div>List body</div>
+            </Prototype.Item>
+          </div>
+        </div>
+      </Prototype>,
+      { wrapper: ThemeWrapper },
+    )
+
+    expect(screen.getByText("1 / 2 — grid")).toBeDefined()
+    expect(screen.getByText("Grid header")).toBeDefined()
+    expect(screen.getByText("Grid footer")).toBeDefined()
+    expect(screen.queryByText("List body")).toBeNull()
+
+    fireEvent.click(screen.getByRole("button", { name: "Next prototype" }))
+
+    expect(screen.getByText("2 / 2 — list")).toBeDefined()
+    expect(screen.getByText("List body")).toBeDefined()
+    expect(screen.queryByText("Grid header")).toBeNull()
+    expect(screen.queryByText("Grid footer")).toBeNull()
   })
 })

--- a/src/components/ui/prototype/prototype.tsx
+++ b/src/components/ui/prototype/prototype.tsx
@@ -11,10 +11,10 @@ interface PrototypeComponent {
 
 /**
  * Compound `Prototype` component for switching between multiple in-progress
- * prototypes/mockups without leaving the page. Wraps the selected
- * `Prototype.Item`'s content in a thin, padding-free border and overlays a
- * floating prev/next bar, so it can be dropped in around any component with
- * minimal layout impact.
+ * prototypes/mockups without leaving the page. `Prototype.Item`s can be
+ * nested arbitrarily deep in the tree; items sharing the same `name` are
+ * shown or hidden together. A prev/next bar fixed to the bottom of the
+ * screen switches between the named groups.
  *
  * See `docs/ui/prototype.md` for usage examples.
  */

--- a/src/components/ui/prototype/prototypeContext.ts
+++ b/src/components/ui/prototype/prototypeContext.ts
@@ -1,0 +1,5 @@
+// fallow-ignore-file
+import { createContext } from "react"
+
+/** Name of the currently selected `Prototype.Item` group, or `null` if there are none. */
+export const PrototypeSelectionContext = createContext<string | null>(null)

--- a/src/components/ui/prototype/prototypeItem.tsx
+++ b/src/components/ui/prototype/prototypeItem.tsx
@@ -1,12 +1,22 @@
 // fallow-ignore-file
 import type { FC, ReactNode } from "react"
+import { useContext } from "react"
+
+import { PrototypeSelectionContext } from "./prototypeContext.ts"
 
 export interface PrototypeItemProps {
-  /** Label shown for this prototype in the switcher bar. */
-  title: string
+  /**
+   * Unique key for this prototype option. Every `Prototype.Item` sharing the
+   * same `name` is shown or hidden together, no matter how deeply each one is
+   * nested under the enclosing `Prototype`.
+   */
+  name: string
   children: ReactNode
 }
 
-export const PrototypeItem: FC<PrototypeItemProps> = ({ children }) => <>{children}</>
+export const PrototypeItem: FC<PrototypeItemProps> = ({ name, children }) => {
+  const selectedName = useContext(PrototypeSelectionContext)
+  return selectedName === name ? <>{children}</> : null
+}
 
 PrototypeItem.displayName = "Prototype.Item"

--- a/src/components/ui/prototype/prototypeRoot.tsx
+++ b/src/components/ui/prototype/prototypeRoot.tsx
@@ -4,14 +4,30 @@ import IconButton from "@mui/material/IconButton"
 import Paper from "@mui/material/Paper"
 import Typography from "@mui/material/Typography"
 import { RiArrowLeftSLine, RiArrowRightSLine } from "@remixicon/react"
-import type { FC, ReactElement, ReactNode } from "react"
-import { Children, isValidElement, useState } from "react"
+import type { FC, ReactNode } from "react"
+import { Children, isValidElement, useMemo, useState } from "react"
 
+import { PrototypeSelectionContext } from "./prototypeContext.ts"
 import type { PrototypeItemProps } from "./prototypeItem.tsx"
 import { PrototypeItem } from "./prototypeItem.tsx"
 
-function isPrototypeItem(item: ReactNode): item is ReactElement<PrototypeItemProps> {
-  return isValidElement(item) && item.type === PrototypeItem
+/** Walks the tree (through any wrapping elements) collecting `Prototype.Item` names in first-seen order. */
+function collectNames(node: ReactNode, names: string[] = []): string[] {
+  Children.forEach(node, (child) => {
+    if (!isValidElement(child)) return
+
+    if (child.type === PrototypeItem) {
+      const { name, children } = child.props as PrototypeItemProps
+      if (!names.includes(name)) names.push(name)
+      collectNames(children, names)
+      return
+    }
+
+    const { children } = child.props as { children?: ReactNode }
+    if (children !== undefined) collectNames(children, names)
+  })
+
+  return names
 }
 
 export interface PrototypeRootProps {
@@ -19,32 +35,33 @@ export interface PrototypeRootProps {
 }
 
 export const PrototypeRoot: FC<PrototypeRootProps> = ({ children }) => {
-  const items = Children.toArray(children).filter(isPrototypeItem)
+  const names = useMemo(() => collectNames(children), [children])
   const [selectedIndex, setSelectedIndex] = useState(0)
-  const activeIndex = items.length === 0 ? 0 : Math.min(selectedIndex, items.length - 1)
-  const selected = items[activeIndex]
+  const activeIndex = names.length === 0 ? 0 : Math.min(selectedIndex, names.length - 1)
+  const selectedName = names[activeIndex] ?? null
 
-  const goToPrevious = () => setSelectedIndex((activeIndex - 1 + items.length) % items.length)
-  const goToNext = () => setSelectedIndex((activeIndex + 1) % items.length)
+  const goToPrevious = () => setSelectedIndex((activeIndex - 1 + names.length) % names.length)
+  const goToNext = () => setSelectedIndex((activeIndex + 1) % names.length)
 
   return (
-    <>
+    <PrototypeSelectionContext.Provider value={selectedName}>
       <Box sx={{ border: "1px solid", borderColor: "divider" }}>
-        {selected}
+        {children}
       </Box>
 
       <Paper
         elevation={4}
+        square
         sx={{
           position: "fixed",
-          bottom: 16,
-          left: "50%",
-          transform: "translateX(-50%)",
+          bottom: 0,
+          left: 0,
+          right: 0,
           display: "flex",
           alignItems: "center",
+          justifyContent: "center",
           gap: 0.5,
-          padding: 0.5,
-          borderRadius: 999,
+          padding: 1,
           zIndex: (theme) => theme.zIndex.tooltip,
         }}
       >
@@ -52,13 +69,13 @@ export const PrototypeRoot: FC<PrototypeRootProps> = ({ children }) => {
           <RiArrowLeftSLine />
         </IconButton>
         <Typography variant="body2" sx={{ px: 1, whiteSpace: "nowrap" }}>
-          {activeIndex + 1} / {items.length} — {selected?.props.title}
+          {names.length === 0 ? "0 / 0" : `${activeIndex + 1} / ${names.length} — ${selectedName}`}
         </Typography>
         <IconButton onClick={goToNext} aria-label="Next prototype" size="small">
           <RiArrowRightSLine />
         </IconButton>
       </Paper>
-    </>
+    </PrototypeSelectionContext.Provider>
   )
 }
 


### PR DESCRIPTION
## Summary

- `Prototype.Item` no longer has to be a direct child of `Prototype` — items are discovered anywhere in the tree (through wrapping elements like `div`s) via a recursive walk, and a React context tells each item whether it's currently selected.
- The `title` prop is renamed to `name`, which now doubles as the grouping key: every `Prototype.Item` sharing a `name`, however deeply nested, is shown or hidden together as one group. This lets a single named prototype swap out multiple, differently-located pieces of a layout at once.
- The switcher bar is now a full-width bar fixed to the bottom of the screen, rather than a floating pill centered above the bottom edge.
- Updated `docs/ui/prototype.md` and `prototype.test.tsx` (added coverage for deep nesting and cross-location grouping by `name`).

## Test plan

- [x] `yarn tsc` — clean
- [x] `yarn eslint src/components/ui/prototype` — clean
- [x] `yarn test:unit` — 700/700 tests pass, including the updated/new `prototype.test.tsx` cases


---
_Generated by [Claude Code](https://claude.ai/code/session_01E1q23WRAQMnt4ocALkEreB)_