### PR TITLE
Add explicit edit buttons to item cards, remove card onClick

### DIFF
--- a/src/components/builder/sections/gear/armor/armorList.test.tsx
+++ b/src/components/builder/sections/gear/armor/armorList.test.tsx
@@ -47,9 +47,8 @@ describe("ArmorList", () => {
     })
     expect(screen.getByText("Armor Jacket")).toBeDefined()
 
-    // Act: the remove icon button has no accessible name.
-    const removeButton = screen.getAllByRole("button").find((button) => button.textContent === "")
-    fireEvent.click(removeButton!)
+    // Act
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }))
 
     // Assert: the UI re-rendered off the updated store.
     await waitFor(() => expect(screen.queryByText("Armor Jacket")).toBeNull())

--- a/src/components/builder/sections/gear/generic/itemsList.test.tsx
+++ b/src/components/builder/sections/gear/generic/itemsList.test.tsx
@@ -55,9 +55,8 @@ describe("ItemsList", () => {
     })
     expect(screen.getByText("Trodes")).toBeDefined()
 
-    // Act: the remove icon button has no accessible name.
-    const removeButton = screen.getAllByRole("button").find((button) => button.textContent === "")
-    fireEvent.click(removeButton!)
+    // Act
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }))
 
     // Assert: the UI re-rendered off the updated store.
     await waitFor(() => expect(screen.queryByText("Trodes")).toBeNull())

--- a/src/components/builder/sections/gear/weapons/weaponsList.test.tsx
+++ b/src/components/builder/sections/gear/weapons/weaponsList.test.tsx
@@ -64,9 +64,8 @@ describe("WeaponsList", () => {
     })
     expect(screen.getByText("Ares Predator")).toBeDefined()
 
-    // Act: the remove icon button has no accessible name.
-    const removeButton = screen.getAllByRole("button").find((button) => button.textContent === "")
-    removeButton!.click()
+    // Act
+    screen.getByRole("button", { name: "Remove" }).click()
 
     // Assert: the UI re-rendered off the updated store.
     await waitFor(() => expect(screen.queryByText("Ares Predator")).toBeNull())

--- a/src/components/items/card/gearItemCard.tsx
+++ b/src/components/items/card/gearItemCard.tsx
@@ -1,4 +1,4 @@
-import { RiDeleteBin6Line } from "@remixicon/react"
+import { RiDeleteBin6Line, RiEdit2Line } from "@remixicon/react"
 import type { FC, ReactNode } from "react"
 
 import { AvailabilityChip } from "#/components/items/availability/availabilityChip.tsx"
@@ -13,27 +13,27 @@ import { ItemStatChip } from "./itemStatChip.tsx"
 interface GearItemCardProps extends Pick<ItemCardRootProps, "variant"> {
   availability?: AvailabilityInfo
   source?: SourceData
-  onClick: () => void
+  onEdit: () => void
   onRemove: () => void
   children: ReactNode
 }
 
 /**
  * Wrapper around ItemCard that appends the shared gear metadata footer:
- * availability chip, source reference, and delete action.
+ * availability chip, source reference, and edit/delete actions.
  *
  * Specific card components supply their unique stats as children.
  */
 export const GearItemCard: FC<GearItemCardProps> = ({
   availability,
   source,
-  onClick,
+  onEdit,
   onRemove,
   variant,
   children,
 }) => {
   return (
-    <ItemCard variant={variant} onClick={onClick}>
+    <ItemCard variant={variant}>
       {children}
 
       {availability && (
@@ -51,7 +51,11 @@ export const GearItemCard: FC<GearItemCardProps> = ({
         </ItemCard.Meta>
       )}
 
-      <ItemCard.Action type="icon" color="error" onClick={onRemove}>
+      <ItemCard.Action type="icon" aria-label="Edit" onClick={onEdit}>
+        <RiEdit2Line size={16} />
+      </ItemCard.Action>
+
+      <ItemCard.Action type="icon" color="error" aria-label="Remove" onClick={onRemove}>
         <RiDeleteBin6Line size={16} />
       </ItemCard.Action>
     </ItemCard>

--- a/src/components/items/card/itemCard.tsx
+++ b/src/components/items/card/itemCard.tsx
@@ -9,7 +9,6 @@ import { ItemCardRoot } from "./itemCardRoot.tsx"
 import { ItemCardTitle } from "./itemCardTitle.tsx"
 
 export interface ItemCardProps extends ItemCardRootProps {
-  onClick?: () => void
   children: ReactNode
 }
 

--- a/src/components/items/card/itemCardRoot.tsx
+++ b/src/components/items/card/itemCardRoot.tsx
@@ -1,8 +1,6 @@
 import Box from "@mui/material/Box"
-import ButtonBase from "@mui/material/ButtonBase"
 import Stack from "@mui/material/Stack"
-import type { SxProps } from "@mui/material/styles"
-import type { ElementType, FC, PropsWithChildren, ReactElement, ReactNode } from "react"
+import type { FC, ReactElement, ReactNode } from "react"
 import { Children, isValidElement } from "react"
 
 import { ItemCardAction } from "./itemCardAction.tsx"
@@ -12,7 +10,6 @@ import { ItemCardMeta } from "./itemCardMeta.tsx"
 import { ItemCardTitle } from "./itemCardTitle.tsx"
 
 export interface ItemCardRootProps {
-  onClick?: () => void
   children: ReactNode
   variant?: "borderless" | "outlined"
 }
@@ -23,7 +20,7 @@ function isElementType<TProps>(type: FC<TProps>) {
   }
 }
 
-export const ItemCardRoot: FC<ItemCardRootProps> = ({ onClick, children, variant = "outlined" }) => {
+export const ItemCardRoot: FC<ItemCardRootProps> = ({ children, variant = "outlined" }) => {
   const childArray = Children.toArray(children)
 
   const titleNode = childArray.find(isElementType(ItemCardTitle))
@@ -42,13 +39,9 @@ export const ItemCardRoot: FC<ItemCardRootProps> = ({ onClick, children, variant
 
   const hasMiddleRow = statMetas.length > 0 || sourceMetas.length > 0
 
-  const Wrapper: FC<PropsWithChildren<{ onClick?: () => void, sx: SxProps, component?: ElementType }>> = onClick ? ButtonBase : Box
-
   return (
     <Stack direction="column" sx={{ gap: 0 }}>
-      <Wrapper
-        component="div"
-        onClick={onClick}
+      <Box
         sx={{
           padding: 1,
           border: variant === "outlined" ? "1px solid" : "none",
@@ -76,7 +69,7 @@ export const ItemCardRoot: FC<ItemCardRootProps> = ({ onClick, children, variant
             {costMetas}
           </Stack>
 
-          <Stack direction="row" sx={{ gap: 0.5 }} onClick={(e) => e.stopPropagation()}>
+          <Stack direction="row" sx={{ gap: 0.5 }}>
             {iconActions}
           </Stack>
         </Stack>
@@ -97,17 +90,16 @@ export const ItemCardRoot: FC<ItemCardRootProps> = ({ onClick, children, variant
         )}
 
         {detailMetas.length > 0 && (
-          <Stack sx={{ width: "100%", gap: 1 }} onClick={(e) => e.stopPropagation()}>
+          <Stack sx={{ width: "100%", gap: 1 }}>
             {detailMetas}
           </Stack>
         )}
-      </Wrapper>
+      </Box>
 
       {buttonActions.length > 0 && (
         <Stack
           direction="row"
           sx={{ flexWrap: "wrap", border: "1px solid", borderColor: "divider" }}
-          onClick={(e) => e.stopPropagation()}
         >
           {buttonActions}
         </Stack>

--- a/src/components/items/genericItemCard.tsx
+++ b/src/components/items/genericItemCard.tsx
@@ -1,5 +1,5 @@
 import Typography from "@mui/material/Typography"
-import { RiDeleteBin6Line } from "@remixicon/react"
+import { RiDeleteBin6Line, RiEdit2Line } from "@remixicon/react"
 import type { FC } from "react"
 
 import { Nuyen } from "#/components/ui/nuyen.tsx"
@@ -35,7 +35,7 @@ export const GenericItemCard: FC<GenericItemCardProps> = ({
   const { availability, source, description } = item
 
   return (
-    <ItemCard variant={variant} onClick={onEdit}>
+    <ItemCard variant={variant}>
       <ItemCard.Title>{item.name}</ItemCard.Title>
 
       {(item.quantity ?? 1) > 1 && (
@@ -87,7 +87,11 @@ export const GenericItemCard: FC<GenericItemCardProps> = ({
         </ItemCard.Meta>
       )}
 
-      <ItemCard.Action type="icon" color="error" onClick={onRemove}>
+      <ItemCard.Action type="icon" aria-label="Edit" onClick={onEdit}>
+        <RiEdit2Line size={16} />
+      </ItemCard.Action>
+
+      <ItemCard.Action type="icon" color="error" aria-label="Remove" onClick={onRemove}>
         <RiDeleteBin6Line size={16} />
       </ItemCard.Action>
 

--- a/src/components/items/types/armor/armorItemCard.tsx
+++ b/src/components/items/types/armor/armorItemCard.tsx
@@ -1,5 +1,5 @@
 import Typography from "@mui/material/Typography"
-import { RiDeleteBin6Line } from "@remixicon/react"
+import { RiDeleteBin6Line, RiEdit2Line } from "@remixicon/react"
 import type { FC } from "react"
 
 import { AvailabilityChip } from "#/components/items/availability/availabilityChip.tsx"
@@ -20,7 +20,7 @@ export const ArmorItemCard: FC<ArmorItemCardProps> = ({ armor, onEdit, onRemove 
   const { availability, source } = armor
 
   return (
-    <ItemCard onClick={onEdit}>
+    <ItemCard>
       <ItemCard.Title>{armor.name}</ItemCard.Title>
 
       {armor.equipped && (
@@ -57,7 +57,11 @@ export const ArmorItemCard: FC<ArmorItemCardProps> = ({ armor, onEdit, onRemove 
         </ItemCard.Meta>
       )}
 
-      <ItemCard.Action type="icon" color="error" onClick={onRemove}>
+      <ItemCard.Action type="icon" aria-label="Edit" onClick={onEdit}>
+        <RiEdit2Line size={16} />
+      </ItemCard.Action>
+
+      <ItemCard.Action type="icon" color="error" aria-label="Remove" onClick={onRemove}>
         <RiDeleteBin6Line size={16} />
       </ItemCard.Action>
     </ItemCard>

--- a/src/components/items/types/credsticks/credstickCard.tsx
+++ b/src/components/items/types/credsticks/credstickCard.tsx
@@ -1,5 +1,6 @@
 import Chip from "@mui/material/Chip"
 import Typography from "@mui/material/Typography"
+import { RiEdit2Line } from "@remixicon/react"
 import type { FC } from "react"
 
 import { ItemCard } from "#/components/items/card/itemCard.tsx"
@@ -17,7 +18,7 @@ export const CredstickCard: FC<CredstickCardProps> = ({ credstick, onClick }) =>
   const fillPercent = maxBalance > 0 ? (credstick.balance / maxBalance) * 100 : 0
 
   return (
-    <ItemCard onClick={() => onClick(credstick)}>
+    <ItemCard>
       <ItemCard.Title>
         {credstick.name || CredstickTypeLabel[credstick.credstickType]}
       </ItemCard.Title>
@@ -38,6 +39,10 @@ export const CredstickCard: FC<CredstickCardProps> = ({ credstick, onClick }) =>
           {fillPercent.toFixed(0)}% full
         </Typography>
       </ItemCard.Meta>
+
+      <ItemCard.Action type="icon" aria-label="Edit" onClick={() => onClick(credstick)}>
+        <RiEdit2Line size={16} />
+      </ItemCard.Action>
     </ItemCard>
   )
 }

--- a/src/components/items/types/credsticks/credstickSection.test.tsx
+++ b/src/components/items/types/credsticks/credstickSection.test.tsx
@@ -57,7 +57,7 @@ describe("CredstickSection", () => {
     })
 
     // Act
-    fireEvent.click(screen.getByText("Street Cred"))
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }))
     await screen.findByRole("dialog", { name: "Edit Credstick" })
     fireEvent.click(screen.getByRole("button", { name: /withdraw/i }))
     fireEvent.click(await screen.findByRole("button", { name: /confirm withdrawal/i }))

--- a/src/components/items/types/devices/deviceItemCard.tsx
+++ b/src/components/items/types/devices/deviceItemCard.tsx
@@ -46,7 +46,7 @@ export const DeviceItemCard: FC<DeviceItemCardProps> = ({
     <GearItemCard
       availability={availability}
       source={source}
-      onClick={onEdit}
+      onEdit={onEdit}
       onRemove={onRemove}
     >
       <ItemCard.Title>{device.name}</ItemCard.Title>

--- a/src/components/items/types/devices/programItemCard.tsx
+++ b/src/components/items/types/devices/programItemCard.tsx
@@ -1,5 +1,5 @@
 import Typography from "@mui/material/Typography"
-import { RiDeleteBin6Line } from "@remixicon/react"
+import { RiDeleteBin6Line, RiEdit2Line } from "@remixicon/react"
 import type { FC } from "react"
 
 import { AvailabilityChip } from "#/components/items/availability/availabilityChip.tsx"
@@ -25,7 +25,7 @@ export const ProgramItemCard: FC<ProgramItemCardProps> = ({
   const { availability, source } = program
 
   return (
-    <ItemCard variant={variant} onClick={onEdit}>
+    <ItemCard variant={variant}>
       <ItemCard.Title>{program.name}</ItemCard.Title>
 
       <ItemCard.Meta type="cost">
@@ -59,7 +59,11 @@ export const ProgramItemCard: FC<ProgramItemCardProps> = ({
         </ItemCard.Meta>
       )}
 
-      <ItemCard.Action type="icon" color="error" onClick={onRemove}>
+      <ItemCard.Action type="icon" aria-label="Edit" onClick={onEdit}>
+        <RiEdit2Line size={16} />
+      </ItemCard.Action>
+
+      <ItemCard.Action type="icon" color="error" aria-label="Remove" onClick={onRemove}>
         <RiDeleteBin6Line size={16} />
       </ItemCard.Action>
     </ItemCard>

--- a/src/components/items/types/implants/implantItemCard.tsx
+++ b/src/components/items/types/implants/implantItemCard.tsx
@@ -1,5 +1,5 @@
 import Typography from "@mui/material/Typography"
-import { RiDeleteBin6Line } from "@remixicon/react"
+import { RiDeleteBin6Line, RiEdit2Line } from "@remixicon/react"
 import type { FC } from "react"
 
 import { AvailabilityChip } from "#/components/items/availability/availabilityChip.tsx"
@@ -65,7 +65,7 @@ export const ImplantItemCard: FC<ImplantItemCardProps> = ({
 
   return (
     <>
-      <ItemCard onClick={handleEdit} {...props}>
+      <ItemCard {...props}>
         <ItemCard.Title>{implant.name}</ItemCard.Title>
 
         <ItemCard.Meta type="cost">
@@ -118,7 +118,11 @@ export const ImplantItemCard: FC<ImplantItemCardProps> = ({
           </ItemCard.Meta>
         )}
 
-        <ItemCard.Action type="icon" color="error" onClick={handleRemove}>
+        <ItemCard.Action type="icon" aria-label="Edit" onClick={handleEdit}>
+          <RiEdit2Line size={16} />
+        </ItemCard.Action>
+
+        <ItemCard.Action type="icon" color="error" aria-label="Remove" onClick={handleRemove}>
           <RiDeleteBin6Line size={16} />
         </ItemCard.Action>
 

--- a/src/components/items/types/implants/implantItemList.test.tsx
+++ b/src/components/items/types/implants/implantItemList.test.tsx
@@ -76,8 +76,9 @@ describe("ImplantItemList", () => {
       </BuilderWrapperWithGear>,
     )
 
-    // Act
-    fireEvent.click(screen.getByText("Alphaware Upgrade"))
+    // Act: the accessory's Edit button is the second one rendered (after the parent's).
+    const editButtons = screen.getAllByRole("button", { name: "Edit" })
+    fireEvent.click(editButtons[1])
 
     // Assert
     const dialog = await screen.findByRole("dialog")
@@ -97,9 +98,8 @@ describe("ImplantItemList", () => {
     )
     expect(screen.getByText("Wired Reflexes 1")).toBeDefined()
 
-    // Act: the remove icon button has no accessible name.
-    const removeButton = screen.getAllByRole("button").find((button) => button.textContent === "")
-    fireEvent.click(removeButton!)
+    // Act
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }))
     fireEvent.click(await screen.findByRole("button", { name: "Remove Implant" }))
 
     // Assert: the UI re-rendered off the updated store.

--- a/src/components/items/types/licenses/licenseCard.tsx
+++ b/src/components/items/types/licenses/licenseCard.tsx
@@ -1,4 +1,4 @@
-import { RiDeleteBin6Line } from "@remixicon/react"
+import { RiDeleteBin6Line, RiEdit2Line } from "@remixicon/react"
 import type { FC, ReactNode } from "react"
 
 import { ItemCard } from "#/components/items/card/itemCard.tsx"
@@ -23,7 +23,7 @@ export const LicenseCard: FC<LicenseCardProps> = ({
   onDelete,
 }) => {
   return (
-    <ItemCard onClick={onClick}>
+    <ItemCard>
       <ItemCard.Title>{license.name}</ItemCard.Title>
 
       {slots?.trailingContent && (
@@ -34,15 +34,14 @@ export const LicenseCard: FC<LicenseCardProps> = ({
         <RatingChip rating={license.rating} />
       </ItemCard.Meta>
 
+      {onClick && (
+        <ItemCard.Action type="icon" aria-label="Edit" onClick={onClick}>
+          <RiEdit2Line size={16} />
+        </ItemCard.Action>
+      )}
+
       {onDelete && (
-        <ItemCard.Action
-          type="icon"
-          color="error"
-          onClick={(e) => {
-            e.stopPropagation()
-            onDelete()
-          }}
-        >
+        <ItemCard.Action type="icon" color="error" aria-label="Remove" onClick={onDelete}>
           <RiDeleteBin6Line size={16} />
         </ItemCard.Action>
       )}

--- a/src/components/items/types/licenses/sinCard.tsx
+++ b/src/components/items/types/licenses/sinCard.tsx
@@ -1,4 +1,4 @@
-import { RiDeleteBin6Line } from "@remixicon/react"
+import { RiDeleteBin6Line, RiEdit2Line } from "@remixicon/react"
 import type { FC, ReactNode } from "react"
 
 import { ItemCard } from "#/components/items/card/itemCard.tsx"
@@ -25,7 +25,7 @@ export const SinCard: FC<SinCardProps> = ({
   children,
 }) => {
   return (
-    <ItemCard onClick={onClick}>
+    <ItemCard>
       <ItemCard.Title>{sin.name}</ItemCard.Title>
 
       {slots?.trailingContent && (
@@ -36,15 +36,14 @@ export const SinCard: FC<SinCardProps> = ({
         <RatingChip rating={sin.rating} />
       </ItemCard.Meta>
 
+      {onClick && (
+        <ItemCard.Action type="icon" aria-label="Edit" onClick={onClick}>
+          <RiEdit2Line size={16} />
+        </ItemCard.Action>
+      )}
+
       {onDelete && (
-        <ItemCard.Action
-          type="icon"
-          color="error"
-          onClick={(e) => {
-            e.stopPropagation()
-            onDelete()
-          }}
-        >
+        <ItemCard.Action type="icon" color="error" aria-label="Remove" onClick={onDelete}>
           <RiDeleteBin6Line size={16} />
         </ItemCard.Action>
       )}

--- a/src/components/items/types/licenses/sinsAndLicensesSection.test.tsx
+++ b/src/components/items/types/licenses/sinsAndLicensesSection.test.tsx
@@ -46,9 +46,8 @@ describe("SinsAndLicensesSection", () => {
     })
     expect(screen.getByText("National ID (Fake)")).toBeDefined()
 
-    // Act: the delete icon button has no accessible name.
-    const removeButton = screen.getAllByRole("button").find((button) => button.textContent === "")
-    fireEvent.click(removeButton!)
+    // Act
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }))
 
     // Assert: the UI re-rendered off the updated store (SIN with no licenses removes without confirming).
     await waitFor(() => expect(screen.queryByText("National ID (Fake)")).toBeNull())

--- a/src/components/items/types/vehicles/vehicleItemCard.tsx
+++ b/src/components/items/types/vehicles/vehicleItemCard.tsx
@@ -40,7 +40,7 @@ export const VehicleItemCard: FC<VehicleItemCardProps> = ({
     <GearItemCard
       availability={availability}
       source={source}
-      onClick={onEdit}
+      onEdit={onEdit}
       onRemove={onRemove}
     >
       <ItemCard.Title>{vehicle.name}</ItemCard.Title>

--- a/src/components/items/types/vehicles/vehiclesList.test.tsx
+++ b/src/components/items/types/vehicles/vehiclesList.test.tsx
@@ -72,9 +72,8 @@ describe("VehiclesList", () => {
     })
     expect(screen.getByText("Suzuki Mirage")).toBeDefined()
 
-    // Act: the remove icon button has no accessible name.
-    const removeButton = screen.getAllByRole("button").find((button) => button.textContent === "")
-    fireEvent.click(removeButton!)
+    // Act
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }))
 
     // Assert: the UI re-rendered off the updated store.
     await waitFor(() => expect(screen.queryByText("Suzuki Mirage")).toBeNull())

--- a/src/components/items/types/weapons/weaponItemCard.tsx
+++ b/src/components/items/types/weapons/weaponItemCard.tsx
@@ -36,7 +36,7 @@ export const WeaponItemCard: FC<WeaponItemCardProps> = ({
     <GearItemCard
       availability={availability}
       source={source}
-      onClick={onEdit}
+      onEdit={onEdit}
       onRemove={onRemove}
     >
       <ItemCard.Title>{weapon.name}</ItemCard.Title>

--- a/src/components/runner/magician/spirits/spiritItemCard.tsx
+++ b/src/components/runner/magician/spirits/spiritItemCard.tsx
@@ -35,7 +35,7 @@ export const SpiritItemCard: FC<SpiritItemCardProps> = ({ spirit, onEdit, onRemo
   const registry = SpiritRegistry[spirit.spiritType]
 
   return (
-    <ItemCard onClick={onEdit}>
+    <ItemCard>
       <ItemCard.Title>
         <Stack direction="row" sx={{ alignItems: "baseline", gap: 1 }}>
           <Typography variant="body1" sx={{ fontWeight: "bold" }}>{title}</Typography>


### PR DESCRIPTION
## Summary
- Every item card previously made its whole body clickable to open the edit dialog (`ItemCard`/`ItemCardRoot` wrapped the card in a `ButtonBase` when an `onClick` was passed). This was ambiguous next to the delete/action icon buttons and had no accessible affordance.
- Added an explicit Edit icon button (`RiEdit2Line`, `aria-label="Edit"`) alongside the existing Remove button on every item card: generic items, armor, weapons/devices/vehicles (via the shared `GearItemCard` wrapper), programs, implants, licenses, SINs, and credsticks.
- Removed the `onClick` prop entirely from `ItemCardRootProps`/`ItemCardProps` and dropped the `ButtonBase`/`stopPropagation` plumbing in `ItemCardRoot` now that nothing wraps the card body in a click target.
- Renamed `GearItemCardProps.onClick` to `onEdit` for clarity now that it only ever wires the new edit button.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run` (755 passed) — updated tests that relied on clicking card text or on being-the-only-icon-button-with-no-name to instead target the buttons by their new `Edit`/`Remove` accessible names.
- [x] `npx eslint` on all touched files

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4DaxpRwKjcj5h6P7QEmwE)_