### PR TITLE
Add runner edit mode with tabbed layout and roster kebab menu

### DIFF
--- a/src/components/builder/buildPoints/hooks/useBuildPointsAlerts.ts
+++ b/src/components/builder/buildPoints/hooks/useBuildPointsAlerts.ts
@@ -6,11 +6,11 @@ import { useBuilderBuildPointsApi } from "./useBuildPointsApi.ts"
 
 export const useBuildPointsAlerts = (): AlertInfo[] => {
   const summary = useBuilderBuildPointsApi()
-  const { isEdit } = useEditorMode()
+  const editorMode = useEditorMode()
 
   const alerts: AlertInfo[] = []
 
-  if (summary.remaining > BuilderConfig.buildPoints.unspentWarningThreshold && !isEdit) {
+  if (summary.remaining > BuilderConfig.buildPoints.unspentWarningThreshold && !editorMode.isEdit) {
     alerts.push({
       section: "Build Points",
       severity: "warning",

--- a/src/components/builder/buildPoints/hooks/useBuildPointsAlerts.ts
+++ b/src/components/builder/buildPoints/hooks/useBuildPointsAlerts.ts
@@ -1,14 +1,16 @@
 import { BuilderConfig } from "#/components/builder/builderConfig.ts"
 import type { AlertInfo } from "#/components/ui/alerts/alertInfo.ts"
+import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
 
 import { useBuilderBuildPointsApi } from "./useBuildPointsApi.ts"
 
 export const useBuildPointsAlerts = (): AlertInfo[] => {
   const summary = useBuilderBuildPointsApi()
+  const isEditMode = useIsEditMode()
 
   const alerts: AlertInfo[] = []
 
-  if (summary.remaining > BuilderConfig.buildPoints.unspentWarningThreshold) {
+  if (summary.remaining > BuilderConfig.buildPoints.unspentWarningThreshold && !isEditMode) {
     alerts.push({
       section: "Build Points",
       severity: "warning",

--- a/src/components/builder/buildPoints/hooks/useBuildPointsAlerts.ts
+++ b/src/components/builder/buildPoints/hooks/useBuildPointsAlerts.ts
@@ -10,7 +10,7 @@ export const useBuildPointsAlerts = (): AlertInfo[] => {
 
   const alerts: AlertInfo[] = []
 
-  if (summary.remaining > BuilderConfig.buildPoints.unspentWarningThreshold && !editorMode.isEdit) {
+  if (summary.remaining > BuilderConfig.buildPoints.unspentWarningThreshold && editorMode.isBuilder) {
     alerts.push({
       section: "Build Points",
       severity: "warning",

--- a/src/components/builder/buildPoints/hooks/useBuildPointsAlerts.ts
+++ b/src/components/builder/buildPoints/hooks/useBuildPointsAlerts.ts
@@ -1,16 +1,16 @@
 import { BuilderConfig } from "#/components/builder/builderConfig.ts"
 import type { AlertInfo } from "#/components/ui/alerts/alertInfo.ts"
-import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
+import { useEditorMode } from "#/stores/builder/editorMode.tsx"
 
 import { useBuilderBuildPointsApi } from "./useBuildPointsApi.ts"
 
 export const useBuildPointsAlerts = (): AlertInfo[] => {
   const summary = useBuilderBuildPointsApi()
-  const isEditMode = useIsEditMode()
+  const { isEdit } = useEditorMode()
 
   const alerts: AlertInfo[] = []
 
-  if (summary.remaining > BuilderConfig.buildPoints.unspentWarningThreshold && !isEditMode) {
+  if (summary.remaining > BuilderConfig.buildPoints.unspentWarningThreshold && !isEdit) {
     alerts.push({
       section: "Build Points",
       severity: "warning",

--- a/src/components/builder/nav/builderTabs.tsx
+++ b/src/components/builder/nav/builderTabs.tsx
@@ -1,0 +1,27 @@
+import Tab from "@mui/material/Tab"
+import Tabs from "@mui/material/Tabs"
+import type { FC } from "react"
+
+import type { BuilderSectionId } from "#/components/builder/sections/builderSectionId.ts"
+import { builderSectionOrder, builderSections } from "#/components/builder/sections/builderSectionId.ts"
+
+interface BuilderTabsProps {
+  value: BuilderSectionId
+  onChange: (value: BuilderSectionId) => void
+}
+
+export const BuilderTabs: FC<BuilderTabsProps> = ({ value, onChange }) => {
+  return (
+    <Tabs
+      value={value}
+      onChange={(_, next: BuilderSectionId) => onChange(next)}
+      variant="scrollable"
+      allowScrollButtonsMobile
+      scrollButtons="auto"
+    >
+      {builderSectionOrder.map((id) => (
+        <Tab key={id} label={builderSections[id].label} value={id} />
+      ))}
+    </Tabs>
+  )
+}

--- a/src/components/builder/runnerBuilder.tsx
+++ b/src/components/builder/runnerBuilder.tsx
@@ -5,6 +5,7 @@ import type { FC } from "react"
 import { useState } from "react"
 
 import { ExportRunnerButton } from "#/components/runner/exportImport/exportRunnerButton.tsx"
+import { EditorModeProvider } from "#/stores/builder/editorMode.tsx"
 import type { RunnerData } from "#/system/runnerData.ts"
 
 import { AllBuilderAlerts } from "./alerts/allBuilderAlerts.tsx"
@@ -47,56 +48,58 @@ export const RunnerBuilder: FC<RunnerFormProps> = ({ runner }) => {
 
   return (
     <BuilderStoreProvider runnerStore={runnerStore} builderStore={builderStore}>
-      <Stack>
-        <Stack
-          sx={{
-            opacity: isBpPanelExpanded ? 0.6 : 1,
-            transition: "opacity 0.2s ease",
-            pointerEvents: isBpPanelExpanded ? "none" : "auto",
-          }}
-        >
-          <Stack direction="row" sx={{ justifyContent: "space-between", gap: 1 }}>
-            <Button
-              variant="outlined"
-              color="inherit"
-              size="small"
-              onClick={handleCancel}
-            >
-              Cancel
-            </Button>
-            <Stack direction="row" sx={{ gap: 1 }}>
-              <BuilderImportButton onImport={loadRunner} />
-              <ExportRunnerButton />
+      <EditorModeProvider mode="builder">
+        <Stack>
+          <Stack
+            sx={{
+              opacity: isBpPanelExpanded ? 0.6 : 1,
+              transition: "opacity 0.2s ease",
+              pointerEvents: isBpPanelExpanded ? "none" : "auto",
+            }}
+          >
+            <Stack direction="row" sx={{ justifyContent: "space-between", gap: 1 }}>
               <Button
                 variant="outlined"
-                color="warning"
+                color="inherit"
                 size="small"
-                onClick={() => reset()}
+                onClick={handleCancel}
               >
-                Reset
+                Cancel
               </Button>
+              <Stack direction="row" sx={{ gap: 1 }}>
+                <BuilderImportButton onImport={loadRunner} />
+                <ExportRunnerButton />
+                <Button
+                  variant="outlined"
+                  color="warning"
+                  size="small"
+                  onClick={() => reset()}
+                >
+                  Reset
+                </Button>
+              </Stack>
             </Stack>
+
+            <ProfileBuilderSection />
+            <BiologyBuilderSection />
+            <AttributesBuilderSection />
+            <QualitiesBuilderSection />
+            <ActiveSkillsBuilderSection />
+            <KnowledgeSkillsBuilderSection />
+            <AdeptPowersBuilderSection />
+            <SpellsBuilderSection />
+            <ComplexFormsBuilderSection />
+            <SpritesBuilderSection />
+            <GearBuilderSection />
+            <ContactsBuilderSection />
           </Stack>
 
-          <ProfileBuilderSection />
-          <BiologyBuilderSection />
-          <AttributesBuilderSection />
-          <QualitiesBuilderSection />
-          <ActiveSkillsBuilderSection />
-          <KnowledgeSkillsBuilderSection />
-          <AdeptPowersBuilderSection />
-          <SpellsBuilderSection />
-          <ComplexFormsBuilderSection />
-          <SpritesBuilderSection />
-          <GearBuilderSection />
-          <ContactsBuilderSection />
+          <BpSummaryFooter onExpandedChange={setIsBpPanelExpanded} />
+
+          <AllBuilderAlerts />
+          <SaveRunnerButton />
         </Stack>
-
-        <BpSummaryFooter onExpandedChange={setIsBpPanelExpanded} />
-
-        <AllBuilderAlerts />
-        <SaveRunnerButton />
-      </Stack>
+      </EditorModeProvider>
     </BuilderStoreProvider>
   )
 }

--- a/src/components/builder/runnerEditor.tsx
+++ b/src/components/builder/runnerEditor.tsx
@@ -7,6 +7,7 @@ import { useState } from "react"
 import { ExportRunnerButton } from "#/components/runner/exportImport/exportRunnerButton.tsx"
 import { SwipeSurface } from "#/components/ui/swipeSurface.tsx"
 import { NumberUtils } from "#/lib/numberUtils.ts"
+import { EditModeContext } from "#/stores/builder/editMode.context.ts"
 import type { RunnerData } from "#/system/runnerData.ts"
 
 import { AllBuilderAlerts } from "./alerts/allBuilderAlerts.tsx"
@@ -30,7 +31,6 @@ import {
 import { SpritesBuilderSection } from "./sections/resources/technomancer/sprites/spritesBuilderSection.tsx"
 import { ActiveSkillsBuilderSection } from "./sections/skills/activeSkills/activeSkillsBuilderSection.tsx"
 import { KnowledgeSkillsBuilderSection } from "./sections/skills/knowledgeSkills/knowledgeSkillsBuilderSection.tsx"
-import { BpSummaryFooter } from "./sections/summary/bpSummaryFooter.tsx"
 
 interface RunnerEditorProps {
   runner: RunnerData
@@ -52,7 +52,6 @@ const sectionComponents: Record<BuilderSectionId, FC> = {
 }
 
 export const RunnerEditor: FC<RunnerEditorProps> = ({ runner }) => {
-  const [isBpPanelExpanded, setIsBpPanelExpanded] = useState(false)
   const [activeSection, setActiveSection] = useState<BuilderSectionId>(BuilderSectionId.profile)
   const { runnerStore, builderStore, loadRunner } = useBuilderStores(runner)
   const navigate = useNavigate()
@@ -81,14 +80,8 @@ export const RunnerEditor: FC<RunnerEditorProps> = ({ runner }) => {
 
   return (
     <BuilderStoreProvider runnerStore={runnerStore} builderStore={builderStore}>
-      <Stack>
-        <Stack
-          sx={{
-            opacity: isBpPanelExpanded ? 0.6 : 1,
-            transition: "opacity 0.2s ease",
-            pointerEvents: isBpPanelExpanded ? "none" : "auto",
-          }}
-        >
+      <EditModeContext.Provider value={true}>
+        <Stack>
           <Stack direction="row" sx={{ justifyContent: "space-between", gap: 1 }}>
             <Button
               variant="outlined"
@@ -117,13 +110,11 @@ export const RunnerEditor: FC<RunnerEditorProps> = ({ runner }) => {
           <SwipeSurface onSwipeRightToLeft={nextSection} onSwipeLeftToRight={prevSection}>
             <ActiveSection />
           </SwipeSurface>
+
+          <AllBuilderAlerts />
+          <SaveRunnerButton requireValid={false} />
         </Stack>
-
-        <BpSummaryFooter onExpandedChange={setIsBpPanelExpanded} onSelectSection={setActiveSection} />
-
-        <AllBuilderAlerts />
-        <SaveRunnerButton requireValid={false} />
-      </Stack>
+      </EditModeContext.Provider>
     </BuilderStoreProvider>
   )
 }

--- a/src/components/builder/runnerEditor.tsx
+++ b/src/components/builder/runnerEditor.tsx
@@ -1,0 +1,129 @@
+import Button from "@mui/material/Button"
+import Stack from "@mui/material/Stack"
+import { useNavigate } from "@tanstack/react-router"
+import type { FC } from "react"
+import { useState } from "react"
+
+import { ExportRunnerButton } from "#/components/runner/exportImport/exportRunnerButton.tsx"
+import { SwipeSurface } from "#/components/ui/swipeSurface.tsx"
+import { NumberUtils } from "#/lib/numberUtils.ts"
+import type { RunnerData } from "#/system/runnerData.ts"
+
+import { AllBuilderAlerts } from "./alerts/allBuilderAlerts.tsx"
+import { BuilderImportButton } from "./builderImportButton.tsx"
+import { BuilderStoreProvider } from "./builderStoreProvider.tsx"
+import { useBuilderStores } from "./hooks/useBuilderStores.ts"
+import { BuilderTabs } from "./nav/builderTabs.tsx"
+import { SaveRunnerButton } from "./saveRunnerButton.tsx"
+import { AttributesBuilderSection } from "./sections/attributes/attributesBuilderSection.tsx"
+import { BiologyBuilderSection } from "./sections/biology/biologyBuilderSection.tsx"
+import { BuilderSectionId, builderSectionOrder } from "./sections/builderSectionId.ts"
+import { ContactsBuilderSection } from "./sections/contacts/contactsBuilderSection.tsx"
+import { GearBuilderSection } from "./sections/gear/gearBuilderSection.tsx"
+import { ProfileBuilderSection } from "./sections/profile/profileBuilderSection.tsx"
+import { QualitiesBuilderSection } from "./sections/qualities/qualitiesBuilderSection.tsx"
+import { AdeptPowersBuilderSection } from "./sections/resources/adept/adeptPowersBuilderSection.tsx"
+import { SpellsBuilderSection } from "./sections/resources/magician/spellsBuilderSection.tsx"
+import {
+  ComplexFormsBuilderSection,
+} from "./sections/resources/technomancer/complexForms/complexFormsBuilderSection.tsx"
+import { SpritesBuilderSection } from "./sections/resources/technomancer/sprites/spritesBuilderSection.tsx"
+import { ActiveSkillsBuilderSection } from "./sections/skills/activeSkills/activeSkillsBuilderSection.tsx"
+import { KnowledgeSkillsBuilderSection } from "./sections/skills/knowledgeSkills/knowledgeSkillsBuilderSection.tsx"
+import { BpSummaryFooter } from "./sections/summary/bpSummaryFooter.tsx"
+
+interface RunnerEditorProps {
+  runner: RunnerData
+}
+
+const sectionComponents: Record<BuilderSectionId, FC> = {
+  [BuilderSectionId.profile]: ProfileBuilderSection,
+  [BuilderSectionId.biology]: BiologyBuilderSection,
+  [BuilderSectionId.attributes]: AttributesBuilderSection,
+  [BuilderSectionId.qualities]: QualitiesBuilderSection,
+  [BuilderSectionId.activeSkills]: ActiveSkillsBuilderSection,
+  [BuilderSectionId.knowledgeSkills]: KnowledgeSkillsBuilderSection,
+  [BuilderSectionId.spells]: SpellsBuilderSection,
+  [BuilderSectionId.adeptPowers]: AdeptPowersBuilderSection,
+  [BuilderSectionId.complexForms]: ComplexFormsBuilderSection,
+  [BuilderSectionId.sprites]: SpritesBuilderSection,
+  [BuilderSectionId.gear]: GearBuilderSection,
+  [BuilderSectionId.contacts]: ContactsBuilderSection,
+}
+
+export const RunnerEditor: FC<RunnerEditorProps> = ({ runner }) => {
+  const [isBpPanelExpanded, setIsBpPanelExpanded] = useState(false)
+  const [activeSection, setActiveSection] = useState<BuilderSectionId>(BuilderSectionId.profile)
+  const { runnerStore, builderStore, loadRunner } = useBuilderStores(runner)
+  const navigate = useNavigate()
+
+  const currentIndex = builderSectionOrder.indexOf(activeSection)
+
+  const nextSection = () => {
+    const nextIndex = NumberUtils.clamp(currentIndex + 1, { max: builderSectionOrder.length - 1 })
+    setActiveSection(builderSectionOrder[nextIndex])
+  }
+
+  const prevSection = () => {
+    const prevIndex = NumberUtils.clamp(currentIndex - 1, { min: 0 })
+    setActiveSection(builderSectionOrder[prevIndex])
+  }
+
+  const handleCancel = () => {
+    navigate({ to: "/$runnerId/about", params: { runnerId: runner.id } })
+  }
+
+  const handleRevert = () => {
+    runnerStore.setState(() => runner)
+  }
+
+  const ActiveSection = sectionComponents[activeSection]
+
+  return (
+    <BuilderStoreProvider runnerStore={runnerStore} builderStore={builderStore}>
+      <Stack>
+        <Stack
+          sx={{
+            opacity: isBpPanelExpanded ? 0.6 : 1,
+            transition: "opacity 0.2s ease",
+            pointerEvents: isBpPanelExpanded ? "none" : "auto",
+          }}
+        >
+          <Stack direction="row" sx={{ justifyContent: "space-between", gap: 1 }}>
+            <Button
+              variant="outlined"
+              color="inherit"
+              size="small"
+              onClick={handleCancel}
+            >
+              Cancel
+            </Button>
+            <Stack direction="row" sx={{ gap: 1 }}>
+              <BuilderImportButton onImport={loadRunner} />
+              <ExportRunnerButton />
+              <Button
+                variant="outlined"
+                color="warning"
+                size="small"
+                onClick={handleRevert}
+              >
+                Revert
+              </Button>
+            </Stack>
+          </Stack>
+
+          <BuilderTabs value={activeSection} onChange={setActiveSection} />
+
+          <SwipeSurface onSwipeRightToLeft={nextSection} onSwipeLeftToRight={prevSection}>
+            <ActiveSection />
+          </SwipeSurface>
+        </Stack>
+
+        <BpSummaryFooter onExpandedChange={setIsBpPanelExpanded} onSelectSection={setActiveSection} />
+
+        <AllBuilderAlerts />
+        <SaveRunnerButton requireValid={false} />
+      </Stack>
+    </BuilderStoreProvider>
+  )
+}

--- a/src/components/builder/runnerEditor.tsx
+++ b/src/components/builder/runnerEditor.tsx
@@ -7,7 +7,7 @@ import { useState } from "react"
 import { ExportRunnerButton } from "#/components/runner/exportImport/exportRunnerButton.tsx"
 import { SwipeSurface } from "#/components/ui/swipeSurface.tsx"
 import { NumberUtils } from "#/lib/numberUtils.ts"
-import { EditModeContext } from "#/stores/builder/editMode.context.ts"
+import { EditorModeProvider } from "#/stores/builder/editorMode.tsx"
 import type { RunnerData } from "#/system/runnerData.ts"
 
 import { AllBuilderAlerts } from "./alerts/allBuilderAlerts.tsx"
@@ -80,7 +80,7 @@ export const RunnerEditor: FC<RunnerEditorProps> = ({ runner }) => {
 
   return (
     <BuilderStoreProvider runnerStore={runnerStore} builderStore={builderStore}>
-      <EditModeContext.Provider value={true}>
+      <EditorModeProvider mode="edit">
         <Stack>
           <Stack direction="row" sx={{ justifyContent: "space-between", gap: 1 }}>
             <Button
@@ -114,7 +114,7 @@ export const RunnerEditor: FC<RunnerEditorProps> = ({ runner }) => {
           <AllBuilderAlerts />
           <SaveRunnerButton requireValid={false} />
         </Stack>
-      </EditModeContext.Provider>
+      </EditorModeProvider>
     </BuilderStoreProvider>
   )
 }

--- a/src/components/builder/saveRunnerButton.tsx
+++ b/src/components/builder/saveRunnerButton.tsx
@@ -9,7 +9,13 @@ import { useRunnerStoreContext } from "#/stores/runner/runnerStore.context.ts"
 
 import { useAllAlerts } from "./alerts/hooks/useAllAlerts.ts"
 
-export const SaveRunnerButton: FC = () => {
+interface SaveRunnerButtonProps {
+  // Character creation enforces build-point validity; editing an existing runner should not
+  // be blocked by build-point budget errors that only make sense at creation time.
+  requireValid?: boolean
+}
+
+export const SaveRunnerButton: FC<SaveRunnerButtonProps> = ({ requireValid = true }) => {
   const store = useRunnerStoreContext()
   const navigate = useNavigate()
   const runnerManager = useRunnerManager()
@@ -27,9 +33,8 @@ export const SaveRunnerButton: FC = () => {
     },
   })
 
-  const isValid = useAllAlerts()
-    .filter((status) => status.severity === "error")
-    .length === 0
+  const hasErrors = useAllAlerts().some((status) => status.severity === "error")
+  const isValid = !requireValid || !hasErrors
 
   return (
     <Button

--- a/src/components/builder/sections/attributes/attrDecrementButton.tsx
+++ b/src/components/builder/sections/attributes/attrDecrementButton.tsx
@@ -6,6 +6,7 @@ import type { FC } from "react"
 import { BuilderConfig } from "#/components/builder/builderConfig.ts"
 import { useAttrValue } from "#/components/runner/attributes/attributesProvider.tsx"
 import { useAttrInfo } from "#/components/runner/runnerUtils.ts"
+import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
 import { useRunnerStoreContext } from "#/stores/runner/runnerStore.context.ts"
 import { AttributeKey } from "#/system/attributeKey.ts"
 
@@ -21,6 +22,7 @@ export const AttrDecrementButton: FC<AttrDecrementButtonProps> = (props) => {
   const store = useRunnerStoreContext()
   const attrApi = useAttrInfo(props.attr)
   const attrValue = useAttrValue(props.attr)
+  const isEditMode = useIsEditMode()
 
   let disabled = false
   let refund = BuilderConfig.attributes.bpCost.base
@@ -29,6 +31,10 @@ export const AttrDecrementButton: FC<AttrDecrementButtonProps> = (props) => {
   if (attrValue >= attrApi.max) {
     refund = BuilderConfig.attributes.bpCost.maxOut
     label = `${refund} BP`
+  }
+
+  if (isEditMode) {
+    label = ""
   }
 
   if (attrValue <= attrApi.min) {

--- a/src/components/builder/sections/attributes/attrDecrementButton.tsx
+++ b/src/components/builder/sections/attributes/attrDecrementButton.tsx
@@ -6,7 +6,7 @@ import type { FC } from "react"
 import { BuilderConfig } from "#/components/builder/builderConfig.ts"
 import { useAttrValue } from "#/components/runner/attributes/attributesProvider.tsx"
 import { useAttrInfo } from "#/components/runner/runnerUtils.ts"
-import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
+import { useEditorMode } from "#/stores/builder/editorMode.tsx"
 import { useRunnerStoreContext } from "#/stores/runner/runnerStore.context.ts"
 import { AttributeKey } from "#/system/attributeKey.ts"
 
@@ -22,7 +22,7 @@ export const AttrDecrementButton: FC<AttrDecrementButtonProps> = (props) => {
   const store = useRunnerStoreContext()
   const attrApi = useAttrInfo(props.attr)
   const attrValue = useAttrValue(props.attr)
-  const isEditMode = useIsEditMode()
+  const { isEdit } = useEditorMode()
 
   let disabled = false
   let refund = BuilderConfig.attributes.bpCost.base
@@ -33,7 +33,7 @@ export const AttrDecrementButton: FC<AttrDecrementButtonProps> = (props) => {
     label = `${refund} BP`
   }
 
-  if (isEditMode) {
+  if (isEdit) {
     label = ""
   }
 

--- a/src/components/builder/sections/attributes/attrDecrementButton.tsx
+++ b/src/components/builder/sections/attributes/attrDecrementButton.tsx
@@ -22,7 +22,7 @@ export const AttrDecrementButton: FC<AttrDecrementButtonProps> = (props) => {
   const store = useRunnerStoreContext()
   const attrApi = useAttrInfo(props.attr)
   const attrValue = useAttrValue(props.attr)
-  const { isEdit } = useEditorMode()
+  const editorMode = useEditorMode()
 
   let disabled = false
   let refund = BuilderConfig.attributes.bpCost.base
@@ -33,7 +33,7 @@ export const AttrDecrementButton: FC<AttrDecrementButtonProps> = (props) => {
     label = `${refund} BP`
   }
 
-  if (isEdit) {
+  if (editorMode.isEdit) {
     label = ""
   }
 

--- a/src/components/builder/sections/attributes/attrIncrementButton.tsx
+++ b/src/components/builder/sections/attributes/attrIncrementButton.tsx
@@ -8,6 +8,7 @@ import { BuilderConfig } from "#/components/builder/builderConfig.ts"
 import { useAttrValue } from "#/components/runner/attributes/attributesProvider.tsx"
 import { useHasMaxxedAttribute } from "#/components/runner/attributes/hooks/useHasMaxxedAttribute.ts"
 import { useAttrInfo } from "#/components/runner/runnerUtils.ts"
+import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
 import { useRunnerStoreContext } from "#/stores/runner/runnerStore.context.ts"
 import { AttributeKey } from "#/system/attributeKey.ts"
 
@@ -20,6 +21,7 @@ export const AttrIncrementButton: FC<AttrIncrementButtonProps> = (props) => {
     throw new Error("Essence can not be incremented")
   }
   const { budget } = useAttributesBuildPoints()
+  const isEditMode = useIsEditMode()
 
   const store = useRunnerStoreContext()
   const attrKey = props.attr
@@ -38,7 +40,11 @@ export const AttrIncrementButton: FC<AttrIncrementButtonProps> = (props) => {
     label = `${cost} BP`
   }
 
-  if (willMaxAttr && hasMaxxedAttr) {
+  if (isEditMode) {
+    label = ""
+  }
+
+  if (willMaxAttr && hasMaxxedAttr && !isEditMode) {
     disabled = true
     label = "---"
   }
@@ -48,7 +54,7 @@ export const AttrIncrementButton: FC<AttrIncrementButtonProps> = (props) => {
     label = "MAX"
   }
 
-  if (budget.remaining < cost) {
+  if (budget.remaining < cost && !isEditMode) {
     disabled = true
   }
 

--- a/src/components/builder/sections/attributes/attrIncrementButton.tsx
+++ b/src/components/builder/sections/attributes/attrIncrementButton.tsx
@@ -44,7 +44,7 @@ export const AttrIncrementButton: FC<AttrIncrementButtonProps> = (props) => {
     label = ""
   }
 
-  if (willMaxAttr && hasMaxxedAttr && !editorMode.isEdit) {
+  if (willMaxAttr && hasMaxxedAttr && editorMode.isBuilder) {
     disabled = true
     label = "---"
   }
@@ -54,7 +54,7 @@ export const AttrIncrementButton: FC<AttrIncrementButtonProps> = (props) => {
     label = "MAX"
   }
 
-  if (budget.remaining < cost && !editorMode.isEdit) {
+  if (budget.remaining < cost && editorMode.isBuilder) {
     disabled = true
   }
 

--- a/src/components/builder/sections/attributes/attrIncrementButton.tsx
+++ b/src/components/builder/sections/attributes/attrIncrementButton.tsx
@@ -8,7 +8,7 @@ import { BuilderConfig } from "#/components/builder/builderConfig.ts"
 import { useAttrValue } from "#/components/runner/attributes/attributesProvider.tsx"
 import { useHasMaxxedAttribute } from "#/components/runner/attributes/hooks/useHasMaxxedAttribute.ts"
 import { useAttrInfo } from "#/components/runner/runnerUtils.ts"
-import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
+import { useEditorMode } from "#/stores/builder/editorMode.tsx"
 import { useRunnerStoreContext } from "#/stores/runner/runnerStore.context.ts"
 import { AttributeKey } from "#/system/attributeKey.ts"
 
@@ -21,7 +21,7 @@ export const AttrIncrementButton: FC<AttrIncrementButtonProps> = (props) => {
     throw new Error("Essence can not be incremented")
   }
   const { budget } = useAttributesBuildPoints()
-  const isEditMode = useIsEditMode()
+  const { isEdit } = useEditorMode()
 
   const store = useRunnerStoreContext()
   const attrKey = props.attr
@@ -40,11 +40,11 @@ export const AttrIncrementButton: FC<AttrIncrementButtonProps> = (props) => {
     label = `${cost} BP`
   }
 
-  if (isEditMode) {
+  if (isEdit) {
     label = ""
   }
 
-  if (willMaxAttr && hasMaxxedAttr && !isEditMode) {
+  if (willMaxAttr && hasMaxxedAttr && !isEdit) {
     disabled = true
     label = "---"
   }
@@ -54,7 +54,7 @@ export const AttrIncrementButton: FC<AttrIncrementButtonProps> = (props) => {
     label = "MAX"
   }
 
-  if (budget.remaining < cost && !isEditMode) {
+  if (budget.remaining < cost && !isEdit) {
     disabled = true
   }
 

--- a/src/components/builder/sections/attributes/attrIncrementButton.tsx
+++ b/src/components/builder/sections/attributes/attrIncrementButton.tsx
@@ -21,7 +21,7 @@ export const AttrIncrementButton: FC<AttrIncrementButtonProps> = (props) => {
     throw new Error("Essence can not be incremented")
   }
   const { budget } = useAttributesBuildPoints()
-  const { isEdit } = useEditorMode()
+  const editorMode = useEditorMode()
 
   const store = useRunnerStoreContext()
   const attrKey = props.attr
@@ -40,11 +40,11 @@ export const AttrIncrementButton: FC<AttrIncrementButtonProps> = (props) => {
     label = `${cost} BP`
   }
 
-  if (isEdit) {
+  if (editorMode.isEdit) {
     label = ""
   }
 
-  if (willMaxAttr && hasMaxxedAttr && !isEdit) {
+  if (willMaxAttr && hasMaxxedAttr && !editorMode.isEdit) {
     disabled = true
     label = "---"
   }
@@ -54,7 +54,7 @@ export const AttrIncrementButton: FC<AttrIncrementButtonProps> = (props) => {
     label = "MAX"
   }
 
-  if (budget.remaining < cost && !isEdit) {
+  if (budget.remaining < cost && !editorMode.isEdit) {
     disabled = true
   }
 

--- a/src/components/builder/sections/attributes/attributesSection.tsx
+++ b/src/components/builder/sections/attributes/attributesSection.tsx
@@ -7,6 +7,7 @@ import { useAllAttrInfos } from "#/components/runner/runnerUtils.ts"
 import { BuildPoints } from "#/components/ui/buildPoints.tsx"
 import { Label } from "#/components/ui/text/label.tsx"
 import { getProgress } from "#/lib/progressUtils.ts"
+import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
 import {
   AttributeKey,
   AttributeOrder,
@@ -20,6 +21,7 @@ import { AttributesList } from "./attributesList.tsx"
 export const AttributesSection: FC = () => {
   const { budget, specialBp } = useAttributesBuildPoints()
   const attributes = useAllAttrInfos()
+  const isEditMode = useIsEditMode()
 
   const attrRows: AttributeKey[] = AttributeOrder
     .filter((key) => key !== AttributeKey.essence)
@@ -33,15 +35,19 @@ export const AttributesSection: FC = () => {
 
   return (
     <Stack sx={{ gap: 1 }}>
-      <Stack direction="row" sx={{ alignSelf: "flex-end", gap: 1 }}>
-        <BuildPoints value={budget.spent} total={budget.limit} /> + <BuildPoints value={specialBp} />
-      </Stack>
+      {!isEditMode && (
+        <>
+          <Stack direction="row" sx={{ alignSelf: "flex-end", gap: 1 }}>
+            <BuildPoints value={budget.spent} total={budget.limit} /> + <BuildPoints value={specialBp} />
+          </Stack>
 
-      <LinearProgress
-        variant="determinate"
-        value={getProgress(budget.spent, budget.limit)}
-        sx={{ height: 8, borderRadius: 1, width: "100%" }}
-      />
+          <LinearProgress
+            variant="determinate"
+            value={getProgress(budget.spent, budget.limit)}
+            sx={{ height: 8, borderRadius: 1, width: "100%" }}
+          />
+        </>
+      )}
 
       <Label label="Pysical" variant="outlined" />
       <AttributesList attributeKeys={physicalAttrs} />
@@ -50,7 +56,7 @@ export const AttributesSection: FC = () => {
       <AttributesList attributeKeys={mentalAttrs} />
 
       <Label label="Special" variant="outlined" />
-      <Label label="Does not count towards BP limit" variant="text" />
+      {!isEditMode && <Label label="Does not count towards BP limit" variant="text" />}
       <AttributesList attributeKeys={specialAttrs} />
 
     </Stack>

--- a/src/components/builder/sections/attributes/attributesSection.tsx
+++ b/src/components/builder/sections/attributes/attributesSection.tsx
@@ -7,7 +7,7 @@ import { useAllAttrInfos } from "#/components/runner/runnerUtils.ts"
 import { BuildPoints } from "#/components/ui/buildPoints.tsx"
 import { Label } from "#/components/ui/text/label.tsx"
 import { getProgress } from "#/lib/progressUtils.ts"
-import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
+import { EditorMode } from "#/stores/builder/editorMode.tsx"
 import {
   AttributeKey,
   AttributeOrder,
@@ -21,7 +21,6 @@ import { AttributesList } from "./attributesList.tsx"
 export const AttributesSection: FC = () => {
   const { budget, specialBp } = useAttributesBuildPoints()
   const attributes = useAllAttrInfos()
-  const isEditMode = useIsEditMode()
 
   const attrRows: AttributeKey[] = AttributeOrder
     .filter((key) => key !== AttributeKey.essence)
@@ -35,19 +34,17 @@ export const AttributesSection: FC = () => {
 
   return (
     <Stack sx={{ gap: 1 }}>
-      {!isEditMode && (
-        <>
-          <Stack direction="row" sx={{ alignSelf: "flex-end", gap: 1 }}>
-            <BuildPoints value={budget.spent} total={budget.limit} /> + <BuildPoints value={specialBp} />
-          </Stack>
+      <EditorMode.IsBuilder>
+        <Stack direction="row" sx={{ alignSelf: "flex-end", gap: 1 }}>
+          <BuildPoints value={budget.spent} total={budget.limit} /> + <BuildPoints value={specialBp} />
+        </Stack>
 
-          <LinearProgress
-            variant="determinate"
-            value={getProgress(budget.spent, budget.limit)}
-            sx={{ height: 8, borderRadius: 1, width: "100%" }}
-          />
-        </>
-      )}
+        <LinearProgress
+          variant="determinate"
+          value={getProgress(budget.spent, budget.limit)}
+          sx={{ height: 8, borderRadius: 1, width: "100%" }}
+        />
+      </EditorMode.IsBuilder>
 
       <Label label="Pysical" variant="outlined" />
       <AttributesList attributeKeys={physicalAttrs} />
@@ -56,7 +53,9 @@ export const AttributesSection: FC = () => {
       <AttributesList attributeKeys={mentalAttrs} />
 
       <Label label="Special" variant="outlined" />
-      {!isEditMode && <Label label="Does not count towards BP limit" variant="text" />}
+      <EditorMode.IsBuilder>
+        <Label label="Does not count towards BP limit" variant="text" />
+      </EditorMode.IsBuilder>
       <AttributesList attributeKeys={specialAttrs} />
 
     </Stack>

--- a/src/components/builder/sections/builderSectionId.ts
+++ b/src/components/builder/sections/builderSectionId.ts
@@ -31,3 +31,5 @@ export const builderSections: Record<BuilderSectionId, BuilderSectionInfo> = {
   [BuilderSectionId.gear]: { label: "Gear" },
   [BuilderSectionId.contacts]: { label: "Contacts" },
 }
+
+export const builderSectionOrder = Object.values(BuilderSectionId)

--- a/src/components/builder/sections/gear/gearSection.tsx
+++ b/src/components/builder/sections/gear/gearSection.tsx
@@ -18,7 +18,7 @@ import { SinsAndLicensesSection } from "#/components/items/types/licenses/sinsAn
 import { BuildPoints } from "#/components/ui/buildPoints.tsx"
 import { Nuyen } from "#/components/ui/nuyen.tsx"
 import { getProgress } from "#/lib/progressUtils.ts"
-import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
+import { EditorMode } from "#/stores/builder/editorMode.tsx"
 import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
 import { isImplant } from "#/system/gear/implantData.ts"
 import { isLicenseData } from "#/system/gear/licenseData.ts"
@@ -40,7 +40,6 @@ export const GearSection: FC = () => {
   const totalNuyen = useGearTotalCost()
   const buildPoints = useGearBuildPoints()
   const { invalidSections } = useGearAvailabilityIssues()
-  const isEditMode = useIsEditMode()
 
   const [activeSection, setActiveSection] = useState<SectionHeader | null>(null)
 
@@ -52,7 +51,7 @@ export const GearSection: FC = () => {
 
   return (
     <Stack sx={{ gap: 1 }}>
-      {!isEditMode && (
+      <EditorMode.IsBuilder>
         <Stack sx={{ gap: 0.5 }}>
           <Stack
             direction="row"
@@ -72,7 +71,7 @@ export const GearSection: FC = () => {
             color={buildPoints.isOverBudget ? "error" : "primary"}
           />
         </Stack>
-      )}
+      </EditorMode.IsBuilder>
 
       {Object.values(SectionHeader).map((sectionName) => (
         <Accordion
@@ -124,7 +123,9 @@ export const GearSection: FC = () => {
         </Accordion>
       ))}
 
-      {!isEditMode && <StartingNuyenSection />}
+      <EditorMode.IsBuilder>
+        <StartingNuyenSection />
+      </EditorMode.IsBuilder>
     </Stack>
   )
 }

--- a/src/components/builder/sections/gear/gearSection.tsx
+++ b/src/components/builder/sections/gear/gearSection.tsx
@@ -18,6 +18,7 @@ import { SinsAndLicensesSection } from "#/components/items/types/licenses/sinsAn
 import { BuildPoints } from "#/components/ui/buildPoints.tsx"
 import { Nuyen } from "#/components/ui/nuyen.tsx"
 import { getProgress } from "#/lib/progressUtils.ts"
+import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
 import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
 import { isImplant } from "#/system/gear/implantData.ts"
 import { isLicenseData } from "#/system/gear/licenseData.ts"
@@ -39,6 +40,7 @@ export const GearSection: FC = () => {
   const totalNuyen = useGearTotalCost()
   const buildPoints = useGearBuildPoints()
   const { invalidSections } = useGearAvailabilityIssues()
+  const isEditMode = useIsEditMode()
 
   const [activeSection, setActiveSection] = useState<SectionHeader | null>(null)
 
@@ -50,25 +52,27 @@ export const GearSection: FC = () => {
 
   return (
     <Stack sx={{ gap: 1 }}>
-      <Stack sx={{ gap: 0.5 }}>
-        <Stack
-          direction="row"
-          sx={{ justifyContent: "space-between", alignItems: "center" }}
-        >
-          <Typography>
-            <Nuyen amount={totalNuyen} />
-            {" / "}
-            <Nuyen amount={BuilderConfig.gear.nuyenPerBp * BuilderConfig.gear.bpAllowance} />
-          </Typography>
-          <BuildPoints value={buildPoints.spent} total={buildPoints.allowance} />
-        </Stack>
+      {!isEditMode && (
+        <Stack sx={{ gap: 0.5 }}>
+          <Stack
+            direction="row"
+            sx={{ justifyContent: "space-between", alignItems: "center" }}
+          >
+            <Typography>
+              <Nuyen amount={totalNuyen} />
+              {" / "}
+              <Nuyen amount={BuilderConfig.gear.nuyenPerBp * BuilderConfig.gear.bpAllowance} />
+            </Typography>
+            <BuildPoints value={buildPoints.spent} total={buildPoints.allowance} />
+          </Stack>
 
-        <LinearProgress
-          variant="determinate"
-          value={getProgress(buildPoints.spent, BuilderConfig.gear.bpAllowance)}
-          color={buildPoints.isOverBudget ? "error" : "primary"}
-        />
-      </Stack>
+          <LinearProgress
+            variant="determinate"
+            value={getProgress(buildPoints.spent, BuilderConfig.gear.bpAllowance)}
+            color={buildPoints.isOverBudget ? "error" : "primary"}
+          />
+        </Stack>
+      )}
 
       {Object.values(SectionHeader).map((sectionName) => (
         <Accordion
@@ -120,7 +124,7 @@ export const GearSection: FC = () => {
         </Accordion>
       ))}
 
-      <StartingNuyenSection />
+      {!isEditMode && <StartingNuyenSection />}
     </Stack>
   )
 }

--- a/src/components/builder/sections/gear/useGearAlerts.ts
+++ b/src/components/builder/sections/gear/useGearAlerts.ts
@@ -13,11 +13,11 @@ export const useGearAlerts = (): AlertInfo[] => {
   const { totalInvalidCount } = useGearAvailabilityIssues()
   const { isOverBudget } = useGearBuildPoints()
   const { isEncumbered, penalty, totalBallistic, totalImpact, threshold } = useEncumbrance()
-  const { isEdit } = useEditorMode()
+  const editorMode = useEditorMode()
 
   const alerts: AlertInfo[] = []
 
-  if (isOverBudget && !isEdit) {
+  if (isOverBudget && !editorMode.isEdit) {
     alerts.push({
       section: "Gear",
       severity: "error",

--- a/src/components/builder/sections/gear/useGearAlerts.ts
+++ b/src/components/builder/sections/gear/useGearAlerts.ts
@@ -4,7 +4,7 @@ import { useGearBuildPoints } from "#/components/builder/buildPoints/hooks/useGe
 import { BuilderConfig } from "#/components/builder/builderConfig.ts"
 import { useEncumbrance } from "#/components/system/encumbrance/useEncumbrance.ts"
 import type { AlertInfo } from "#/components/ui/alerts/alertInfo.ts"
-import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
+import { useEditorMode } from "#/stores/builder/editorMode.tsx"
 import { useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
 
 import { useGearAvailabilityIssues } from "./gearUtils.ts"
@@ -13,11 +13,11 @@ export const useGearAlerts = (): AlertInfo[] => {
   const { totalInvalidCount } = useGearAvailabilityIssues()
   const { isOverBudget } = useGearBuildPoints()
   const { isEncumbered, penalty, totalBallistic, totalImpact, threshold } = useEncumbrance()
-  const isEditMode = useIsEditMode()
+  const { isEdit } = useEditorMode()
 
   const alerts: AlertInfo[] = []
 
-  if (isOverBudget && !isEditMode) {
+  if (isOverBudget && !isEdit) {
     alerts.push({
       section: "Gear",
       severity: "error",

--- a/src/components/builder/sections/gear/useGearAlerts.ts
+++ b/src/components/builder/sections/gear/useGearAlerts.ts
@@ -4,6 +4,7 @@ import { useGearBuildPoints } from "#/components/builder/buildPoints/hooks/useGe
 import { BuilderConfig } from "#/components/builder/builderConfig.ts"
 import { useEncumbrance } from "#/components/system/encumbrance/useEncumbrance.ts"
 import type { AlertInfo } from "#/components/ui/alerts/alertInfo.ts"
+import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
 import { useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
 
 import { useGearAvailabilityIssues } from "./gearUtils.ts"
@@ -12,10 +13,11 @@ export const useGearAlerts = (): AlertInfo[] => {
   const { totalInvalidCount } = useGearAvailabilityIssues()
   const { isOverBudget } = useGearBuildPoints()
   const { isEncumbered, penalty, totalBallistic, totalImpact, threshold } = useEncumbrance()
+  const isEditMode = useIsEditMode()
 
   const alerts: AlertInfo[] = []
 
-  if (isOverBudget) {
+  if (isOverBudget && !isEditMode) {
     alerts.push({
       section: "Gear",
       severity: "error",

--- a/src/components/builder/sections/gear/useGearAlerts.ts
+++ b/src/components/builder/sections/gear/useGearAlerts.ts
@@ -17,7 +17,7 @@ export const useGearAlerts = (): AlertInfo[] => {
 
   const alerts: AlertInfo[] = []
 
-  if (isOverBudget && !editorMode.isEdit) {
+  if (isOverBudget && editorMode.isBuilder) {
     alerts.push({
       section: "Gear",
       severity: "error",

--- a/src/components/builder/sections/qualities/qualitiesList.tsx
+++ b/src/components/builder/sections/qualities/qualitiesList.tsx
@@ -7,6 +7,7 @@ import { useQualitiesBuildPoints } from "#/components/builder/buildPoints/hooks/
 import { BuilderConfig } from "#/components/builder/builderConfig.ts"
 import { useQualityFormDialog } from "#/components/runner/qualities/dialogs/qualityFormDialog.tsx"
 import { Label } from "#/components/ui/text/label.tsx"
+import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
 import { Actions } from "#/stores/runner/runnerStore.actions.ts"
 import { useRunnerStoreDispatch } from "#/stores/runner/runnerStore.dispatch.ts"
 import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
@@ -22,6 +23,7 @@ export const QualitiesList: FC<QualitiesListProps> = ({ type = "all" }) => {
   const qualities = useRunnerStoreSelector(Selectors.qualities.selectQualities)
   const qualitiesBuildPoints = useQualitiesBuildPoints()
   const qualityFormDialog = useQualityFormDialog()
+  const isEditMode = useIsEditMode()
 
   let label: string
   let bpLabel: string
@@ -53,13 +55,16 @@ export const QualitiesList: FC<QualitiesListProps> = ({ type = "all" }) => {
     <>
       <Label label={label} variant="outlined" />
 
-      <Stack direction="row" sx={{ justifyContent: "flex-end" }}>
-        <Typography color="secondary.main">
-          {bpLabel}: {bpValue} BP
-        </Typography>
-      </Stack>
+      {!isEditMode && (
+        <Stack direction="row" sx={{ justifyContent: "flex-end" }}>
+          <Typography color="secondary.main">
+            {bpLabel}: {bpValue} BP
+          </Typography>
+        </Stack>
+      )}
 
-      {type === "negative" && qualitiesBuildPoints.negative < -BuilderConfig.qualities.maxNegativeBpBonus && (
+      {type === "negative" && !isEditMode
+        && qualitiesBuildPoints.negative < -BuilderConfig.qualities.maxNegativeBpBonus && (
         <Alert severity="warning" sx={{ py: 0 }}>
           Negative qualities exceed the {BuilderConfig.qualities.maxNegativeBpBonus} BP bonus limit.
         </Alert>

--- a/src/components/builder/sections/qualities/qualitiesList.tsx
+++ b/src/components/builder/sections/qualities/qualitiesList.tsx
@@ -7,7 +7,7 @@ import { useQualitiesBuildPoints } from "#/components/builder/buildPoints/hooks/
 import { BuilderConfig } from "#/components/builder/builderConfig.ts"
 import { useQualityFormDialog } from "#/components/runner/qualities/dialogs/qualityFormDialog.tsx"
 import { Label } from "#/components/ui/text/label.tsx"
-import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
+import { EditorMode } from "#/stores/builder/editorMode.tsx"
 import { Actions } from "#/stores/runner/runnerStore.actions.ts"
 import { useRunnerStoreDispatch } from "#/stores/runner/runnerStore.dispatch.ts"
 import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
@@ -23,7 +23,6 @@ export const QualitiesList: FC<QualitiesListProps> = ({ type = "all" }) => {
   const qualities = useRunnerStoreSelector(Selectors.qualities.selectQualities)
   const qualitiesBuildPoints = useQualitiesBuildPoints()
   const qualityFormDialog = useQualityFormDialog()
-  const isEditMode = useIsEditMode()
 
   let label: string
   let bpLabel: string
@@ -55,19 +54,20 @@ export const QualitiesList: FC<QualitiesListProps> = ({ type = "all" }) => {
     <>
       <Label label={label} variant="outlined" />
 
-      {!isEditMode && (
+      <EditorMode.IsBuilder>
         <Stack direction="row" sx={{ justifyContent: "flex-end" }}>
           <Typography color="secondary.main">
             {bpLabel}: {bpValue} BP
           </Typography>
         </Stack>
-      )}
+      </EditorMode.IsBuilder>
 
-      {type === "negative" && !isEditMode
-        && qualitiesBuildPoints.negative < -BuilderConfig.qualities.maxNegativeBpBonus && (
-        <Alert severity="warning" sx={{ py: 0 }}>
-          Negative qualities exceed the {BuilderConfig.qualities.maxNegativeBpBonus} BP bonus limit.
-        </Alert>
+      {type === "negative" && qualitiesBuildPoints.negative < -BuilderConfig.qualities.maxNegativeBpBonus && (
+        <EditorMode.IsBuilder>
+          <Alert severity="warning" sx={{ py: 0 }}>
+            Negative qualities exceed the {BuilderConfig.qualities.maxNegativeBpBonus} BP bonus limit.
+          </Alert>
+        </EditorMode.IsBuilder>
       )}
 
       {filteredQualities.length === 0

--- a/src/components/builder/sections/qualities/qualitiesListItem.tsx
+++ b/src/components/builder/sections/qualities/qualitiesListItem.tsx
@@ -5,6 +5,7 @@ import Typography from "@mui/material/Typography"
 import { RiDeleteBin6Line } from "@remixicon/react"
 import type { FC } from "react"
 
+import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
 import type { QualityData } from "#/system/qualityData.ts"
 
 interface QualityRowProps {
@@ -18,6 +19,7 @@ export const QualitiesListItem: FC<QualityRowProps> = ({
   onClick,
   onRemove,
 }) => {
+  const isEditMode = useIsEditMode()
   const { bpValue = 0, rating } = quality
   const bpLabel = bpValue >= 1 ? `${quality.bpValue} BP` : "FREE"
 
@@ -36,9 +38,11 @@ export const QualitiesListItem: FC<QualityRowProps> = ({
           {quality.name}
           {rating !== undefined && ` (Rating ${rating})`}
         </Typography>
-        <Typography color="secondary.main">
-          {bpLabel}
-        </Typography>
+        {!isEditMode && (
+          <Typography color="secondary.main">
+            {bpLabel}
+          </Typography>
+        )}
         {onRemove && (
           <IconButton
             color="error"

--- a/src/components/builder/sections/qualities/qualitiesListItem.tsx
+++ b/src/components/builder/sections/qualities/qualitiesListItem.tsx
@@ -5,7 +5,7 @@ import Typography from "@mui/material/Typography"
 import { RiDeleteBin6Line } from "@remixicon/react"
 import type { FC } from "react"
 
-import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
+import { EditorMode } from "#/stores/builder/editorMode.tsx"
 import type { QualityData } from "#/system/qualityData.ts"
 
 interface QualityRowProps {
@@ -19,7 +19,6 @@ export const QualitiesListItem: FC<QualityRowProps> = ({
   onClick,
   onRemove,
 }) => {
-  const isEditMode = useIsEditMode()
   const { bpValue = 0, rating } = quality
   const bpLabel = bpValue >= 1 ? `${quality.bpValue} BP` : "FREE"
 
@@ -38,11 +37,11 @@ export const QualitiesListItem: FC<QualityRowProps> = ({
           {quality.name}
           {rating !== undefined && ` (Rating ${rating})`}
         </Typography>
-        {!isEditMode && (
+        <EditorMode.IsBuilder>
           <Typography color="secondary.main">
             {bpLabel}
           </Typography>
-        )}
+        </EditorMode.IsBuilder>
         {onRemove && (
           <IconButton
             color="error"

--- a/src/components/builder/sections/qualities/useQualitiesAlerts.ts
+++ b/src/components/builder/sections/qualities/useQualitiesAlerts.ts
@@ -1,14 +1,14 @@
 import type { AlertInfo } from "#/components/ui/alerts/alertInfo.ts"
-import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
+import { useEditorMode } from "#/stores/builder/editorMode.tsx"
 import { useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
 
 export const useQualitiesAlerts = (): AlertInfo[] => {
   const qualities = useRunnerStoreSelector((sheet) => sheet.qualities)
-  const isEditMode = useIsEditMode()
+  const { isEdit } = useEditorMode()
 
   const statuses: AlertInfo[] = []
 
-  if (qualities.length === 0 && !isEditMode) {
+  if (qualities.length === 0 && !isEdit) {
     statuses.push({
       section: "Qualities",
       severity: "warning",

--- a/src/components/builder/sections/qualities/useQualitiesAlerts.ts
+++ b/src/components/builder/sections/qualities/useQualitiesAlerts.ts
@@ -8,7 +8,7 @@ export const useQualitiesAlerts = (): AlertInfo[] => {
 
   const statuses: AlertInfo[] = []
 
-  if (qualities.length === 0 && !editorMode.isEdit) {
+  if (qualities.length === 0 && editorMode.isBuilder) {
     statuses.push({
       section: "Qualities",
       severity: "warning",

--- a/src/components/builder/sections/qualities/useQualitiesAlerts.ts
+++ b/src/components/builder/sections/qualities/useQualitiesAlerts.ts
@@ -4,11 +4,11 @@ import { useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts
 
 export const useQualitiesAlerts = (): AlertInfo[] => {
   const qualities = useRunnerStoreSelector((sheet) => sheet.qualities)
-  const { isEdit } = useEditorMode()
+  const editorMode = useEditorMode()
 
   const statuses: AlertInfo[] = []
 
-  if (qualities.length === 0 && !isEdit) {
+  if (qualities.length === 0 && !editorMode.isEdit) {
     statuses.push({
       section: "Qualities",
       severity: "warning",

--- a/src/components/builder/sections/qualities/useQualitiesAlerts.ts
+++ b/src/components/builder/sections/qualities/useQualitiesAlerts.ts
@@ -1,12 +1,14 @@
 import type { AlertInfo } from "#/components/ui/alerts/alertInfo.ts"
+import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
 import { useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
 
 export const useQualitiesAlerts = (): AlertInfo[] => {
   const qualities = useRunnerStoreSelector((sheet) => sheet.qualities)
+  const isEditMode = useIsEditMode()
 
   const statuses: AlertInfo[] = []
 
-  if (qualities.length === 0) {
+  if (qualities.length === 0 && !isEditMode) {
     statuses.push({
       section: "Qualities",
       severity: "warning",

--- a/src/components/builder/sections/resources/magician/useSpellsAlerts.ts
+++ b/src/components/builder/sections/resources/magician/useSpellsAlerts.ts
@@ -3,7 +3,7 @@ import { useAttrValue } from "#/components/runner/attributes/attributesProvider.
 import { isMagician } from "#/components/runner/magician/magicianUtils.ts"
 import { useActiveSkill } from "#/components/runner/runnerUtils.ts"
 import type { AlertInfo } from "#/components/ui/alerts/alertInfo.ts"
-import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
+import { useEditorMode } from "#/stores/builder/editorMode.tsx"
 import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
 import { AttributeKey } from "#/system/attributeKey.ts"
 import { SkillKey } from "#/system/skills/skillKey.ts"
@@ -14,7 +14,7 @@ export const useSpellsAlerts = (): AlertInfo[] => {
   const spellcasting = useActiveSkill(SkillKey.spellcasting)
   const ritualSpellcasting = useActiveSkill(SkillKey.ritualSpellcasting)
   const spells = useRunnerStoreSelector(Selectors.spells.selectSpells)
-  const isEditMode = useIsEditMode()
+  const { isEdit } = useEditorMode()
 
   const statuses: AlertInfo[] = []
 
@@ -43,7 +43,7 @@ export const useSpellsAlerts = (): AlertInfo[] => {
     })
   }
 
-  if (spent > allowance && !isEditMode) {
+  if (spent > allowance && !isEdit) {
     statuses.push({
       section: "Spells",
       severity: "error",

--- a/src/components/builder/sections/resources/magician/useSpellsAlerts.ts
+++ b/src/components/builder/sections/resources/magician/useSpellsAlerts.ts
@@ -3,6 +3,7 @@ import { useAttrValue } from "#/components/runner/attributes/attributesProvider.
 import { isMagician } from "#/components/runner/magician/magicianUtils.ts"
 import { useActiveSkill } from "#/components/runner/runnerUtils.ts"
 import type { AlertInfo } from "#/components/ui/alerts/alertInfo.ts"
+import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
 import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
 import { AttributeKey } from "#/system/attributeKey.ts"
 import { SkillKey } from "#/system/skills/skillKey.ts"
@@ -13,6 +14,7 @@ export const useSpellsAlerts = (): AlertInfo[] => {
   const spellcasting = useActiveSkill(SkillKey.spellcasting)
   const ritualSpellcasting = useActiveSkill(SkillKey.ritualSpellcasting)
   const spells = useRunnerStoreSelector(Selectors.spells.selectSpells)
+  const isEditMode = useIsEditMode()
 
   const statuses: AlertInfo[] = []
 
@@ -41,7 +43,7 @@ export const useSpellsAlerts = (): AlertInfo[] => {
     })
   }
 
-  if (spent > allowance) {
+  if (spent > allowance && !isEditMode) {
     statuses.push({
       section: "Spells",
       severity: "error",

--- a/src/components/builder/sections/resources/magician/useSpellsAlerts.ts
+++ b/src/components/builder/sections/resources/magician/useSpellsAlerts.ts
@@ -14,7 +14,7 @@ export const useSpellsAlerts = (): AlertInfo[] => {
   const spellcasting = useActiveSkill(SkillKey.spellcasting)
   const ritualSpellcasting = useActiveSkill(SkillKey.ritualSpellcasting)
   const spells = useRunnerStoreSelector(Selectors.spells.selectSpells)
-  const { isEdit } = useEditorMode()
+  const editorMode = useEditorMode()
 
   const statuses: AlertInfo[] = []
 
@@ -43,7 +43,7 @@ export const useSpellsAlerts = (): AlertInfo[] => {
     })
   }
 
-  if (spent > allowance && !isEdit) {
+  if (spent > allowance && !editorMode.isEdit) {
     statuses.push({
       section: "Spells",
       severity: "error",

--- a/src/components/builder/sections/resources/magician/useSpellsAlerts.ts
+++ b/src/components/builder/sections/resources/magician/useSpellsAlerts.ts
@@ -43,7 +43,7 @@ export const useSpellsAlerts = (): AlertInfo[] => {
     })
   }
 
-  if (spent > allowance && !editorMode.isEdit) {
+  if (spent > allowance && editorMode.isBuilder) {
     statuses.push({
       section: "Spells",
       severity: "error",

--- a/src/components/builder/sections/skills/activeSkills/activeSkillGroupsListItem.tsx
+++ b/src/components/builder/sections/skills/activeSkills/activeSkillGroupsListItem.tsx
@@ -7,6 +7,7 @@ import { RiDeleteBin6Line } from "@remixicon/react"
 import type { FC } from "react"
 
 import { getActiveSkillGroupBp } from "#/components/builder/sections/skills/skillsBuilderUtils.ts"
+import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
 import type { SkillGroupData } from "#/system/skills/skillGroupData"
 
 import { getSkillsInGroup } from "./skillGroupUtils.ts"
@@ -24,6 +25,7 @@ export const ActiveSkillGroupsListItem: FC<ActiveSkillGroupsListItemProps> = ({
 }) => {
   const bpCost = getActiveSkillGroupBp(group)
   const memberSkills = getSkillsInGroup(group.name)
+  const isEditMode = useIsEditMode()
 
   return (
     <Box
@@ -47,13 +49,14 @@ export const ActiveSkillGroupsListItem: FC<ActiveSkillGroupsListItemProps> = ({
           variant="outlined"
           sx={{ height: 20, fontSize: "0.75rem", minWidth: 28 }}
         />
-        <Typography
-
-          color="secondary.main"
-          sx={{ minWidth: 40, textAlign: "right" }}
-        >
-          {bpCost} BP
-        </Typography>
+        {!isEditMode && (
+          <Typography
+            color="secondary.main"
+            sx={{ minWidth: 40, textAlign: "right" }}
+          >
+            {bpCost} BP
+          </Typography>
+        )}
         <IconButton
           size="small"
           color="error"

--- a/src/components/builder/sections/skills/activeSkills/activeSkillGroupsListItem.tsx
+++ b/src/components/builder/sections/skills/activeSkills/activeSkillGroupsListItem.tsx
@@ -7,7 +7,7 @@ import { RiDeleteBin6Line } from "@remixicon/react"
 import type { FC } from "react"
 
 import { getActiveSkillGroupBp } from "#/components/builder/sections/skills/skillsBuilderUtils.ts"
-import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
+import { EditorMode } from "#/stores/builder/editorMode.tsx"
 import type { SkillGroupData } from "#/system/skills/skillGroupData"
 
 import { getSkillsInGroup } from "./skillGroupUtils.ts"
@@ -25,7 +25,6 @@ export const ActiveSkillGroupsListItem: FC<ActiveSkillGroupsListItemProps> = ({
 }) => {
   const bpCost = getActiveSkillGroupBp(group)
   const memberSkills = getSkillsInGroup(group.name)
-  const isEditMode = useIsEditMode()
 
   return (
     <Box
@@ -49,14 +48,14 @@ export const ActiveSkillGroupsListItem: FC<ActiveSkillGroupsListItemProps> = ({
           variant="outlined"
           sx={{ height: 20, fontSize: "0.75rem", minWidth: 28 }}
         />
-        {!isEditMode && (
+        <EditorMode.IsBuilder>
           <Typography
             color="secondary.main"
             sx={{ minWidth: 40, textAlign: "right" }}
           >
             {bpCost} BP
           </Typography>
-        )}
+        </EditorMode.IsBuilder>
         <IconButton
           size="small"
           color="error"

--- a/src/components/builder/sections/skills/activeSkills/activeSkillsList.tsx
+++ b/src/components/builder/sections/skills/activeSkills/activeSkillsList.tsx
@@ -9,7 +9,7 @@ import { useActiveSkillDialog } from "#/components/runner/skills/activeSkills/di
 import {
   useActiveSkillGroupDialog,
 } from "#/components/runner/skills/activeSkills/dialogs/activeSkillGroupFormDialog.tsx"
-import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
+import { EditorMode } from "#/stores/builder/editorMode.tsx"
 import { Actions } from "#/stores/runner/runnerStore.actions.ts"
 import { useRunnerStoreDispatch } from "#/stores/runner/runnerStore.dispatch.ts"
 import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
@@ -27,7 +27,6 @@ import {
 
 export const ActiveSkillsList: FC = () => {
   const skillsBuildPoints = useBuilderSkillsBuildPoints()
-  const isEditMode = useIsEditMode()
   const dispatch = useRunnerStoreDispatch()
   const activeSkills = useRunnerStoreSelector(Selectors.skills.selectActiveSkills)
   const skillGroups = useRunnerStoreSelector(Selectors.skills.selectSkillGroups)
@@ -51,11 +50,11 @@ export const ActiveSkillsList: FC = () => {
 
   return (
     <Stack sx={{ gap: 1 }}>
-      {!isEditMode && (
+      <EditorMode.IsBuilder>
         <Typography color="secondary.main">
           {skillsBuildPoints.activeSkills.bpSpent} BP
         </Typography>
-      )}
+      </EditorMode.IsBuilder>
 
       {activeSkills.length > 0 && (
         <Stack sx={{ gap: 0.5 }}>

--- a/src/components/builder/sections/skills/activeSkills/activeSkillsList.tsx
+++ b/src/components/builder/sections/skills/activeSkills/activeSkillsList.tsx
@@ -9,6 +9,7 @@ import { useActiveSkillDialog } from "#/components/runner/skills/activeSkills/di
 import {
   useActiveSkillGroupDialog,
 } from "#/components/runner/skills/activeSkills/dialogs/activeSkillGroupFormDialog.tsx"
+import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
 import { Actions } from "#/stores/runner/runnerStore.actions.ts"
 import { useRunnerStoreDispatch } from "#/stores/runner/runnerStore.dispatch.ts"
 import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
@@ -26,6 +27,7 @@ import {
 
 export const ActiveSkillsList: FC = () => {
   const skillsBuildPoints = useBuilderSkillsBuildPoints()
+  const isEditMode = useIsEditMode()
   const dispatch = useRunnerStoreDispatch()
   const activeSkills = useRunnerStoreSelector(Selectors.skills.selectActiveSkills)
   const skillGroups = useRunnerStoreSelector(Selectors.skills.selectSkillGroups)
@@ -49,9 +51,11 @@ export const ActiveSkillsList: FC = () => {
 
   return (
     <Stack sx={{ gap: 1 }}>
-      <Typography color="secondary.main">
-        {skillsBuildPoints.activeSkills.bpSpent} BP
-      </Typography>
+      {!isEditMode && (
+        <Typography color="secondary.main">
+          {skillsBuildPoints.activeSkills.bpSpent} BP
+        </Typography>
+      )}
 
       {activeSkills.length > 0 && (
         <Stack sx={{ gap: 0.5 }}>

--- a/src/components/builder/sections/skills/activeSkills/activeSkillsListItem.tsx
+++ b/src/components/builder/sections/skills/activeSkills/activeSkillsListItem.tsx
@@ -7,6 +7,7 @@ import { RiDeleteBin6Line } from "@remixicon/react"
 import type { FC } from "react"
 
 import { getActiveSkillBp } from "#/components/builder/sections/skills/skillsBuilderUtils.ts"
+import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
 import type { ActiveSkillData } from "#/system/skills/activeSkillData"
 
 interface ActiveSkillsListItemProps {
@@ -21,6 +22,7 @@ export const ActiveSkillsListItem: FC<ActiveSkillsListItemProps> = ({
   onDelete,
 }) => {
   const bpCost = getActiveSkillBp(skill)
+  const isEditMode = useIsEditMode()
 
   return (
     <Box
@@ -51,13 +53,14 @@ export const ActiveSkillsListItem: FC<ActiveSkillsListItemProps> = ({
           variant="outlined"
           sx={{ height: 20, fontSize: "0.75rem", minWidth: 28 }}
         />
-        <Typography
-
-          color="secondary.main"
-          sx={{ minWidth: 40, textAlign: "right" }}
-        >
-          {bpCost} BP
-        </Typography>
+        {!isEditMode && (
+          <Typography
+            color="secondary.main"
+            sx={{ minWidth: 40, textAlign: "right" }}
+          >
+            {bpCost} BP
+          </Typography>
+        )}
         <IconButton
           size="small"
           color="error"

--- a/src/components/builder/sections/skills/activeSkills/activeSkillsListItem.tsx
+++ b/src/components/builder/sections/skills/activeSkills/activeSkillsListItem.tsx
@@ -7,7 +7,7 @@ import { RiDeleteBin6Line } from "@remixicon/react"
 import type { FC } from "react"
 
 import { getActiveSkillBp } from "#/components/builder/sections/skills/skillsBuilderUtils.ts"
-import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
+import { EditorMode } from "#/stores/builder/editorMode.tsx"
 import type { ActiveSkillData } from "#/system/skills/activeSkillData"
 
 interface ActiveSkillsListItemProps {
@@ -22,7 +22,6 @@ export const ActiveSkillsListItem: FC<ActiveSkillsListItemProps> = ({
   onDelete,
 }) => {
   const bpCost = getActiveSkillBp(skill)
-  const isEditMode = useIsEditMode()
 
   return (
     <Box
@@ -53,14 +52,14 @@ export const ActiveSkillsListItem: FC<ActiveSkillsListItemProps> = ({
           variant="outlined"
           sx={{ height: 20, fontSize: "0.75rem", minWidth: 28 }}
         />
-        {!isEditMode && (
+        <EditorMode.IsBuilder>
           <Typography
             color="secondary.main"
             sx={{ minWidth: 40, textAlign: "right" }}
           >
             {bpCost} BP
           </Typography>
-        )}
+        </EditorMode.IsBuilder>
         <IconButton
           size="small"
           color="error"

--- a/src/components/builder/sections/skills/activeSkills/hooks/useActiveSkillsAlerts.ts
+++ b/src/components/builder/sections/skills/activeSkills/hooks/useActiveSkillsAlerts.ts
@@ -13,7 +13,7 @@ export const useActiveSkillsAlerts = (): AlertInfo[] => {
   const r6Count = activeSkills.filter((s) => s.rating >= 6).length
   const r5Count = skillGroups.filter((s) => s.rating === 5).length
 
-  if ((r6Count > 1 || r5Count > 2 || (r6Count === 1 && r5Count > 0)) && !editorMode.isEdit) {
+  if ((r6Count > 1 || r5Count > 2 || (r6Count === 1 && r5Count > 0)) && editorMode.isBuilder) {
     statuses.push({
       section: "Skills",
       severity: "error",

--- a/src/components/builder/sections/skills/activeSkills/hooks/useActiveSkillsAlerts.ts
+++ b/src/components/builder/sections/skills/activeSkills/hooks/useActiveSkillsAlerts.ts
@@ -1,17 +1,19 @@
 import { getSkillsInGroup } from "#/components/builder/sections/skills/activeSkills/skillGroupUtils.ts"
 import type { AlertInfo } from "#/components/ui/alerts/alertInfo.ts"
+import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
 import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
 
 export const useActiveSkillsAlerts = (): AlertInfo[] => {
   const activeSkills = useRunnerStoreSelector(Selectors.skills.selectActiveSkills)
   const skillGroups = useRunnerStoreSelector(Selectors.skills.selectSkillGroups)
+  const isEditMode = useIsEditMode()
 
   const statuses: AlertInfo[] = []
 
   const r6Count = activeSkills.filter((s) => s.rating >= 6).length
   const r5Count = skillGroups.filter((s) => s.rating === 5).length
 
-  if (r6Count > 1 || r5Count > 2 || (r6Count === 1 && r5Count > 0)) {
+  if ((r6Count > 1 || r5Count > 2 || (r6Count === 1 && r5Count > 0)) && !isEditMode) {
     statuses.push({
       section: "Skills",
       severity: "error",

--- a/src/components/builder/sections/skills/activeSkills/hooks/useActiveSkillsAlerts.ts
+++ b/src/components/builder/sections/skills/activeSkills/hooks/useActiveSkillsAlerts.ts
@@ -1,19 +1,19 @@
 import { getSkillsInGroup } from "#/components/builder/sections/skills/activeSkills/skillGroupUtils.ts"
 import type { AlertInfo } from "#/components/ui/alerts/alertInfo.ts"
-import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
+import { useEditorMode } from "#/stores/builder/editorMode.tsx"
 import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
 
 export const useActiveSkillsAlerts = (): AlertInfo[] => {
   const activeSkills = useRunnerStoreSelector(Selectors.skills.selectActiveSkills)
   const skillGroups = useRunnerStoreSelector(Selectors.skills.selectSkillGroups)
-  const isEditMode = useIsEditMode()
+  const { isEdit } = useEditorMode()
 
   const statuses: AlertInfo[] = []
 
   const r6Count = activeSkills.filter((s) => s.rating >= 6).length
   const r5Count = skillGroups.filter((s) => s.rating === 5).length
 
-  if ((r6Count > 1 || r5Count > 2 || (r6Count === 1 && r5Count > 0)) && !isEditMode) {
+  if ((r6Count > 1 || r5Count > 2 || (r6Count === 1 && r5Count > 0)) && !isEdit) {
     statuses.push({
       section: "Skills",
       severity: "error",

--- a/src/components/builder/sections/skills/activeSkills/hooks/useActiveSkillsAlerts.ts
+++ b/src/components/builder/sections/skills/activeSkills/hooks/useActiveSkillsAlerts.ts
@@ -6,14 +6,14 @@ import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.s
 export const useActiveSkillsAlerts = (): AlertInfo[] => {
   const activeSkills = useRunnerStoreSelector(Selectors.skills.selectActiveSkills)
   const skillGroups = useRunnerStoreSelector(Selectors.skills.selectSkillGroups)
-  const { isEdit } = useEditorMode()
+  const editorMode = useEditorMode()
 
   const statuses: AlertInfo[] = []
 
   const r6Count = activeSkills.filter((s) => s.rating >= 6).length
   const r5Count = skillGroups.filter((s) => s.rating === 5).length
 
-  if ((r6Count > 1 || r5Count > 2 || (r6Count === 1 && r5Count > 0)) && !isEdit) {
+  if ((r6Count > 1 || r5Count > 2 || (r6Count === 1 && r5Count > 0)) && !editorMode.isEdit) {
     statuses.push({
       section: "Skills",
       severity: "error",

--- a/src/components/builder/sections/skills/knowledgeSkills/hooks/useKnowledgeSkillsAlerts.ts
+++ b/src/components/builder/sections/skills/knowledgeSkills/hooks/useKnowledgeSkillsAlerts.ts
@@ -12,9 +12,9 @@ export const useKnowledgeSkillsAlerts = (): AlertInfo[] => {
   const knowledgeSkills = useRunnerStoreSelector(Selectors.skills.selectKnowledgeSkills)
   const languageSkills = useRunnerStoreSelector(Selectors.skills.selectLanguageSkills)
   const skillPoints = useKnowledgeSkillPoints()
-  const { isEdit } = useEditorMode()
+  const editorMode = useEditorMode()
 
-  if (isEdit) return []
+  if (editorMode.isEdit) return []
 
   const statuses: AlertInfo[] = []
 

--- a/src/components/builder/sections/skills/knowledgeSkills/hooks/useKnowledgeSkillsAlerts.ts
+++ b/src/components/builder/sections/skills/knowledgeSkills/hooks/useKnowledgeSkillsAlerts.ts
@@ -1,7 +1,7 @@
 import pluralize from "pluralize"
 
 import type { AlertInfo } from "#/components/ui/alerts/alertInfo.ts"
-import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
+import { useEditorMode } from "#/stores/builder/editorMode.tsx"
 import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
 
 import {
@@ -12,9 +12,9 @@ export const useKnowledgeSkillsAlerts = (): AlertInfo[] => {
   const knowledgeSkills = useRunnerStoreSelector(Selectors.skills.selectKnowledgeSkills)
   const languageSkills = useRunnerStoreSelector(Selectors.skills.selectLanguageSkills)
   const skillPoints = useKnowledgeSkillPoints()
-  const isEditMode = useIsEditMode()
+  const { isEdit } = useEditorMode()
 
-  if (isEditMode) return []
+  if (isEdit) return []
 
   const statuses: AlertInfo[] = []
 

--- a/src/components/builder/sections/skills/knowledgeSkills/hooks/useKnowledgeSkillsAlerts.ts
+++ b/src/components/builder/sections/skills/knowledgeSkills/hooks/useKnowledgeSkillsAlerts.ts
@@ -1,6 +1,7 @@
 import pluralize from "pluralize"
 
 import type { AlertInfo } from "#/components/ui/alerts/alertInfo.ts"
+import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
 import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
 
 import {
@@ -11,6 +12,9 @@ export const useKnowledgeSkillsAlerts = (): AlertInfo[] => {
   const knowledgeSkills = useRunnerStoreSelector(Selectors.skills.selectKnowledgeSkills)
   const languageSkills = useRunnerStoreSelector(Selectors.skills.selectLanguageSkills)
   const skillPoints = useKnowledgeSkillPoints()
+  const isEditMode = useIsEditMode()
+
+  if (isEditMode) return []
 
   const statuses: AlertInfo[] = []
 

--- a/src/components/builder/sections/skills/knowledgeSkills/knowledgeSkillsList.tsx
+++ b/src/components/builder/sections/skills/knowledgeSkills/knowledgeSkillsList.tsx
@@ -11,6 +11,7 @@ import {
 import { useLanguageSkillDialog } from "#/components/runner/skills/knowledgeSkills/dialogs/languageSkillDialog.tsx"
 import { BuildPoints } from "#/components/ui/buildPoints.tsx"
 import { SkillPoints } from "#/components/ui/skillPoints.tsx"
+import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
 import { Actions } from "#/stores/runner/runnerStore.actions.ts"
 import { useRunnerStoreDispatch } from "#/stores/runner/runnerStore.dispatch.ts"
 import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
@@ -31,6 +32,7 @@ export const KnowledgeSkillsList: FC = () => {
   const dispatch = useRunnerStoreDispatch()
   const skillPoints = useKnowledgeSkillPoints()
   const buildPoints = useKnowledgeSkillsBuildPoints()
+  const isEditMode = useIsEditMode()
 
   const knowledgeSkills = useRunnerStoreSelector(Selectors.skills.selectKnowledgeSkills)
   const languageSkills = useRunnerStoreSelector(Selectors.skills.selectLanguageSkills)
@@ -60,7 +62,7 @@ export const KnowledgeSkillsList: FC = () => {
             <SkillPoints value={skillPoints.spent.extra} />
           </Stack>
 
-          <Typography>Extra SP costs 2 BP each</Typography>
+          {!isEditMode && <Typography>Extra SP costs 2 BP each</Typography>}
         </Stack>
 
         <BuildPoints value={buildPoints.spent} />

--- a/src/components/builder/sections/skills/knowledgeSkills/knowledgeSkillsList.tsx
+++ b/src/components/builder/sections/skills/knowledgeSkills/knowledgeSkillsList.tsx
@@ -11,7 +11,7 @@ import {
 import { useLanguageSkillDialog } from "#/components/runner/skills/knowledgeSkills/dialogs/languageSkillDialog.tsx"
 import { BuildPoints } from "#/components/ui/buildPoints.tsx"
 import { SkillPoints } from "#/components/ui/skillPoints.tsx"
-import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
+import { EditorMode } from "#/stores/builder/editorMode.tsx"
 import { Actions } from "#/stores/runner/runnerStore.actions.ts"
 import { useRunnerStoreDispatch } from "#/stores/runner/runnerStore.dispatch.ts"
 import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
@@ -32,7 +32,6 @@ export const KnowledgeSkillsList: FC = () => {
   const dispatch = useRunnerStoreDispatch()
   const skillPoints = useKnowledgeSkillPoints()
   const buildPoints = useKnowledgeSkillsBuildPoints()
-  const isEditMode = useIsEditMode()
 
   const knowledgeSkills = useRunnerStoreSelector(Selectors.skills.selectKnowledgeSkills)
   const languageSkills = useRunnerStoreSelector(Selectors.skills.selectLanguageSkills)
@@ -62,7 +61,9 @@ export const KnowledgeSkillsList: FC = () => {
             <SkillPoints value={skillPoints.spent.extra} />
           </Stack>
 
-          {!isEditMode && <Typography>Extra SP costs 2 BP each</Typography>}
+          <EditorMode.IsBuilder>
+            <Typography>Extra SP costs 2 BP each</Typography>
+          </EditorMode.IsBuilder>
         </Stack>
 
         <BuildPoints value={buildPoints.spent} />

--- a/src/components/builder/sections/summary/bpSummaryFooter.tsx
+++ b/src/components/builder/sections/summary/bpSummaryFooter.tsx
@@ -15,16 +15,19 @@ import type { FC } from "react"
 import { useState } from "react"
 
 import { useBuilderBuildPointsApi } from "#/components/builder/buildPoints/hooks/useBuildPointsApi.ts"
+import type { BuilderSectionId } from "#/components/builder/sections/builderSectionId.ts"
 import { builderSections } from "#/components/builder/sections/builderSectionId.ts"
 import { BuildPoints } from "#/components/ui/buildPoints.tsx"
 import { getProgress } from "#/lib/progressUtils.ts"
 
 interface BpSummaryFooterProps {
   onExpandedChange?: (expanded: boolean) => void
+  onSelectSection?: (sectionId: BuilderSectionId) => void
 }
 
 export const BpSummaryFooter: FC<BpSummaryFooterProps> = ({
   onExpandedChange,
+  onSelectSection,
 }) => {
   const [isExpanded, setIsExpanded] = useState(false)
   const summary = useBuilderBuildPointsApi()
@@ -34,8 +37,14 @@ export const BpSummaryFooter: FC<BpSummaryFooterProps> = ({
     onExpandedChange?.(expanded)
   }
 
-  const handleSectionClick = (sectionId: string | undefined) => {
+  const handleSectionClick = (sectionId: BuilderSectionId | undefined) => {
     if (!sectionId) return
+
+    if (onSelectSection) {
+      onSelectSection(sectionId)
+      handleExpandedChange(false)
+      return
+    }
 
     const targetElement = document.getElementById(sectionId)
     if (!targetElement) {

--- a/src/components/builder/sections/summary/bpSummaryFooter.tsx
+++ b/src/components/builder/sections/summary/bpSummaryFooter.tsx
@@ -15,19 +15,16 @@ import type { FC } from "react"
 import { useState } from "react"
 
 import { useBuilderBuildPointsApi } from "#/components/builder/buildPoints/hooks/useBuildPointsApi.ts"
-import type { BuilderSectionId } from "#/components/builder/sections/builderSectionId.ts"
 import { builderSections } from "#/components/builder/sections/builderSectionId.ts"
 import { BuildPoints } from "#/components/ui/buildPoints.tsx"
 import { getProgress } from "#/lib/progressUtils.ts"
 
 interface BpSummaryFooterProps {
   onExpandedChange?: (expanded: boolean) => void
-  onSelectSection?: (sectionId: BuilderSectionId) => void
 }
 
 export const BpSummaryFooter: FC<BpSummaryFooterProps> = ({
   onExpandedChange,
-  onSelectSection,
 }) => {
   const [isExpanded, setIsExpanded] = useState(false)
   const summary = useBuilderBuildPointsApi()
@@ -37,14 +34,8 @@ export const BpSummaryFooter: FC<BpSummaryFooterProps> = ({
     onExpandedChange?.(expanded)
   }
 
-  const handleSectionClick = (sectionId: BuilderSectionId | undefined) => {
+  const handleSectionClick = (sectionId: string | undefined) => {
     if (!sectionId) return
-
-    if (onSelectSection) {
-      onSelectSection(sectionId)
-      handleExpandedChange(false)
-      return
-    }
 
     const targetElement = document.getElementById(sectionId)
     if (!targetElement) {

--- a/src/components/runner/runnerRosterList.tsx
+++ b/src/components/runner/runnerRosterList.tsx
@@ -1,16 +1,21 @@
 import DeleteIcon from "@mui/icons-material/Delete"
 import DownloadIcon from "@mui/icons-material/Download"
+import EditIcon from "@mui/icons-material/Edit"
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutlined"
+import MoreVertIcon from "@mui/icons-material/MoreVert"
 import IconButton from "@mui/material/IconButton"
 import List from "@mui/material/List"
 import ListItem from "@mui/material/ListItem"
 import ListItemButton from "@mui/material/ListItemButton"
 import ListItemIcon from "@mui/material/ListItemIcon"
 import ListItemText from "@mui/material/ListItemText"
+import Menu from "@mui/material/Menu"
+import MenuItem from "@mui/material/MenuItem"
 import Paper from "@mui/material/Paper"
 import Tooltip from "@mui/material/Tooltip"
 import Typography from "@mui/material/Typography"
 import { useNavigate, useRouter } from "@tanstack/react-router"
+import { useState } from "react"
 
 import { useConfirmDialog } from "#/components/ui/dialog/confirmDialog.tsx"
 import type { RunnerLoadError } from "#/runner/runnerLoadError.ts"
@@ -32,6 +37,7 @@ export default function RunnerRosterList({
   const router = useRouter()
   const confirmDialog = useConfirmDialog()
   const runnerManager = useRunnerManager()
+  const [menuState, setMenuState] = useState<{ anchorEl: HTMLElement, runner: RunnerData } | null>(null)
 
   const sortedRunners = Object.values(runners).sort((a, b) =>
     a.profile.alias.localeCompare(b.profile.alias),
@@ -71,6 +77,18 @@ export default function RunnerRosterList({
     }
   }
 
+  const closeMenu = () => setMenuState(null)
+
+  const handleEditRunner = (runner: RunnerData) => {
+    closeMenu()
+    navigate({ to: "/edit/$runnerId", params: { runnerId: runner.id } })
+  }
+
+  const handleDeleteRunner = (runner: RunnerData) => {
+    closeMenu()
+    void confirmAndDeleteRunner(runner)
+  }
+
   return (
     <Paper>
       <List disablePadding>
@@ -79,17 +97,16 @@ export default function RunnerRosterList({
             key={runner.id}
             divider={index < totalItems - 1}
             secondaryAction={(
-              <Tooltip title="Delete runner">
+              <Tooltip title="Runner actions">
                 <IconButton
                   edge="end"
-                  aria-label="delete runner"
-                  color="error"
+                  aria-label="runner actions"
                   onClick={(event) => {
                     event.stopPropagation()
-                    void confirmAndDeleteRunner(runner)
+                    setMenuState({ anchorEl: event.currentTarget, runner })
                   }}
                 >
-                  <DeleteIcon />
+                  <MoreVertIcon />
                 </IconButton>
               </Tooltip>
             )}
@@ -169,6 +186,21 @@ export default function RunnerRosterList({
           </ListItem>
         ))}
       </List>
+
+      <Menu
+        anchorEl={menuState?.anchorEl}
+        open={menuState !== null}
+        onClose={closeMenu}
+      >
+        <MenuItem onClick={() => menuState && handleEditRunner(menuState.runner)}>
+          <ListItemIcon><EditIcon fontSize="small" /></ListItemIcon>
+          Edit
+        </MenuItem>
+        <MenuItem onClick={() => menuState && handleDeleteRunner(menuState.runner)} sx={{ color: "error.main" }}>
+          <ListItemIcon sx={{ color: "error.main" }}><DeleteIcon fontSize="small" /></ListItemIcon>
+          Delete
+        </MenuItem>
+      </Menu>
 
       {confirmDialog.dialog}
     </Paper>

--- a/src/components/ui/buildPoints.tsx
+++ b/src/components/ui/buildPoints.tsx
@@ -5,7 +5,7 @@ import type { SxProps, Theme } from "@mui/material/styles"
 import type { FC } from "react"
 
 import { mergeSx } from "#/integrations/mui/muiUtils.ts"
-import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
+import { EditorMode } from "#/stores/builder/editorMode.tsx"
 
 interface BuildPointsProps {
   value: number
@@ -22,18 +22,17 @@ export const BuildPoints: FC<BuildPointsProps> = ({
   sx,
   error = false,
 }) => {
-  const isEditMode = useIsEditMode()
-  if (isEditMode) return null
-
   const displayText =
     total !== undefined ? `${value} / ${total} BP` : `${value} BP`
 
   return (
-    <Typography
-      variant={variant}
-      sx={mergeSx({ color: error ? "error.main" : lightBlue[700] }, sx)}
-    >
-      {displayText}
-    </Typography>
+    <EditorMode.IsBuilder>
+      <Typography
+        variant={variant}
+        sx={mergeSx({ color: error ? "error.main" : lightBlue[700] }, sx)}
+      >
+        {displayText}
+      </Typography>
+    </EditorMode.IsBuilder>
   )
 }

--- a/src/components/ui/buildPoints.tsx
+++ b/src/components/ui/buildPoints.tsx
@@ -5,6 +5,7 @@ import type { SxProps, Theme } from "@mui/material/styles"
 import type { FC } from "react"
 
 import { mergeSx } from "#/integrations/mui/muiUtils.ts"
+import { useIsEditMode } from "#/stores/builder/editMode.context.ts"
 
 interface BuildPointsProps {
   value: number
@@ -21,6 +22,9 @@ export const BuildPoints: FC<BuildPointsProps> = ({
   sx,
   error = false,
 }) => {
+  const isEditMode = useIsEditMode()
+  if (isEditMode) return null
+
   const displayText =
     total !== undefined ? `${value} / ${total} BP` : `${value} BP`
 

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as RunnerIdIndexRouteImport } from './routes/$runnerId/index'
 import { Route as GmNpcBuilderRouteImport } from './routes/gm/npc-builder'
 import { Route as GmInitiativeTrackerRouteImport } from './routes/gm/initiative-tracker'
 import { Route as GmEncounterBuilderRouteImport } from './routes/gm/encounter-builder'
+import { Route as EditRunnerIdRouteImport } from './routes/edit/$runnerId'
 import { Route as RunnerIdVehiclesRouteImport } from './routes/$runnerId/vehicles'
 import { Route as RunnerIdSpritesRouteImport } from './routes/$runnerId/sprites'
 import { Route as RunnerIdSpiritsRouteImport } from './routes/$runnerId/spirits'
@@ -74,6 +75,11 @@ const GmInitiativeTrackerRoute = GmInitiativeTrackerRouteImport.update({
 const GmEncounterBuilderRoute = GmEncounterBuilderRouteImport.update({
   id: '/gm/encounter-builder',
   path: '/gm/encounter-builder',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const EditRunnerIdRoute = EditRunnerIdRouteImport.update({
+  id: '/edit/$runnerId',
+  path: '/edit/$runnerId',
   getParentRoute: () => rootRouteImport,
 } as any)
 const RunnerIdVehiclesRoute = RunnerIdVehiclesRouteImport.update({
@@ -187,6 +193,7 @@ export interface FileRoutesByFullPath {
   '/$runnerId/spirits': typeof RunnerIdSpiritsRoute
   '/$runnerId/sprites': typeof RunnerIdSpritesRoute
   '/$runnerId/vehicles': typeof RunnerIdVehiclesRoute
+  '/edit/$runnerId': typeof EditRunnerIdRoute
   '/gm/encounter-builder': typeof GmEncounterBuilderRoute
   '/gm/initiative-tracker': typeof GmInitiativeTrackerRoute
   '/gm/npc-builder': typeof GmNpcBuilderRoute
@@ -214,6 +221,7 @@ export interface FileRoutesByTo {
   '/$runnerId/spirits': typeof RunnerIdSpiritsRoute
   '/$runnerId/sprites': typeof RunnerIdSpritesRoute
   '/$runnerId/vehicles': typeof RunnerIdVehiclesRoute
+  '/edit/$runnerId': typeof EditRunnerIdRoute
   '/gm/encounter-builder': typeof GmEncounterBuilderRoute
   '/gm/initiative-tracker': typeof GmInitiativeTrackerRoute
   '/gm/npc-builder': typeof GmNpcBuilderRoute
@@ -243,6 +251,7 @@ export interface FileRoutesById {
   '/$runnerId/spirits': typeof RunnerIdSpiritsRoute
   '/$runnerId/sprites': typeof RunnerIdSpritesRoute
   '/$runnerId/vehicles': typeof RunnerIdVehiclesRoute
+  '/edit/$runnerId': typeof EditRunnerIdRoute
   '/gm/encounter-builder': typeof GmEncounterBuilderRoute
   '/gm/initiative-tracker': typeof GmInitiativeTrackerRoute
   '/gm/npc-builder': typeof GmNpcBuilderRoute
@@ -273,6 +282,7 @@ export interface FileRouteTypes {
     | '/$runnerId/spirits'
     | '/$runnerId/sprites'
     | '/$runnerId/vehicles'
+    | '/edit/$runnerId'
     | '/gm/encounter-builder'
     | '/gm/initiative-tracker'
     | '/gm/npc-builder'
@@ -300,6 +310,7 @@ export interface FileRouteTypes {
     | '/$runnerId/spirits'
     | '/$runnerId/sprites'
     | '/$runnerId/vehicles'
+    | '/edit/$runnerId'
     | '/gm/encounter-builder'
     | '/gm/initiative-tracker'
     | '/gm/npc-builder'
@@ -328,6 +339,7 @@ export interface FileRouteTypes {
     | '/$runnerId/spirits'
     | '/$runnerId/sprites'
     | '/$runnerId/vehicles'
+    | '/edit/$runnerId'
     | '/gm/encounter-builder'
     | '/gm/initiative-tracker'
     | '/gm/npc-builder'
@@ -340,6 +352,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   RunnerIdRoute: typeof RunnerIdRouteWithChildren
+  EditRunnerIdRoute: typeof EditRunnerIdRoute
   GmEncounterBuilderRoute: typeof GmEncounterBuilderRoute
   GmInitiativeTrackerRoute: typeof GmInitiativeTrackerRoute
   GmNpcBuilderRoute: typeof GmNpcBuilderRoute
@@ -404,6 +417,13 @@ declare module '@tanstack/react-router' {
       path: '/gm/encounter-builder'
       fullPath: '/gm/encounter-builder'
       preLoaderRoute: typeof GmEncounterBuilderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/edit/$runnerId': {
+      id: '/edit/$runnerId'
+      path: '/edit/$runnerId'
+      fullPath: '/edit/$runnerId'
+      preLoaderRoute: typeof EditRunnerIdRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/$runnerId/vehicles': {
@@ -584,6 +604,7 @@ const RunnerIdRouteWithChildren = RunnerIdRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   RunnerIdRoute: RunnerIdRouteWithChildren,
+  EditRunnerIdRoute: EditRunnerIdRoute,
   GmEncounterBuilderRoute: GmEncounterBuilderRoute,
   GmInitiativeTrackerRoute: GmInitiativeTrackerRoute,
   GmNpcBuilderRoute: GmNpcBuilderRoute,

--- a/src/routes/edit/$runnerId.tsx
+++ b/src/routes/edit/$runnerId.tsx
@@ -1,0 +1,32 @@
+import Box from "@mui/material/Box"
+import { createFileRoute } from "@tanstack/react-router"
+import { Suspense } from "react"
+
+import { RunnerEditor } from "#/components/builder/runnerEditor.tsx"
+import { RunnerErrorRoute } from "#/components/runner/runnerErrorRoute.tsx"
+import { LocalStorageProvider } from "#/lib/storage/providers/localStorageProvider.ts"
+import { RunnerManager } from "#/runner/runnerManager.ts"
+import type { RunnerData } from "#/system/runnerData.ts"
+
+// Module-level manager for use in loaders (outside React context)
+const loaderManager = new RunnerManager({ local: LocalStorageProvider.getStorage() })
+
+export const Route = createFileRoute("/edit/$runnerId")({
+  component: RouteComponent,
+  errorComponent: RunnerErrorRoute,
+  loader: ({ params }): Promise<RunnerData> => {
+    return loaderManager.getRunner(params.runnerId)
+  },
+})
+
+function RouteComponent() {
+  const runner = Route.useLoaderData()
+
+  return (
+    <Box sx={{ padding: 1 }}>
+      <Suspense>
+        <RunnerEditor runner={runner} />
+      </Suspense>
+    </Box>
+  )
+}

--- a/src/stores/builder/editMode.context.ts
+++ b/src/stores/builder/editMode.context.ts
@@ -1,7 +1,0 @@
-import { createContext, useContext } from "react"
-
-// True when editing an existing runner (as opposed to creating a new one), where
-// build-point budgets are creation-time guardrails that no longer apply.
-export const EditModeContext = createContext(false)
-
-export const useIsEditMode = (): boolean => useContext(EditModeContext)

--- a/src/stores/builder/editMode.context.ts
+++ b/src/stores/builder/editMode.context.ts
@@ -1,0 +1,7 @@
+import { createContext, useContext } from "react"
+
+// True when editing an existing runner (as opposed to creating a new one), where
+// build-point budgets are creation-time guardrails that no longer apply.
+export const EditModeContext = createContext(false)
+
+export const useIsEditMode = (): boolean => useContext(EditModeContext)

--- a/src/stores/builder/editorMode.tsx
+++ b/src/stores/builder/editorMode.tsx
@@ -26,13 +26,13 @@ export const useEditorMode = (): EditorModeInfo => {
 }
 
 const IsBuilder: FC<PropsWithChildren> = ({ children }) => {
-  const { isBuilder } = useEditorMode()
-  return isBuilder ? children : null
+  const editorMode = useEditorMode()
+  return editorMode.isBuilder ? children : null
 }
 
 const IsEdit: FC<PropsWithChildren> = ({ children }) => {
-  const { isEdit } = useEditorMode()
-  return isEdit ? children : null
+  const editorMode = useEditorMode()
+  return editorMode.isEdit ? children : null
 }
 
 export const EditorMode = { IsBuilder, IsEdit }

--- a/src/stores/builder/editorMode.tsx
+++ b/src/stores/builder/editorMode.tsx
@@ -1,0 +1,38 @@
+import type { FC, PropsWithChildren } from "react"
+import { createContext, useContext } from "react"
+
+type EditorModeValue = "builder" | "edit"
+
+// Defaults to "builder" so components that render outside an explicit provider
+// (e.g. in isolation in tests) keep their original character-creation behavior.
+const EditorModeContext = createContext<EditorModeValue>("builder")
+
+export const EditorModeProvider: FC<PropsWithChildren<{ mode: EditorModeValue }>> = ({ mode, children }) => (
+  <EditorModeContext.Provider value={mode}>{children}</EditorModeContext.Provider>
+)
+
+export interface EditorModeInfo {
+  isBuilder: boolean
+  isEdit: boolean
+}
+
+export const useEditorMode = (): EditorModeInfo => {
+  const mode = useContext(EditorModeContext)
+
+  return {
+    isBuilder: mode === "builder",
+    isEdit: mode === "edit",
+  }
+}
+
+const IsBuilder: FC<PropsWithChildren> = ({ children }) => {
+  const { isBuilder } = useEditorMode()
+  return isBuilder ? children : null
+}
+
+const IsEdit: FC<PropsWithChildren> = ({ children }) => {
+  const { isEdit } = useEditorMode()
+  return isEdit ? children : null
+}
+
+export const EditorMode = { IsBuilder, IsEdit }


### PR DESCRIPTION
## Summary

- Adds a third runner mode, **edit**, at `/edit/$runnerId`: a full-CRUD editor for an existing runner built on the character builder's existing section components (Profile, Biology, Attributes, Qualities, Skills, Spells, Powers, Complex Forms, Sprites, Gear, Contacts), but laid out as scrollable tabs — mirroring the viewer's `RunnerNav` — instead of the creation flow's single long stacked page.
- The roster list (`RunnerRosterList`) no longer shows a standalone delete icon per runner; both Edit and Delete now live behind a three-dot ("more actions") menu. Edit opens the new edit mode for that runner; Delete keeps its existing confirm-dialog behavior.
- Build points don't matter when editing an existing runner (only at creation time), so edit mode hides all of it. This is driven by a shared `useEditorMode()` hook (returning `{ isBuilder, isEdit }`) plus `EditorMode.IsBuilder`/`EditorMode.IsEdit` children-gated components, backed by an `EditorModeContext` that `RunnerBuilder` provides as `"builder"` and `RunnerEditor` provides as `"edit"` (defaulting to `"builder"` so components rendered in isolation, e.g. in tests, keep their original behavior). Using this, edit mode makes the shared `BuildPoints` display a no-op, removes the BP summary footer and per-section budget bars/progress rows, lets attribute increments proceed regardless of remaining budget or the one-maxed-attribute chargen rule, and suppresses alerts that only make sense during creation (gear nuyen budget, unspent BP, priority-table skill-rating limits, unspent free skill points, spell BP allowance, negative-quality BP bonus cap). Genuine data-integrity and game-rule checks are unaffected (missing profile fields, duplicate skill selection, power points vs. Magic, armor encumbrance, gear availability). Character creation at `/new` is untouched — it still tracks build points exactly as before.
- `SaveRunnerButton` gained a `requireValid` prop (default `true`, unchanged for `/new`). Edit mode passes `requireValid={false}` since the remaining alert types it can still surface (e.g. a missing alias) shouldn't hard-block saving an edit.

## Test plan

- [x] `yarn tsc` — no type errors
- [x] `yarn eslint` — no lint errors
- [x] `yarn test:unit` — full suite passing
- [x] Manually exercised in a running dev server via Playwright: opened the roster kebab menu, navigated into edit mode, switched tabs, edited a field, saved, and confirmed the change persisted back on the roster; confirmed Cancel returns to the viewer.
- [x] Scanned every edit-mode tab for leftover "BP" text after the build-points-hiding pass, and again after the `EditorMode` refactor — none found in either pass.
- [x] Confirmed `/new` (character creation) still shows full build-point tracking, unaffected by the edit-mode changes, in both passes.