### PR TITLE
DicePool: show penalties in the ledger, add type-based color coding

### DIFF
--- a/src/components/system/damage/resistanceDicePools.test.tsx
+++ b/src/components/system/damage/resistanceDicePools.test.tsx
@@ -53,9 +53,10 @@ describe("MeleeDodgeDicePool", () => {
     // Arrange / Act
     const view = renderWithRunner(<MeleeDodgeDicePool />)
 
-    // Assert
-    expect(view.getAllByText("Defaulting")).toHaveLength(1)
-    expect(view.getAllByText("-1")).toHaveLength(1)
+    // Assert: DicePool renders each penalty group twice — once as an
+    // always-visible chip, once as its own line in the expanded ledger.
+    expect(view.getAllByText("Defaulting")).toHaveLength(2)
+    expect(view.getAllByText("-1")).toHaveLength(2)
   })
 
   it("shows no defaulting entry when dodge is trained", () => {
@@ -74,9 +75,9 @@ describe("MeleeFullDodgeDicePool", () => {
     // Arrange / Act
     const view = renderWithRunner(<MeleeFullDodgeDicePool />)
 
-    // Assert
-    expect(view.getAllByText("Defaulting")).toHaveLength(1)
-    expect(view.getAllByText("-1")).toHaveLength(1)
+    // Assert: one defaulting group, shown twice (chip + ledger line).
+    expect(view.getAllByText("Defaulting")).toHaveLength(2)
+    expect(view.getAllByText("-1")).toHaveLength(2)
   })
 
   it("shows no defaulting entry when dodge is trained", () => {
@@ -95,8 +96,8 @@ describe("RangedFullDefenseDicePool", () => {
     // Arrange / Act
     const view = renderWithRunner(<RangedFullDefenseDicePool />)
 
-    // Assert
-    expect(view.getAllByText("Defaulting")).toHaveLength(1)
+    // Assert: one defaulting group, shown twice (chip + ledger line).
+    expect(view.getAllByText("Defaulting")).toHaveLength(2)
   })
 
   it("shows no defaulting entry when dodge is trained", () => {
@@ -115,8 +116,9 @@ describe("MeleeFullParryDicePool", () => {
     // Arrange / Act
     const view = renderWithRunner(<MeleeFullParryDicePool weaponSkill={SkillKey.blades} />)
 
-    // Assert
-    expect(view.getAllByText("Defaulting")).toHaveLength(2)
+    // Assert: two defaulting groups (weapon skill + dodge), each shown twice
+    // (chip + ledger line).
+    expect(view.getAllByText("Defaulting")).toHaveLength(4)
   })
 
   it("shows one defaulting entry when only dodge is untrained", () => {
@@ -128,8 +130,8 @@ describe("MeleeFullParryDicePool", () => {
       },
     )
 
-    // Assert
-    expect(view.getAllByText("Defaulting")).toHaveLength(1)
+    // Assert: one defaulting group, shown twice (chip + ledger line).
+    expect(view.getAllByText("Defaulting")).toHaveLength(2)
   })
 
   it("shows no defaulting entries when both weapon skill and dodge are trained", () => {
@@ -154,8 +156,9 @@ describe("MeleeFullBlockDicePool", () => {
     // Arrange / Act
     const view = renderWithRunner(<MeleeFullBlockDicePool />)
 
-    // Assert
-    expect(view.getAllByText("Defaulting")).toHaveLength(2)
+    // Assert: two defaulting groups (unarmed combat + dodge), each shown
+    // twice (chip + ledger line).
+    expect(view.getAllByText("Defaulting")).toHaveLength(4)
   })
 
   it("shows no defaulting entries when both skills are trained", () => {

--- a/src/components/system/dicePool/diceGroup.tsx
+++ b/src/components/system/dicePool/diceGroup.tsx
@@ -1,7 +1,11 @@
+export type DiceGroupType = "attribute" | "skill" | "bonus" | "defaulting" | "penalty"
+
 export interface DiceGroup {
   id?: string
   name: string
   size: number
+  type?: DiceGroupType
+  /** Explicit color override. Prefer `type` where the group fits one of the standard categories. */
   color?: string
 }
 

--- a/src/components/system/dicePool/dicePool.tsx
+++ b/src/components/system/dicePool/dicePool.tsx
@@ -11,9 +11,23 @@ import { useContext, useState } from "react"
 import { DiceTrayContext } from "#/components/dice/diceTrayContext.ts"
 import { DieFace } from "#/components/system/dice/dieFace.tsx"
 
-import type { DiceGroupList } from "./diceGroup.tsx"
+import type { DiceGroup, DiceGroupList, DiceGroupType } from "./diceGroup.tsx"
 import { isDiceGroup } from "./diceGroup.tsx"
 import { getPoolSize } from "./dicePoolData.tsx"
+
+const typeColors: Record<DiceGroupType, string> = {
+  attribute: "primary.main",
+  skill: "secondary.main",
+  bonus: "success.main",
+  defaulting: "warning.main",
+  penalty: "error.main",
+}
+
+function getGroupColor(group: DiceGroup): string {
+  if (group.color) return group.color
+  if (group.type) return typeColors[group.type]
+  return group.size < 0 ? typeColors.penalty : typeColors.bonus
+}
 
 interface DicePoolProps {
   name: string
@@ -27,7 +41,6 @@ export const DicePool: FC<DicePoolProps> = ({ name, groups }) => {
   const diceGroups = groups.flat().filter(isDiceGroup)
   const total = getPoolSize(diceGroups)
   const penalties = diceGroups.filter((group) => group.size < 0)
-  const contributions = diceGroups.filter((group) => group.size >= 0)
 
   return (
     <ButtonBase
@@ -83,34 +96,38 @@ export const DicePool: FC<DicePoolProps> = ({ name, groups }) => {
 
           {penalties.length > 0 && (
             <Stack direction="row" sx={{ flexWrap: "wrap", gap: 0.5 }}>
-              {penalties.map((group) => (
-                <Stack
-                  key={group.id ?? group.name}
-                  direction="row"
-                  sx={{
-                    gap: 0.5,
-                    paddingX: 0.75,
-                    paddingY: 0.25,
-                    border: "1px solid",
-                    borderColor: group.color ?? "error.main",
-                  }}
-                >
-                  <Typography
-                    variant="caption"
-                    component="span"
-                    sx={{ fontWeight: "bold", color: group.color ?? "error.main" }}
+              {penalties.map((group) => {
+                const groupColor = getGroupColor(group)
+
+                return (
+                  <Stack
+                    key={group.id ?? group.name}
+                    direction="row"
+                    sx={{
+                      gap: 0.5,
+                      paddingX: 0.75,
+                      paddingY: 0.25,
+                      border: "1px solid",
+                      borderColor: groupColor,
+                    }}
                   >
-                    {group.name}
-                  </Typography>
-                  <Typography
-                    variant="caption"
-                    component="span"
-                    sx={{ fontWeight: "bold", color: group.color ?? "error.main" }}
-                  >
-                    {group.size}
-                  </Typography>
-                </Stack>
-              ))}
+                    <Typography
+                      variant="caption"
+                      component="span"
+                      sx={{ fontWeight: "bold", color: groupColor }}
+                    >
+                      {group.name}
+                    </Typography>
+                    <Typography
+                      variant="caption"
+                      component="span"
+                      sx={{ fontWeight: "bold", color: groupColor }}
+                    >
+                      {group.size}
+                    </Typography>
+                  </Stack>
+                )
+              })}
             </Stack>
           )}
         </Stack>
@@ -118,18 +135,25 @@ export const DicePool: FC<DicePoolProps> = ({ name, groups }) => {
 
       <Collapse in={isOpen}>
         <Stack sx={{ gap: 0.5, paddingTop: 1 }} onClick={(event) => event.stopPropagation()}>
-          {contributions.map((group) => (
-            <Stack
-              key={group.id ?? group.name}
-              direction="row"
-              sx={{ justifyContent: "space-between" }}
-            >
-              <Typography variant="body2">{group.name}</Typography>
-              <Typography variant="body2" sx={{ fontWeight: "bold", fontVariantNumeric: "tabular-nums" }}>
-                {group.size}
-              </Typography>
-            </Stack>
-          ))}
+          {diceGroups.map((group) => {
+            const groupColor = getGroupColor(group)
+
+            return (
+              <Stack
+                key={group.id ?? group.name}
+                direction="row"
+                sx={{ justifyContent: "space-between" }}
+              >
+                <Typography variant="body2" sx={{ color: groupColor }}>{group.name}</Typography>
+                <Typography
+                  variant="body2"
+                  sx={{ fontWeight: "bold", fontVariantNumeric: "tabular-nums", color: groupColor }}
+                >
+                  {group.size}
+                </Typography>
+              </Stack>
+            )
+          })}
 
           <Divider />
 

--- a/src/components/system/dicePool/useDiceGroup.ts
+++ b/src/components/system/dicePool/useDiceGroup.ts
@@ -15,7 +15,7 @@ import type { DiceGroup } from "./diceGroup.tsx"
 
 export function useAttrDiceGroup(attrKey: AttributeKey): DiceGroup {
   const label = AttributeLabels[attrKey]
-  return { name: label, size: useAttrValue(attrKey) }
+  return { name: label, size: useAttrValue(attrKey), type: "attribute" }
 }
 
 export function useActiveSkillDiceGroup(skillKey: SkillKey): DiceGroup {
@@ -28,22 +28,22 @@ export function useActiveSkillDiceGroup(skillKey: SkillKey): DiceGroup {
     .reduce((sum, e) => sum + e.value, 0)
 
   if (skillRating >= 1) {
-    return { id: groupId, name: skillKey, size: skillRating + totalMod }
+    return { id: groupId, name: skillKey, size: skillRating + totalMod, type: "skill" }
   }
 
-  return { id: groupId, name: skillKey, size: totalMod }
+  return { id: groupId, name: skillKey, size: totalMod, type: "skill" }
 }
 
 export function useWoundDiceGroup(): DiceGroup | null {
   const woundMod = useWoundModifier()
   if (woundMod === 0) return null
-  return { name: "Wound", size: woundMod * -1, color: "error.main" }
+  return { name: "Wound", size: woundMod * -1, type: "penalty" }
 }
 
 export function useEncumbranceDiceGroup(): DiceGroup | null {
   const { penalty } = useEncumbrance()
   if (penalty === 0) return null
-  return { name: "Encumbrance", size: penalty * -1, color: "warning.main" }
+  return { name: "Encumbrance", size: penalty * -1, type: "penalty" }
 }
 
 export function useDefaultingDiceGroup(skillKey: SkillKey): DiceGroup | null {
@@ -51,5 +51,5 @@ export function useDefaultingDiceGroup(skillKey: SkillKey): DiceGroup | null {
   const { defaultable } = skillList[skillKey]
   const isDefaulted = skillRating === 0 && (defaultable ?? true)
   if (!isDefaulted) return null
-  return { id: `${skillKey}-defaulting`, name: "Defaulting", size: -1, color: "warning.main" }
+  return { id: `${skillKey}-defaulting`, name: "Defaulting", size: -1, type: "defaulting" }
 }


### PR DESCRIPTION
## Summary

Follow-up to #373 (merged), addressing two review notes on the new `DicePool`:

- **Penalties now show in the ledger.** The expanded ledger previously only listed non-negative groups, so Defaulting/Wound/Encumbrance never appeared once expanded — only as the always-visible collapsed chip. The ledger now lists every contributing group.
- **Type-based color coding.** Adds a `DiceGroup.type` field (`attribute` / `skill` / `bonus` / `defaulting` / `penalty`) that both the collapsed chip and the ledger rows resolve to a theme color: `primary` / `secondary` / `success` / `warning` / `error` respectively. The existing `color` field is still honored as an explicit override, and untyped groups fall back to a sign-based bonus/penalty color, so ad-hoc groups built elsewhere in the app (weapon/defense calculators, legwork dialog, etc.) keep working unchanged.
- `useAttrDiceGroup`, `useActiveSkillDiceGroup`, `useWoundDiceGroup`, `useEncumbranceDiceGroup`, and `useDefaultingDiceGroup` now set `type` instead of an ad-hoc `color` string (Encumbrance moves from warning to error, matching the "penalty" category — Defaulting keeps its own warning color as a distinct category).

## Test plan

- [x] `yarn tsc` — clean
- [x] `yarn lint` — clean
- [x] `yarn test:unit` — 758/758 passing. `resistanceDicePools.test.tsx` assertions updated: each penalty group now renders twice (chip + ledger line) instead of once, which is the intended new behavior.
- [x] Manually re-verified rendering logic and confirmed (via `git stash` against a clean checkout of the base branch) that an unrelated dialog-navigation issue I hit while poking at this in a browser is pre-existing on `shadowrun-4e` and not caused by this change — flagging separately, not fixed here since it's out of scope.

---
_Generated by [Claude Code](https://claude.ai/code/session_018nWPjYCN5zphpvb5cGnfWd)_