### PR TITLE
Fix armor stacking: base takes highest rating, modifiers stack

### DIFF
--- a/src/components/items/types/armor/dialogs/armorFormDialog.test.tsx
+++ b/src/components/items/types/armor/dialogs/armorFormDialog.test.tsx
@@ -65,6 +65,30 @@ describe("ArmorFormDialog", () => {
     })
   })
 
+  it("defaults to Base and submits isModifier: true when Modifier is selected", async () => {
+    // Arrange
+    const ctrl = new DialogCtrl<ArmorData>()
+    ctrl.open()
+    renderInBuilder(<ArmorFormDialog ctrl={ctrl} />)
+
+    const dialogs = screen.getAllByRole("dialog")
+    const dialog = dialogs[dialogs.length - 1]
+
+    // Act
+    fireEvent.change(within(dialog).getByLabelText(/^name$/i), {
+      target: { value: "Helmet" },
+    })
+    fireEvent.click(within(dialog).getByRole("button", { name: /^modifier$/i }))
+    fireEvent.click(within(dialog).getByRole("button", { name: /save/i }))
+
+    // Assert
+    const savedItem = await ctrl.result()
+    await waitFor(() => {
+      expect(savedItem?.name).toBe("Helmet")
+      expect(savedItem?.isModifier).toBe(true)
+    })
+  })
+
   it("populates fields when editing an existing armor item", () => {
     // Arrange
     const existingArmor: ArmorData = {

--- a/src/components/items/types/armor/forms/armorFormFields.tsx
+++ b/src/components/items/types/armor/forms/armorFormFields.tsx
@@ -1,4 +1,6 @@
 import Stack from "@mui/material/Stack"
+import ToggleButton from "@mui/material/ToggleButton"
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup"
 
 import { Label } from "#/components/ui/text/label.tsx"
 import { withFieldGroup } from "#/integrations/tanstackForm/useAppForm.ts"
@@ -21,6 +23,22 @@ export const ArmorFormFields = withFieldGroup({
             {(field) => <field.CounterField label="Impact" min={0} max={20} fullWidth />}
           </group.AppField>
         </Stack>
+
+        <Label label="Armor Type" />
+
+        <group.AppField name="isModifier">
+          {(field) => (
+            <ToggleButtonGroup
+              exclusive
+              size="small"
+              value={field.state.value ? "modifier" : "base"}
+              onChange={(_, value) => value && field.handleChange(value === "modifier")}
+            >
+              <ToggleButton value="base" sx={{ flexGrow: 1 }}>Base</ToggleButton>
+              <ToggleButton value="modifier" sx={{ flexGrow: 1 }}>Modifier</ToggleButton>
+            </ToggleButtonGroup>
+          )}
+        </group.AppField>
       </>
     )
   },

--- a/src/components/items/types/armor/forms/useArmorForm.tsx
+++ b/src/components/items/types/armor/forms/useArmorForm.tsx
@@ -17,6 +17,7 @@ const defaultFormValues: ArmorData = {
   name: "",
   ballistic: 0,
   impact: 0,
+  isModifier: false,
   cost: 0,
   quantity: 1,
   description: "",

--- a/src/components/system/encumbrance/useEncumbrance.ts
+++ b/src/components/system/encumbrance/useEncumbrance.ts
@@ -2,7 +2,7 @@ import { useGearByType } from "#/components/items/gearHooks.ts"
 import { useAttrValue } from "#/components/runner/attributes/attributesProvider.tsx"
 import { AttributeKey } from "#/system/attributeKey.ts"
 import type { ArmorData } from "#/system/gear/armorData.ts"
-import { calculateArmorTotals, calculateEncumbrancePenalty } from "#/system/gear/encumbranceUtils.ts"
+import { calculateArmorBulk, calculateArmorTotals, calculateEncumbrancePenalty } from "#/system/gear/encumbranceUtils.ts"
 import { ItemType } from "#/system/itemType.ts"
 
 export interface EncumbranceInfo {
@@ -19,8 +19,9 @@ export function useEncumbrance(): EncumbranceInfo {
 
   const equippedArmor = allArmor.filter((a) => a.equipped)
   const { ballistic: totalBallistic, impact: totalImpact } = calculateArmorTotals(equippedArmor)
+  const bulk = calculateArmorBulk(equippedArmor)
   const threshold = body * 2
-  const penalty = calculateEncumbrancePenalty(totalBallistic, totalImpact, body)
+  const penalty = calculateEncumbrancePenalty(bulk.ballistic, bulk.impact, body)
 
   return {
     totalBallistic,

--- a/src/system/gear/armorData.ts
+++ b/src/system/gear/armorData.ts
@@ -15,6 +15,11 @@ export interface ArmorData extends ItemData {
     ballistic: number
     impact: number
   }
+  /**
+   * Base armor doesn't stack — only the highest-rated base armor applies.
+   * Modifier armor (e.g. helmets, shields) stacks additively on top of the base.
+   */
+  isModifier?: boolean
 }
 
 // Not yet wired into a form validator (see SpellDataSchema/AdeptPowerDataSchema for the pattern) — kept for parity with sibling item-data schemas
@@ -55,6 +60,7 @@ export const ArmorDataSchema = z.object({
     ballistic: z.number().int().min(0),
     impact: z.number().int().min(0),
   }).optional(),
+  isModifier: z.boolean().optional(),
 }) satisfies z.ZodType<ArmorData>
 
 export function isArmorData(item: ItemData): item is ArmorData {

--- a/src/system/gear/encumbranceUtils.test.ts
+++ b/src/system/gear/encumbranceUtils.test.ts
@@ -4,7 +4,7 @@ import { NullUuid } from "#/lib/uuidUtils.ts"
 import { ItemType } from "#/system/itemType.ts"
 
 import type { ArmorData } from "./armorData.ts"
-import { calculateArmorTotals, calculateEncumbrancePenalty } from "./encumbranceUtils.ts"
+import { calculateArmorBulk, calculateArmorTotals, calculateEncumbrancePenalty } from "./encumbranceUtils.ts"
 
 function armor(overrides: Partial<ArmorData>): ArmorData {
   return {
@@ -76,6 +76,41 @@ describe("calculateArmorTotals", () => {
 
   it("returns zero totals when nothing is equipped", () => {
     expect(calculateArmorTotals([])).toEqual({ ballistic: 0, impact: 0 })
+  })
+})
+
+describe("calculateArmorBulk", () => {
+  it("sums every equipped item's rating regardless of Base/Modifier", () => {
+    // Arrange
+    const equipped = [
+      armor({ name: "Armor 1", ballistic: 8, impact: 6 }),
+      armor({ name: "Armor 2", ballistic: 5, impact: 7 }),
+      armor({ name: "Armor 3", ballistic: 2, impact: 0, isModifier: true }),
+      armor({ name: "Armor 4", ballistic: 0, impact: 3, isModifier: true }),
+    ]
+
+    // Act
+    const bulk = calculateArmorBulk(equipped)
+
+    // Assert
+    expect(bulk).toEqual({ ballistic: 15, impact: 16 })
+  })
+
+  it("does not subtract damage, since damage doesn't reduce bulk", () => {
+    // Arrange
+    const equipped = [
+      armor({ name: "Full Body Armor", ballistic: 8, impact: 6, damage: { ballistic: 5, impact: 0 } }),
+    ]
+
+    // Act
+    const bulk = calculateArmorBulk(equipped)
+
+    // Assert
+    expect(bulk).toEqual({ ballistic: 8, impact: 6 })
+  })
+
+  it("returns zero bulk when nothing is equipped", () => {
+    expect(calculateArmorBulk([])).toEqual({ ballistic: 0, impact: 0 })
   })
 })
 

--- a/src/system/gear/encumbranceUtils.test.ts
+++ b/src/system/gear/encumbranceUtils.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest"
+
+import { NullUuid } from "#/lib/uuidUtils.ts"
+import { ItemType } from "#/system/itemType.ts"
+
+import type { ArmorData } from "./armorData.ts"
+import { calculateArmorTotals, calculateEncumbrancePenalty } from "./encumbranceUtils.ts"
+
+function armor(overrides: Partial<ArmorData>): ArmorData {
+  return {
+    id: NullUuid,
+    itemType: ItemType.armor,
+    name: "Armor",
+    ballistic: 0,
+    impact: 0,
+    ...overrides,
+  }
+}
+
+describe("calculateArmorTotals", () => {
+  it("takes the highest rating among base armor rather than summing them", () => {
+    // Arrange
+    const equipped = [
+      armor({ name: "Armor Jacket", ballistic: 6, impact: 4 }),
+      armor({ name: "Full Body Armor", ballistic: 8, impact: 6 }),
+    ]
+
+    // Act
+    const totals = calculateArmorTotals(equipped)
+
+    // Assert
+    expect(totals).toEqual({ ballistic: 8, impact: 6 })
+  })
+
+  it("adds modifier armor on top of the highest base rating", () => {
+    // Arrange
+    const equipped = [
+      armor({ name: "Full Body Armor", ballistic: 8, impact: 6 }),
+      armor({ name: "Helmet", ballistic: 2, impact: 2, isModifier: true }),
+    ]
+
+    // Act
+    const totals = calculateArmorTotals(equipped)
+
+    // Assert
+    expect(totals).toEqual({ ballistic: 10, impact: 8 })
+  })
+
+  it("stacks multiple modifier items additively", () => {
+    // Arrange
+    const equipped = [
+      armor({ name: "Helmet", ballistic: 2, impact: 2, isModifier: true }),
+      armor({ name: "Shield", ballistic: 3, impact: 1, isModifier: true }),
+    ]
+
+    // Act
+    const totals = calculateArmorTotals(equipped)
+
+    // Assert
+    expect(totals).toEqual({ ballistic: 5, impact: 3 })
+  })
+
+  it("accounts for damage when picking the highest base rating", () => {
+    // Arrange
+    const equipped = [
+      armor({ name: "Armor Jacket", ballistic: 6, impact: 4 }),
+      armor({ name: "Full Body Armor", ballistic: 8, impact: 6, damage: { ballistic: 5, impact: 0 } }),
+    ]
+
+    // Act
+    const totals = calculateArmorTotals(equipped)
+
+    // Assert
+    expect(totals).toEqual({ ballistic: 6, impact: 6 })
+  })
+
+  it("returns zero totals when nothing is equipped", () => {
+    expect(calculateArmorTotals([])).toEqual({ ballistic: 0, impact: 0 })
+  })
+})
+
+describe("calculateEncumbrancePenalty", () => {
+  it("returns zero when totals are within the body threshold", () => {
+    expect(calculateEncumbrancePenalty(6, 4, 4)).toBe(0)
+  })
+
+  it("penalizes based on whichever of ballistic or impact exceeds the threshold more", () => {
+    expect(calculateEncumbrancePenalty(11, 5, 4)).toBe(2)
+  })
+})

--- a/src/system/gear/encumbranceUtils.ts
+++ b/src/system/gear/encumbranceUtils.ts
@@ -1,13 +1,34 @@
 import type { ArmorData } from "./armorData.ts"
 
+function effectiveRatings(armor: ArmorData): { ballistic: number, impact: number } {
+  return {
+    ballistic: Math.max(0, armor.ballistic - (armor.damage?.ballistic ?? 0)),
+    impact: Math.max(0, armor.impact - (armor.damage?.impact ?? 0)),
+  }
+}
+
+// Base armor doesn't stack: only the highest-rated base piece applies, tracked
+// separately for ballistic and impact. Modifier armor (e.g. helmets, shields)
+// adds on top of that base, and does stack with other modifiers.
 export function calculateArmorTotals(equipped: ArmorData[]): { ballistic: number, impact: number } {
-  return equipped.reduce(
-    (totals, a) => ({
-      ballistic: totals.ballistic + Math.max(0, a.ballistic - (a.damage?.ballistic ?? 0)),
-      impact: totals.impact + Math.max(0, a.impact - (a.damage?.impact ?? 0)),
-    }),
-    { ballistic: 0, impact: 0 },
-  )
+  const base = { ballistic: 0, impact: 0 }
+  const modifiers = { ballistic: 0, impact: 0 }
+
+  for (const armor of equipped) {
+    const { ballistic, impact } = effectiveRatings(armor)
+    if (armor.isModifier) {
+      modifiers.ballistic += ballistic
+      modifiers.impact += impact
+    } else {
+      base.ballistic = Math.max(base.ballistic, ballistic)
+      base.impact = Math.max(base.impact, impact)
+    }
+  }
+
+  return {
+    ballistic: base.ballistic + modifiers.ballistic,
+    impact: base.impact + modifiers.impact,
+  }
 }
 
 // SR4A p.160: penalty is –1 to Agility and Reaction per 2 points (or fraction) either

--- a/src/system/gear/encumbranceUtils.ts
+++ b/src/system/gear/encumbranceUtils.ts
@@ -31,6 +31,20 @@ export function calculateArmorTotals(equipped: ArmorData[]): { ballistic: number
   }
 }
 
+// Encumbrance is driven by the bulk of everything worn, not just the armor rating
+// that ends up applying — a redundant base layer still weighs the character down
+// even though its rating is superseded. Sums every equipped item's printed rating;
+// damage doesn't reduce bulk, so it isn't subtracted here.
+export function calculateArmorBulk(equipped: ArmorData[]): { ballistic: number, impact: number } {
+  return equipped.reduce(
+    (totals, a) => ({
+      ballistic: totals.ballistic + a.ballistic,
+      impact: totals.impact + a.impact,
+    }),
+    { ballistic: 0, impact: 0 },
+  )
+}
+
 // SR4A p.160: penalty is –1 to Agility and Reaction per 2 points (or fraction) either
 // armor rating exceeds Body × 2. Check ballistic and impact independently; apply the worse.
 export function calculateEncumbrancePenalty(totalBallistic: number, totalImpact: number, body: number): number {


### PR DESCRIPTION
## Summary
- `calculateArmorTotals` previously summed every equipped armor item's ballistic/impact rating unconditionally, letting multiple full suits of armor stack freely. Only the highest-rated **base** armor should apply (tracked separately for ballistic and impact); only items explicitly marked as a **modifier** (helmets, shields, etc.) should add on top.
- Added an `isModifier?: boolean` flag to `ArmorData` (and its zod schema) to mark which type a piece of armor is.
- Added a Base/Modifier toggle button group to the armor form, matching the existing exclusive-toggle pattern used elsewhere (e.g. `AvailabilityFieldGroup`, `CombatantFormFields`). Defaults to Base.
- Per SR4A p.161, the encumbrance penalty check adds together the ratings of *every* item worn (regardless of whether its rating ends up applying in combat), so it's compared against Body × 2 using total worn bulk, not the effective/stacked combat rating. Added `calculateArmorBulk` for this and wired it into `useEncumbrance` for the penalty calculation, while the displayed armor totals and combat protection still use the base/modifier stacked value.

## Test plan
- [x] `yarn tsc` passes
- [x] `yarn vitest run` — all 719 tests pass (117 files)
- [x] `src/system/gear/encumbranceUtils.test.ts` covers: base armor takes the max rating instead of summing, modifiers stack additively on top of base, multiple modifiers stack with each other, damage is accounted for when picking the highest base rating, `calculateArmorBulk` sums every equipped item regardless of Base/Modifier and ignores damage, and empty-equipped edge cases
- [x] Added a test in `armorFormDialog.test.tsx` verifying the Base/Modifier toggle submits `isModifier: true` when Modifier is selected
- [x] `yarn eslint` clean on changed files
