### PR TITLE
Keep dialog footer visible and scroll content on overflow

### DIFF
--- a/src/components/ui/dialog/dialogRoot.tsx
+++ b/src/components/ui/dialog/dialogRoot.tsx
@@ -63,11 +63,19 @@ export const DialogRoot = ({
       maxWidth={maxWidth}
       fullWidth
       fullScreen={fullScreen}
-      slotProps={{ transition: { onExited: onClosed } }}
+      slotProps={{
+        transition: { onExited: onClosed },
+        // MUI's default paper margin is 32px (top/bottom), keep 40px on
+        // non-mobile so the dialog never touches the viewport edges.
+        paper: fullScreen
+          ? undefined
+          : { sx: { marginTop: "40px", marginBottom: "40px", maxHeight: "calc(100% - 80px)" } },
+      }}
     >
-      {/* In full-screen mode the Stack must stretch to the paper's full
-          height so the content area grows and the actions pin to the bottom. */}
-      <Stack divider={<Divider />} sx={{ gap: 0, ...(fullScreen && { flex: 1, minHeight: 0 }) }}>
+      {/* The Stack must always stretch to the paper's full (possibly capped)
+          height so Dialog.Content can shrink and scroll while the title and
+          actions stay pinned in view. */}
+      <Stack divider={<Divider />} sx={{ gap: 0, flex: 1, minHeight: 0 }}>
         {title}
         {content}
         {actions}


### PR DESCRIPTION
## Summary
- The title/content `Stack` inside `DialogRoot` only stretched to the paper's full height in `fullScreen` mode. In the regular (non-fullscreen) case, a tall dialog body pushed the actions footer off-screen instead of scrolling, since the `Stack` grew past the paper's `maxHeight` with no way to shrink.
- Make the `Stack` always fill the paper's height (`flex: 1, minHeight: 0`) so `Dialog.Content` scrolls internally while `Dialog.Title` and `Dialog.Actions` stay pinned in view.
- On non-mobile (`!fullScreen`) dialogs, bump the paper's vertical margin from MUI's default 32px to 40px (and adjust `maxHeight` to `calc(100% - 80px)` to match), so the dialog always keeps 40px of clearance above and below on tall/short viewports. `fullScreen` (mobile) dialogs are untouched — MUI already collapses their margin to 0.

## Test plan
- [x] `yarn tsc`
- [x] `yarn eslint src/components/ui/dialog`
- [x] `yarn test:unit` (708 tests passing)
- [x] Manually verified in a real browser (Playwright against the dev server) with a short viewport: paper keeps exactly 40px clearance top/bottom, content scrolls (`scrollHeight` > `clientHeight`, `overflow-y: auto`), and the actions footer (Cancel/Save) stays fully visible pinned to the bottom.

https://claude.ai/code/session_019wqPo6bVgpkjtrxUCy6JAT


---
_Generated by [Claude Code](https://claude.ai/code/session_019wqPo6bVgpkjtrxUCy6JAT)_