### PR TITLE
Close dialogs when the browser back button is pressed

### DIFF
--- a/src/components/ui/dialog/dialogRoot.tsx
+++ b/src/components/ui/dialog/dialogRoot.tsx
@@ -8,6 +8,7 @@ import { Children, isValidElement } from "react"
 import { DialogActions } from "./dialogActions.tsx"
 import { DialogContent } from "./dialogContent.tsx"
 import { DialogTitle } from "./dialogTitle.tsx"
+import { useCloseOnBrowserBack } from "./useCloseOnBrowserBack.ts"
 
 function isElementType<TProps>(type: FC<TProps>) {
   return (item: ReactNode): item is ReactElement<TProps> => {
@@ -46,6 +47,8 @@ export const DialogRoot = ({
   fullScreen,
   children,
 }: DialogRootProps) => {
+  useCloseOnBrowserBack(open, onClose)
+
   const childArray = Children.toArray(children)
 
   const title = childArray.find(isElementType(DialogTitle))

--- a/src/components/ui/dialog/useCloseOnBrowserBack.test.tsx
+++ b/src/components/ui/dialog/useCloseOnBrowserBack.test.tsx
@@ -1,10 +1,10 @@
-import { act, fireEvent, render, screen } from "@testing-library/react"
 import {
   createMemoryHistory,
   createRootRoute,
   createRouter,
   RouterProvider,
 } from "@tanstack/react-router"
+import { act, fireEvent, render, screen } from "@testing-library/react"
 import { useState } from "react"
 import { describe, expect, it } from "vitest"
 
@@ -37,7 +37,7 @@ describe("useCloseOnBrowserBack", () => {
     expect(history.length).toBeGreaterThan(1)
     expect((history.location.state as { dialogBackGuard?: boolean }).dialogBackGuard).toBe(true)
 
-    await act(async () => {
+    await act(() => {
       fireEvent.click(screen.getByRole("button", { name: "close" }))
     })
 
@@ -53,7 +53,7 @@ describe("useCloseOnBrowserBack", () => {
 
     expect(screen.getByText("open")).toBeTruthy()
 
-    await act(async () => {
+    await act(() => {
       router.history.back()
     })
 

--- a/src/components/ui/dialog/useCloseOnBrowserBack.test.tsx
+++ b/src/components/ui/dialog/useCloseOnBrowserBack.test.tsx
@@ -1,0 +1,79 @@
+import { act, fireEvent, render, screen } from "@testing-library/react"
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router"
+import { useState } from "react"
+import { describe, expect, it } from "vitest"
+
+import { useCloseOnBrowserBack } from "./useCloseOnBrowserBack.ts"
+
+function TestDialog() {
+  const [open, setOpen] = useState(true)
+  useCloseOnBrowserBack(open, () => setOpen(false))
+  return (
+    <div>
+      <span>{open ? "open" : "closed"}</span>
+      <button onClick={() => setOpen(false)}>close</button>
+    </div>
+  )
+}
+
+function renderTestDialog() {
+  const history = createMemoryHistory({ initialEntries: ["/"] })
+  const router = createRouter({ routeTree: createRootRoute({ component: TestDialog }), history })
+  render(<RouterProvider router={router} />)
+  return { router, history }
+}
+
+describe("useCloseOnBrowserBack", () => {
+  it("pushes a history entry while open and pops it again on normal close", async () => {
+    const { history } = renderTestDialog()
+    await act(async () => {})
+
+    // Opening the dialog pushed a new (marked) history entry on top.
+    expect(history.length).toBeGreaterThan(1)
+    expect((history.location.state as { dialogBackGuard?: boolean }).dialogBackGuard).toBe(true)
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "close" }))
+    })
+
+    // Closing by another means (not the back button) steps back off that
+    // entry again rather than leaving it in history.
+    expect(screen.getByText("closed")).toBeTruthy()
+    expect((history.location.state as { dialogBackGuard?: boolean }).dialogBackGuard).toBeUndefined()
+  })
+
+  it("closes the dialog when the browser back button is pressed", async () => {
+    const { router } = renderTestDialog()
+    await act(async () => {})
+
+    expect(screen.getByText("open")).toBeTruthy()
+
+    await act(async () => {
+      router.history.back()
+    })
+
+    expect(screen.getByText("closed")).toBeTruthy()
+  })
+
+  it("does not intercept back when onClose is undefined", async () => {
+    function NonDismissableDialog() {
+      useCloseOnBrowserBack(true, undefined)
+      return <span>open</span>
+    }
+
+    const history = createMemoryHistory({ initialEntries: ["/"] })
+    const router = createRouter({
+      routeTree: createRootRoute({ component: NonDismissableDialog }),
+      history,
+    })
+    render(<RouterProvider router={router} />)
+    await act(async () => {})
+
+    expect(history.length).toBe(1)
+  })
+})

--- a/src/components/ui/dialog/useCloseOnBrowserBack.ts
+++ b/src/components/ui/dialog/useCloseOnBrowserBack.ts
@@ -1,0 +1,44 @@
+import { useRouter } from "@tanstack/react-router"
+import { useEffect, useRef } from "react"
+
+/**
+ * Pushes a history entry while the dialog is open so that pressing the
+ * browser's back button closes it instead of navigating away. The entry is
+ * popped again as soon as the dialog closes by any other means (backdrop,
+ * Escape, an action button, ...), so it never lingers in history.
+ *
+ * No-ops when `onClose` is undefined — those dialogs already opt out of
+ * backdrop/Escape dismissal, so back-button dismissal is skipped too. Also
+ * no-ops outside a `RouterProvider` (e.g. in component tests rendered
+ * without a router).
+ */
+export function useCloseOnBrowserBack(open: boolean, onClose: (() => void) | undefined): void {
+  const router = useRouter({ warn: false })
+  const onCloseRef = useRef(onClose)
+
+  useEffect(() => {
+    onCloseRef.current = onClose
+  }, [onClose])
+
+  useEffect(() => {
+    if (!open || !onCloseRef.current || !router) return
+
+    let guardPushed = true
+    router.history.push(router.history.location.href, { dialogBackGuard: true })
+
+    const unsubscribe = router.history.subscribe(({ action }) => {
+      if (guardPushed && action.type === "BACK") {
+        guardPushed = false
+        onCloseRef.current?.()
+      }
+    })
+
+    return () => {
+      unsubscribe()
+      if (guardPushed) {
+        guardPushed = false
+        router.history.back()
+      }
+    }
+  }, [open, router])
+}


### PR DESCRIPTION
## Summary
- Pressing the browser's back button now closes an open dialog instead of navigating away from the page.
- Implemented once in the shared `DialogRoot` (`src/components/ui/dialog/dialogRoot.tsx`), so all ~90 dialog call sites across the app inherit the behavior automatically — no per-dialog changes needed.
- New hook `useCloseOnBrowserBack` (`src/components/ui/dialog/useCloseOnBrowserBack.ts`) pushes a history entry through the TanStack Router history API when a dialog opens, and:
  - On back-button press: pops the entry and calls the dialog's `onClose`.
  - On any other close (backdrop, Escape, an action button): pops the entry itself so it never lingers in history.
- Uses the router's own history instance (not raw `window.history`) so the pushed/popped entries stay consistent with TanStack Router's internal index bookkeeping (hash-based routing) instead of corrupting it.
- Dialogs that already opt out of backdrop/Escape dismissal (`onClose={false}`, e.g. required-choice dialogs) also opt out of back-button dismissal, for consistency with existing behavior.
- No-ops gracefully outside a `RouterProvider` (e.g. component tests rendered without a router).

## Test plan
- [x] `yarn tsc --noEmit` — no type errors
- [x] `yarn eslint` on changed/added files — no lint errors
- [x] `yarn vitest run` — full suite (755 tests) passes
- [x] Added `useCloseOnBrowserBack.test.tsx` covering: history entry pushed on open, entry popped on normal close, dialog closes on back-button press, and non-dismissable dialogs (`onClose` undefined) are left alone
- [ ] Manual verification in a running browser (not yet performed in this session)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwEpsLJeWcufb3x769uubj)_