### PR TITLE
Fix dialog-open cascading back-navigation past the browser-back guard

### DIFF
--- a/src/components/ui/dialog/useCloseOnBrowserBack.test.tsx
+++ b/src/components/ui/dialog/useCloseOnBrowserBack.test.tsx
@@ -1,11 +1,12 @@
 import {
+  createBrowserHistory,
   createMemoryHistory,
   createRootRoute,
   createRouter,
   RouterProvider,
 } from "@tanstack/react-router"
 import { act, fireEvent, render, screen } from "@testing-library/react"
-import { useState } from "react"
+import { StrictMode, useState } from "react"
 import { describe, expect, it } from "vitest"
 
 import { useCloseOnBrowserBack } from "./useCloseOnBrowserBack.ts"
@@ -41,6 +42,10 @@ describe("useCloseOnBrowserBack", () => {
       fireEvent.click(screen.getByRole("button", { name: "close" }))
     })
 
+    // The pop is deferred by a tick (so a same-tick remount can cancel it
+    // instead of racing it — see useCloseOnBrowserBack.ts), so wait for it.
+    await act(() => new Promise((resolve) => setTimeout(resolve, 0)))
+
     // Closing by another means (not the back button) steps back off that
     // entry again rather than leaving it in history.
     expect(screen.getByText("closed")).toBeTruthy()
@@ -75,5 +80,43 @@ describe("useCloseOnBrowserBack", () => {
     await act(async () => {})
 
     expect(history.length).toBe(1)
+  })
+
+  it("survives a same-tick unmount/remount (React StrictMode) without cascading back navigation", async () => {
+    // StrictMode synchronously mounts, cleans up, and remounts every effect
+    // once in dev. This only reproduces the original bug against a real
+    // browser history: it batches pushState onto a microtask while back()
+    // navigates immediately, so it's the combination that raced — a memory
+    // history's push/back are both synchronous and wouldn't race here.
+    window.history.pushState(null, "", "/three")
+    const history = createBrowserHistory({ window })
+    const router = createRouter({
+      routeTree: createRootRoute({ component: TestDialog }),
+      history,
+    })
+    render(
+      <StrictMode>
+        <RouterProvider router={router} />
+      </StrictMode>,
+    )
+    await act(async () => {})
+    // Let any deferred pop from the StrictMode "practice" unmount resolve.
+    await act(() => new Promise((resolve) => setTimeout(resolve, 0)))
+
+    expect(screen.getByText("open")).toBeTruthy()
+    // Exactly one guard entry on top of the real route history — not walked
+    // back through earlier real navigation.
+    expect(history.location.pathname).toBe("/three")
+    expect((history.location.state as { dialogBackGuard?: boolean }).dialogBackGuard).toBe(true)
+
+    await act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "close" }))
+    })
+    await act(() => new Promise((resolve) => setTimeout(resolve, 0)))
+
+    // Closing steps back exactly one entry, landing on the real prior page.
+    expect(screen.getByText("closed")).toBeTruthy()
+    expect(history.location.pathname).toBe("/three")
+    expect((history.location.state as { dialogBackGuard?: boolean }).dialogBackGuard).toBeUndefined()
   })
 })

--- a/src/components/ui/dialog/useCloseOnBrowserBack.ts
+++ b/src/components/ui/dialog/useCloseOnBrowserBack.ts
@@ -1,6 +1,13 @@
 import { useRouter } from "@tanstack/react-router"
 import { useEffect, useRef } from "react"
 
+interface GuardState {
+  /** Whether a guard entry is currently believed to be on top of history. */
+  pushed: boolean
+  /** Pending, cancelable pop scheduled by the most recent cleanup. */
+  popTimer: ReturnType<typeof setTimeout> | undefined
+}
+
 /**
  * Pushes a history entry while the dialog is open so that pressing the
  * browser's back button closes it instead of navigating away. The entry is
@@ -15,6 +22,7 @@ import { useEffect, useRef } from "react"
 export function useCloseOnBrowserBack(open: boolean, onClose: (() => void) | undefined): void {
   const router = useRouter({ warn: false })
   const onCloseRef = useRef(onClose)
+  const guardRef = useRef<GuardState>({ pushed: false, popTimer: undefined })
 
   useEffect(() => {
     onCloseRef.current = onClose
@@ -23,22 +31,52 @@ export function useCloseOnBrowserBack(open: boolean, onClose: (() => void) | und
   useEffect(() => {
     if (!open || !onCloseRef.current || !router) return
 
-    let guardPushed = true
-    router.history.push(router.history.location.href, { dialogBackGuard: true })
+    const guard = guardRef.current
+
+    // A pop scheduled by a just-prior cleanup (see below) is still pending —
+    // this setup is the "remount" half of a same-tick unmount/remount (React
+    // StrictMode's dev-only double-invoke, or a fast remount elsewhere), not
+    // a real close followed by a real reopen. Cancel it instead of letting
+    // both run: the guard entry it would pop is still the one already on top
+    // of history, so popping it now would be a leftover of the previous
+    // instance, not this one.
+    if (guard.popTimer !== undefined) {
+      clearTimeout(guard.popTimer)
+      guard.popTimer = undefined
+    }
+
+    if (!guard.pushed) {
+      router.history.push(router.history.location.href, { dialogBackGuard: true })
+      // TanStack's browser history batches the real pushState onto a
+      // microtask (to smooth out rapid calls). Force it to land synchronously
+      // so the entry actually exists in real browser history before anything
+      // else (e.g. the pop below) can act on it.
+      router.history.flush()
+      guard.pushed = true
+    }
 
     const unsubscribe = router.history.subscribe(({ action }) => {
-      if (guardPushed && action.type === "BACK") {
-        guardPushed = false
+      if (guard.pushed && action.type === "BACK") {
+        guard.pushed = false
         onCloseRef.current?.()
       }
     })
 
     return () => {
       unsubscribe()
-      if (guardPushed) {
-        guardPushed = false
-        router.history.back()
-      }
+      // Unlike push/replace, `.back()` triggers a real (asynchronously
+      // observed) browser navigation that can't be forced to land
+      // synchronously. Popping right here would race a same-tick remount's
+      // setup, which pushes its own entry before this pop's navigation has
+      // actually happened — leaving an orphaned entry behind. Defer the pop
+      // one tick so a same-tick setup (above) can cancel it instead.
+      guard.popTimer = setTimeout(() => {
+        guard.popTimer = undefined
+        if (guard.pushed) {
+          guard.pushed = false
+          router.history.back()
+        }
+      }, 0)
     }
   }, [open, router])
 }


### PR DESCRIPTION
## Summary

Opening a dialog (e.g. clicking a skill row on the Skills page) could trigger a cascade of back-navigations through route history, ending back at `/`, with the dialog never appearing.

**Root cause:** `useCloseOnBrowserBack` pushes a guard history entry on open and pops it via `history.back()` on the effect's cleanup. TanStack's browser history batches the real `pushState` onto a microtask (to smooth out rapid calls), while `.back()` triggers a real browser navigation immediately. When an effect's setup and cleanup run back-to-back in the same synchronous tick — React StrictMode's dev-only mount → cleanup → mount, or any other fast remount — `.back()` fired before the guard entry had actually landed in real browser history, so it popped a genuine prior route entry instead. Repeating on each such cycle produced the observed cascade back through `/skills → /about → /`.

**Fix (`src/components/ui/dialog/useCloseOnBrowserBack.ts`):**
- Force the guard push to flush synchronously (`router.history.flush()`) so the entry actually exists in real browser history before anything can act on it.
- Track guard state in a ref that survives across a same-tick unmount/remount, and defer the pop by one tick (`setTimeout(0)`) so a same-tick remount can *cancel* the pending pop instead of racing it. A plain immediate pop can't be used once the push is forced synchronous, since `.back()` itself can't be forced synchronous — deferring avoids leaving orphaned entries in history.

Verified against the reported Playwright repro (dialog now opens, URL stays on `/skills`) and against Escape-close / real-browser-back-close, both of which now land back on exactly the expected page rather than overshooting.

## Test plan
- [x] Added a regression test using `createBrowserHistory` + `<StrictMode>` that reproduces the original race (fails without the fix, passes with it) — memory history doesn't exhibit the async/sync mismatch, so a real browser history was needed to catch this.
- [x] Updated the existing "pops it again on normal close" test to await the now-deferred pop.
- [x] `npx vitest run` — 759/759 tests pass.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on touched files — clean.
- [x] Manually reproduced the original bug with Playwright against `origin/shadowrun-4e`, then confirmed the fix resolves it end-to-end (dialog opens, URL stays on `/skills`), plus verified Escape-close and real browser-back-close both still work correctly.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_018hHKxZgZLfpnXdE4Cxdctd)_