### PR TITLE
Fix armor damage boxes not wrapping in the equipped armor card

### DIFF
--- a/src/components/items/types/armor/equippedArmorCard.tsx
+++ b/src/components/items/types/armor/equippedArmorCard.tsx
@@ -44,6 +44,7 @@ export const EquippedArmorCard: FC<EquippedArmorCardProps> = ({ armor, onDamageC
                     max={armor.ballistic}
                     current={damage.ballistic}
                     woundInterval={armor.ballistic + 1}
+                    columns={Math.min(armor.ballistic, 4)}
                     onChange={(value) => onDamageChange({ ...damage, ballistic: value })}
                   />
                 </Grid>
@@ -55,6 +56,7 @@ export const EquippedArmorCard: FC<EquippedArmorCardProps> = ({ armor, onDamageC
                     max={armor.impact}
                     current={damage.impact}
                     woundInterval={armor.impact + 1}
+                    columns={Math.min(armor.impact, 4)}
                     onChange={(value) => onDamageChange({ ...damage, impact: value })}
                   />
                 </Grid>

--- a/src/components/system/damage/damageTrack.tsx
+++ b/src/components/system/damage/damageTrack.tsx
@@ -12,6 +12,14 @@ interface DamageTrackProps {
   onChange: (value: number) => void
   allowOverflow?: boolean
   woundInterval?: number
+  /**
+   * Number of grid columns to lay cells out in. Defaults to `woundInterval`,
+   * which groups cells into rows that line up with wound markers. Pass this
+   * explicitly when `woundInterval` doesn't reflect a sensible row width
+   * (e.g. it's been inflated to suppress markers), so cells still wrap
+   * instead of being squeezed below their minimum width.
+   */
+  columns?: number
 }
 
 export default function DamageTrack({
@@ -21,6 +29,7 @@ export default function DamageTrack({
   onChange,
   allowOverflow,
   woundInterval = 3,
+  columns,
 }: DamageTrackProps) {
   let numCells = Math.max(max, current)
   if (allowOverflow && current >= max) {
@@ -37,7 +46,7 @@ export default function DamageTrack({
       <Box
         sx={{
           display: "grid",
-          gridTemplateColumns: `repeat(${woundInterval}, 1fr)`,
+          gridTemplateColumns: `repeat(${columns ?? woundInterval}, 1fr)`,
           gap: 0.5,
         }}
       >


### PR DESCRIPTION
## Summary
- The equipped armor card's Ballistic/Impact damage grids set `woundInterval` to `max + 1` to suppress wound markers, which also set the CSS grid's column count. That meant the grid always defined as many (or more) columns as there were cells, so all boxes were forced onto a single row inside the half-width card — squeezing them below their natural minimum width instead of wrapping.
- Added an explicit `columns` prop to `DamageTrack`, decoupled from `woundInterval` (which now only affects wound-marker placement), and used it in `EquippedArmorCard` so damage boxes wrap onto additional rows once they don't fit.

## Test plan
- [x] `tsc --noEmit`
- [x] `vitest run` for the armor and damage components (38 tests passing)
- [x] `eslint` on changed files
- [x] Verified visually in a browser against the `Armored Jacket` (B:8/I:6) fixture — boxes now wrap into multiple rows instead of overlapping/squeezing into a single row

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfwhAf2aC4JNHqFPato5QF)_