### PR TITLE
Merge duplicate UI components identified in the audit

### DIFF
--- a/src/components/builder/sections/profile/profileSection.tsx
+++ b/src/components/builder/sections/profile/profileSection.tsx
@@ -1,6 +1,7 @@
-import MuiTextField from "@mui/material/TextField"
 import type { FC } from "react"
 
+import type { ProfileFieldsValue } from "#/components/runner/profile/profileFields.tsx"
+import { ProfileFields } from "#/components/runner/profile/profileFields.tsx"
 import { Actions } from "#/stores/runner/runnerStore.actions.ts"
 import { useRunnerStoreDispatch } from "#/stores/runner/runnerStore.dispatch.ts"
 import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
@@ -9,59 +10,36 @@ export const ProfileSection: FC = () => {
   const dispatch = useRunnerStoreDispatch()
   const profile = useRunnerStoreSelector(Selectors.profile.selectProfile)
 
+  const handleChange = (field: keyof ProfileFieldsValue, value: string) => {
+    switch (field) {
+      case "alias":
+        dispatch(Actions.profile.setProfileAlias(value))
+        break
+      case "name":
+        dispatch(Actions.profile.setProfileName(value))
+        break
+      case "archetype":
+        dispatch(Actions.profile.setProfileArchetype(value || null))
+        break
+      case "description":
+        dispatch(Actions.profile.setProfileDescription(value || null))
+        break
+      case "personality":
+        dispatch(Actions.profile.setProfilePersonality(value || null))
+        break
+    }
+  }
+
   return (
-    <>
-      <MuiTextField
-        label="Alias"
-        fullWidth
-        variant="outlined"
-        size="small"
-        value={profile.alias}
-        onChange={(event) => dispatch(Actions.profile.setProfileAlias(event.target.value))}
-      />
-
-      <MuiTextField
-        label="Name"
-        fullWidth
-        variant="outlined"
-        size="small"
-        value={profile.name}
-        onChange={(event) => dispatch(Actions.profile.setProfileName(event.target.value))}
-      />
-
-      <MuiTextField
-        label="Archetype"
-        fullWidth
-        variant="outlined"
-        size="small"
-        value={profile.archetype ?? ""}
-        onChange={(event) =>
-          dispatch(Actions.profile.setProfileArchetype(event.target.value || null))}
-      />
-
-      <MuiTextField
-        label="Description"
-        fullWidth
-        multiline
-        rows={3}
-        variant="outlined"
-        size="small"
-        value={profile.description ?? ""}
-        onChange={(event) =>
-          dispatch(Actions.profile.setProfileDescription(event.target.value || null))}
-      />
-
-      <MuiTextField
-        label="Personality"
-        fullWidth
-        multiline
-        rows={3}
-        variant="outlined"
-        size="small"
-        value={profile.personality ?? ""}
-        onChange={(event) =>
-          dispatch(Actions.profile.setProfilePersonality(event.target.value || null))}
-      />
-    </>
+    <ProfileFields
+      value={{
+        alias: profile.alias,
+        name: profile.name,
+        archetype: profile.archetype ?? "",
+        description: profile.description ?? "",
+        personality: profile.personality ?? "",
+      }}
+      onChange={handleChange}
+    />
   )
 }

--- a/src/components/items/availability/availabilityChip.tsx
+++ b/src/components/items/availability/availabilityChip.tsx
@@ -1,7 +1,7 @@
 import type { ChipProps } from "@mui/material/Chip"
-import Chip from "@mui/material/Chip"
 import type { FC } from "react"
 
+import { StatChip } from "#/components/ui/statChip.tsx"
 import type { AvailabilityInfo } from "#/system/availabilityInfo.ts"
 import { availabilityToString } from "#/system/availabilityInfo.ts"
 
@@ -17,13 +17,5 @@ export const AvailabilityChip: FC<AvailabilityChipProps> = ({
 
   if (availability.rating === 0) return null
 
-  return (
-    <Chip
-      size="small"
-      variant="outlined"
-      sx={{ height: 20, fontSize: "0.7rem" }}
-      {...props}
-      label={`Avail: ${rating}`}
-    />
-  )
+  return <StatChip label={`Avail: ${rating}`} {...props} />
 }

--- a/src/components/items/card/itemStatChip.tsx
+++ b/src/components/items/card/itemStatChip.tsx
@@ -1,17 +1,1 @@
-import type { ChipProps } from "@mui/material/Chip"
-import Chip from "@mui/material/Chip"
-import type { FC } from "react"
-
-interface ItemStatChipProps extends Omit<ChipProps, "size" | "variant"> {
-  label: string
-}
-
-export const ItemStatChip: FC<ItemStatChipProps> = ({ label, ...props }) => (
-  <Chip
-    label={label}
-    size="small"
-    variant="outlined"
-    sx={{ height: 20, fontSize: "0.7rem" }}
-    {...props}
-  />
-)
+export { StatChip as ItemStatChip, type StatChipProps as ItemStatChipProps } from "#/components/ui/statChip.tsx"

--- a/src/components/items/types/armor/armorItemCard.tsx
+++ b/src/components/items/types/armor/armorItemCard.tsx
@@ -1,12 +1,10 @@
 import Typography from "@mui/material/Typography"
-import { RiDeleteBin6Line, RiEdit2Line } from "@remixicon/react"
 import type { FC } from "react"
 
-import { AvailabilityChip } from "#/components/items/availability/availabilityChip.tsx"
+import { GearItemCard } from "#/components/items/card/gearItemCard.tsx"
 import { ItemCard } from "#/components/items/card/itemCard.tsx"
 import { ItemStatChip } from "#/components/items/card/itemStatChip.tsx"
 import { EquippedChip } from "#/components/items/equippedChip.tsx"
-import { GearMaxAvailability } from "#/components/items/gearUtils.ts"
 import { Nuyen } from "#/components/ui/nuyen.tsx"
 import type { ArmorData } from "#/system/gear/armorData.ts"
 
@@ -20,7 +18,7 @@ export const ArmorItemCard: FC<ArmorItemCardProps> = ({ armor, onEdit, onRemove 
   const { availability, source } = armor
 
   return (
-    <ItemCard>
+    <GearItemCard availability={availability} source={source} onEdit={onEdit} onRemove={onRemove}>
       <ItemCard.Title>{armor.name}</ItemCard.Title>
 
       {armor.equipped && (
@@ -41,29 +39,6 @@ export const ArmorItemCard: FC<ArmorItemCardProps> = ({ armor, onEdit, onRemove 
         <ItemStatChip label={`B: ${armor.ballistic}`} />
         <ItemStatChip label={`I: ${armor.impact}`} />
       </ItemCard.Meta>
-
-      {availability && (
-        <ItemCard.Meta type="stat">
-          <AvailabilityChip
-            availability={availability}
-            color={availability.rating > GearMaxAvailability ? "warning" : undefined}
-          />
-        </ItemCard.Meta>
-      )}
-
-      {source && (
-        <ItemCard.Meta type="source">
-          <ItemStatChip label={`${source.book} p.${source.page}`} />
-        </ItemCard.Meta>
-      )}
-
-      <ItemCard.Action type="icon" aria-label="Edit" onClick={onEdit}>
-        <RiEdit2Line size={16} />
-      </ItemCard.Action>
-
-      <ItemCard.Action type="icon" color="error" aria-label="Remove" onClick={onRemove}>
-        <RiDeleteBin6Line size={16} />
-      </ItemCard.Action>
-    </ItemCard>
+    </GearItemCard>
   )
 }

--- a/src/components/items/types/devices/programItemCard.tsx
+++ b/src/components/items/types/devices/programItemCard.tsx
@@ -1,12 +1,10 @@
 import Typography from "@mui/material/Typography"
-import { RiDeleteBin6Line, RiEdit2Line } from "@remixicon/react"
 import type { FC } from "react"
 
-import { AvailabilityChip } from "#/components/items/availability/availabilityChip.tsx"
+import { GearItemCard } from "#/components/items/card/gearItemCard.tsx"
 import { ItemCard } from "#/components/items/card/itemCard.tsx"
 import type { ItemCardRootProps } from "#/components/items/card/itemCardRoot.tsx"
 import { ItemStatChip } from "#/components/items/card/itemStatChip.tsx"
-import { GearMaxAvailability } from "#/components/items/gearUtils.ts"
 import { Nuyen } from "#/components/ui/nuyen.tsx"
 import type { ProgramData } from "#/system/gear/programData.ts"
 
@@ -25,7 +23,13 @@ export const ProgramItemCard: FC<ProgramItemCardProps> = ({
   const { availability, source } = program
 
   return (
-    <ItemCard variant={variant}>
+    <GearItemCard
+      availability={availability}
+      source={source}
+      onEdit={onEdit}
+      onRemove={onRemove}
+      variant={variant}
+    >
       <ItemCard.Title>{program.name}</ItemCard.Title>
 
       <ItemCard.Meta type="cost">
@@ -43,29 +47,6 @@ export const ProgramItemCard: FC<ProgramItemCardProps> = ({
       <ItemCard.Meta type="stat">
         <ItemStatChip label={program.programType} color="primary" />
       </ItemCard.Meta>
-
-      {availability && (
-        <ItemCard.Meta type="stat">
-          <AvailabilityChip
-            availability={availability}
-            color={availability.rating > GearMaxAvailability ? "warning" : undefined}
-          />
-        </ItemCard.Meta>
-      )}
-
-      {source && (
-        <ItemCard.Meta type="source">
-          <ItemStatChip label={`${source.book} p.${source.page}`} />
-        </ItemCard.Meta>
-      )}
-
-      <ItemCard.Action type="icon" aria-label="Edit" onClick={onEdit}>
-        <RiEdit2Line size={16} />
-      </ItemCard.Action>
-
-      <ItemCard.Action type="icon" color="error" aria-label="Remove" onClick={onRemove}>
-        <RiDeleteBin6Line size={16} />
-      </ItemCard.Action>
-    </ItemCard>
+    </GearItemCard>
   )
 }

--- a/src/components/runner/contacts/dialogs/legworkInfoDialog.tsx
+++ b/src/components/runner/contacts/dialogs/legworkInfoDialog.tsx
@@ -1,4 +1,3 @@
-import Button from "@mui/material/Button"
 import Stack from "@mui/material/Stack"
 import Table from "@mui/material/Table"
 import TableBody from "@mui/material/TableBody"
@@ -11,7 +10,7 @@ import { DicePool } from "#/components/system/dicePool/dicePool.tsx"
 import { createDicePool } from "#/components/system/dicePool/dicePoolData.tsx"
 import { useActiveSkillDiceGroup, useAttrDiceGroup } from "#/components/system/dicePool/useDiceGroup.ts"
 import type { ControlledDialogProps } from "#/components/ui/dialog/controlledDialogProps.ts"
-import { ControlledDialog, Dialog } from "#/components/ui/dialog/dialog.tsx"
+import { DetailDialog } from "#/components/ui/dialog/detailDialog.tsx"
 import { useDialog } from "#/components/ui/dialog/useDialog.tsx"
 import { Label } from "#/components/ui/text/label.tsx"
 import { AttributeKey } from "#/system/attributeKey.ts"
@@ -44,45 +43,39 @@ const LegworkInfoDialog: FC<LegworkInfoDialogProps> = ({ ctrl, contact }) => {
   ])
 
   return (
-    <ControlledDialog ctrl={ctrl} maxWidth="sm">
-      <Dialog.Title>{`Legwork: ${contact.name}`}</Dialog.Title>
-      <Dialog.Content>
-        <Stack sx={{ gap: 1.5 }}>
-          <Stack sx={{ gap: 0.5 }}>
-            <Label label="GM" variant="outlined" />
-            <DicePool name={gmPool.name} groups={gmPool.groups} />
-            <Typography color="text.secondary">
-              Each hit is how much the contact knows.
-            </Typography>
-          </Stack>
-
-          <Stack sx={{ gap: 0.5 }}>
-            <Label label="Player" variant="outlined" />
-            <DicePool name={playerPool.name} groups={playerPool.groups} />
-            <Typography color="text.secondary">
-              Each hit is how much the contact will offer for free.
-            </Typography>
-          </Stack>
-
-          <Stack sx={{ gap: 0.5 }}>
-            <Label label="Hits" variant="outlined" />
-            <Table size="small">
-              <TableBody>
-                {hitLevels.map(([hits, description]) => (
-                  <TableRow key={hits}>
-                    <TableCell sx={{ whiteSpace: "nowrap" }}>{hits}</TableCell>
-                    <TableCell>{description}</TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </Stack>
+    <DetailDialog ctrl={ctrl} title={`Legwork: ${contact.name}`}>
+      <Stack sx={{ gap: 1.5 }}>
+        <Stack sx={{ gap: 0.5 }}>
+          <Label label="GM" variant="outlined" />
+          <DicePool name={gmPool.name} groups={gmPool.groups} />
+          <Typography color="text.secondary">
+            Each hit is how much the contact knows.
+          </Typography>
         </Stack>
-      </Dialog.Content>
-      <Dialog.Actions>
-        <Button onClick={() => ctrl.close()}>Close</Button>
-      </Dialog.Actions>
-    </ControlledDialog>
+
+        <Stack sx={{ gap: 0.5 }}>
+          <Label label="Player" variant="outlined" />
+          <DicePool name={playerPool.name} groups={playerPool.groups} />
+          <Typography color="text.secondary">
+            Each hit is how much the contact will offer for free.
+          </Typography>
+        </Stack>
+
+        <Stack sx={{ gap: 0.5 }}>
+          <Label label="Hits" variant="outlined" />
+          <Table size="small">
+            <TableBody>
+              {hitLevels.map(([hits, description]) => (
+                <TableRow key={hits}>
+                  <TableCell sx={{ whiteSpace: "nowrap" }}>{hits}</TableCell>
+                  <TableCell>{description}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Stack>
+      </Stack>
+    </DetailDialog>
   )
 }
 

--- a/src/components/runner/magician/spells/dialogs/spellFormDialog.tsx
+++ b/src/components/runner/magician/spells/dialogs/spellFormDialog.tsx
@@ -1,12 +1,9 @@
-import Box from "@mui/material/Box"
-import Button from "@mui/material/Button"
-import Stack from "@mui/material/Stack"
 import type { FC } from "react"
 
 import { SpellFormFields } from "#/components/runner/magician/spells/form/spellFormFields.tsx"
 import { useSpellForm } from "#/components/runner/magician/spells/form/useSpellForm.ts"
 import type { ControlledDialogProps } from "#/components/ui/dialog/controlledDialogProps.ts"
-import { ControlledDialog, Dialog } from "#/components/ui/dialog/dialog.tsx"
+import { FormDialog } from "#/components/ui/dialog/formDialog.tsx"
 import { useDialog } from "#/components/ui/dialog/useDialog.tsx"
 import type { SpellData } from "#/system/magic/spellData.ts"
 
@@ -28,36 +25,15 @@ const SpellFormDialog: FC<SpellFormDialogProps> = ({
   })
 
   return (
-    <ControlledDialog ctrl={ctrl} maxWidth="sm" onClose={false} onClosed={() => form.reset()}>
-      <Dialog.Title>{title}</Dialog.Title>
-      <Dialog.Content>
-        <SpellFormFields form={form} />
-      </Dialog.Content>
-      <Dialog.Actions>
-        <Stack direction="row" sx={{ justifyContent: "space-between", width: "100%" }}>
-          <Box>
-            {onDelete && (
-              <Button
-                color="error"
-                onClick={() => {
-                  onDelete()
-                  ctrl.close()
-                }}
-              >
-                Delete
-              </Button>
-            )}
-          </Box>
-
-          <Box>
-            <Button onClick={() => ctrl.close()}>Cancel</Button>
-            <Button variant="contained" onClick={() => form.handleSubmit()}>
-              Save
-            </Button>
-          </Box>
-        </Stack>
-      </Dialog.Actions>
-    </ControlledDialog>
+    <FormDialog
+      ctrl={ctrl}
+      title={title}
+      onClosed={() => form.reset()}
+      onDelete={onDelete}
+      onSubmit={() => form.handleSubmit()}
+    >
+      <SpellFormFields form={form} />
+    </FormDialog>
   )
 }
 

--- a/src/components/runner/magician/spirits/critterPowerChip.tsx
+++ b/src/components/runner/magician/spirits/critterPowerChip.tsx
@@ -1,11 +1,10 @@
-import Button from "@mui/material/Button"
 import Chip from "@mui/material/Chip"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
 import type { FC } from "react"
-import { useState } from "react"
 
-import { Dialog } from "#/components/ui/dialog/dialog.tsx"
+import { DetailDialog } from "#/components/ui/dialog/detailDialog.tsx"
+import { useDialogCtrl } from "#/components/ui/dialog/useDialogCtrl.ts"
 import type { AttributeKey } from "#/system/attributeKey.ts"
 import type { RollType } from "#/system/magic/critterPowerData.ts"
 import {
@@ -37,7 +36,7 @@ export const CritterPowerChip: FC<CritterPowerChipProps> = ({
   color = "default",
   variant = "outlined",
 }) => {
-  const [open, setOpen] = useState(false)
+  const ctrl = useDialogCtrl<void>()
   const power = lookupCritterPower(name)
 
   const computedPool =
@@ -54,50 +53,44 @@ export const CritterPowerChip: FC<CritterPowerChipProps> = ({
         variant={variant}
         onClick={(e) => {
           e.stopPropagation()
-          setOpen(true)
+          ctrl.open()
         }}
         sx={{ cursor: "pointer" }}
       />
-      <Dialog open={open} onClose={() => setOpen(false)} maxWidth="sm">
-        <Dialog.Title>{name}</Dialog.Title>
-        <Dialog.Content dividers>
-          <Stack sx={{ gap: 1.5 }}>
-            {power?.rollType && (
-              <Stack direction="row" sx={{ alignItems: "center", gap: 1, flexWrap: "wrap" }}>
-                <Chip
-                  label={power.rollType}
-                  size="small"
-                  color={ROLL_TYPE_COLORS[power.rollType]}
-                />
-                {power.spiritPool && (
-                  <Typography variant="body2">
-                    <strong>
-                      {computedPool !== undefined ? `${computedPool} dice` : formatSpiritPoolLabel(power.spiritPool)}
-                    </strong>
-                    {computedPool !== undefined && (
-                      <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 0.5 }}>
-                        ({formatSpiritPoolLabel(power.spiritPool)})
-                      </Typography>
-                    )}
-                    {power.targetPool && ` vs. ${power.targetPool}`}
-                  </Typography>
-                )}
-              </Stack>
-            )}
-            <Typography variant="body2">
-              {power?.description ?? "No description available for this power."}
+      <DetailDialog ctrl={ctrl} title={name} dividers>
+        <Stack sx={{ gap: 1.5 }}>
+          {power?.rollType && (
+            <Stack direction="row" sx={{ alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+              <Chip
+                label={power.rollType}
+                size="small"
+                color={ROLL_TYPE_COLORS[power.rollType]}
+              />
+              {power.spiritPool && (
+                <Typography variant="body2">
+                  <strong>
+                    {computedPool !== undefined ? `${computedPool} dice` : formatSpiritPoolLabel(power.spiritPool)}
+                  </strong>
+                  {computedPool !== undefined && (
+                    <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 0.5 }}>
+                      ({formatSpiritPoolLabel(power.spiritPool)})
+                    </Typography>
+                  )}
+                  {power.targetPool && ` vs. ${power.targetPool}`}
+                </Typography>
+              )}
+            </Stack>
+          )}
+          <Typography variant="body2">
+            {power?.description ?? "No description available for this power."}
+          </Typography>
+          {power?.source && (
+            <Typography variant="caption" color="text.secondary">
+              {bookOptions.find((b) => b.value === power.source!.book)?.label ?? power.source.book}, p. {power.source.page}
             </Typography>
-            {power?.source && (
-              <Typography variant="caption" color="text.secondary">
-                {bookOptions.find((b) => b.value === power.source!.book)?.label ?? power.source.book}, p. {power.source.page}
-              </Typography>
-            )}
-          </Stack>
-        </Dialog.Content>
-        <Dialog.Actions>
-          <Button onClick={() => setOpen(false)}>Close</Button>
-        </Dialog.Actions>
-      </Dialog>
+          )}
+        </Stack>
+      </DetailDialog>
     </>
   )
 }

--- a/src/components/runner/profile/profileEditDialog.tsx
+++ b/src/components/runner/profile/profileEditDialog.tsx
@@ -13,6 +13,9 @@ import { useDialog } from "#/components/ui/dialog/useDialog.tsx"
 import { useRunnerStoreContext } from "#/stores/runner/runnerStore.context.ts"
 import { useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
 
+import type { ProfileFieldsValue } from "./profileFields.tsx"
+import { ProfileFields } from "./profileFields.tsx"
+
 type ProfileEditDialogProps = ControlledDialogProps<void>
 
 const ProfileEditDialog: FC<ProfileEditDialogProps> = ({ ctrl }) => {
@@ -20,24 +23,30 @@ const ProfileEditDialog: FC<ProfileEditDialogProps> = ({ ctrl }) => {
   const profile = useRunnerStoreSelector((s) => s.profile)
   const biology = useRunnerStoreSelector((s) => s.biology)
 
-  const [alias, setAlias] = useState(profile.alias)
-  const [name, setName] = useState(profile.name)
-  const [archetype, setArchetype] = useState(profile.archetype ?? "")
-  const [description, setDescription] = useState(profile.description ?? "")
-  const [personality, setPersonality] = useState(profile.personality ?? "")
+  const [profileFields, setProfileFields] = useState<ProfileFieldsValue>({
+    alias: profile.alias,
+    name: profile.name,
+    archetype: profile.archetype ?? "",
+    description: profile.description ?? "",
+    personality: profile.personality ?? "",
+  })
   const [gender, setGender] = useState(biology.gender ?? "")
   const [age, setAge] = useState(biology.age?.toString() ?? "")
   const [height, setHeight] = useState(biology.height ?? "")
   const [weight, setWeight] = useState(biology.weight ?? "")
 
+  const handleProfileFieldChange = (field: keyof ProfileFieldsValue, value: string) => {
+    setProfileFields((prev) => ({ ...prev, [field]: value }))
+  }
+
   const handleSave = () => {
     store.setState(
       produce((prev) => {
-        prev.profile.alias = alias
-        prev.profile.name = name
-        prev.profile.archetype = archetype || null
-        prev.profile.description = description || null
-        prev.profile.personality = personality || null
+        prev.profile.alias = profileFields.alias
+        prev.profile.name = profileFields.name
+        prev.profile.archetype = profileFields.archetype || null
+        prev.profile.description = profileFields.description || null
+        prev.profile.personality = profileFields.personality || null
         prev.biology.gender = gender || null
         prev.biology.age = age ? Number(age) : null
         prev.biology.height = height || null
@@ -55,51 +64,7 @@ const ProfileEditDialog: FC<ProfileEditDialogProps> = ({ ctrl }) => {
         <Stack divider={<Divider />} sx={{ gap: 2, padding: 1 }}>
           <Stack sx={{ gap: 1 }}>
             <Typography variant="subtitle2">Profile</Typography>
-            <MuiTextField
-              label="Alias"
-              fullWidth
-              variant="outlined"
-              size="small"
-              autoFocus
-              value={alias}
-              onChange={(e) => setAlias(e.target.value)}
-            />
-            <MuiTextField
-              label="Name"
-              fullWidth
-              variant="outlined"
-              size="small"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-            />
-            <MuiTextField
-              label="Archetype"
-              fullWidth
-              variant="outlined"
-              size="small"
-              value={archetype}
-              onChange={(e) => setArchetype(e.target.value)}
-            />
-            <MuiTextField
-              label="Description"
-              fullWidth
-              multiline
-              rows={3}
-              variant="outlined"
-              size="small"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-            />
-            <MuiTextField
-              label="Personality"
-              fullWidth
-              multiline
-              rows={3}
-              variant="outlined"
-              size="small"
-              value={personality}
-              onChange={(e) => setPersonality(e.target.value)}
-            />
+            <ProfileFields value={profileFields} onChange={handleProfileFieldChange} autoFocus />
           </Stack>
 
           <Stack sx={{ gap: 1 }}>

--- a/src/components/runner/profile/profileFields.tsx
+++ b/src/components/runner/profile/profileFields.tsx
@@ -1,0 +1,72 @@
+import MuiTextField from "@mui/material/TextField"
+import type { FC } from "react"
+
+export interface ProfileFieldsValue {
+  alias: string
+  name: string
+  archetype: string
+  description: string
+  personality: string
+}
+
+interface ProfileFieldsProps {
+  value: ProfileFieldsValue
+  onChange: (field: keyof ProfileFieldsValue, value: string) => void
+  /** Autofocus the Alias field on mount. Defaults to false. */
+  autoFocus?: boolean
+}
+
+/** Shared Alias/Name/Archetype/Description/Personality fields, used by both the builder's live-bound profile section and the viewer's locally-buffered edit dialog. */
+export const ProfileFields: FC<ProfileFieldsProps> = ({ value, onChange, autoFocus = false }) => (
+  <>
+    <MuiTextField
+      label="Alias"
+      fullWidth
+      variant="outlined"
+      size="small"
+      autoFocus={autoFocus}
+      value={value.alias}
+      onChange={(e) => onChange("alias", e.target.value)}
+    />
+
+    <MuiTextField
+      label="Name"
+      fullWidth
+      variant="outlined"
+      size="small"
+      value={value.name}
+      onChange={(e) => onChange("name", e.target.value)}
+    />
+
+    <MuiTextField
+      label="Archetype"
+      fullWidth
+      variant="outlined"
+      size="small"
+      value={value.archetype}
+      onChange={(e) => onChange("archetype", e.target.value)}
+    />
+
+    <MuiTextField
+      label="Description"
+      fullWidth
+      multiline
+      rows={3}
+      variant="outlined"
+      size="small"
+      value={value.description}
+      onChange={(e) => onChange("description", e.target.value)}
+    />
+
+    <MuiTextField
+      label="Personality"
+      fullWidth
+      multiline
+      rows={3}
+      variant="outlined"
+      size="small"
+      value={value.personality}
+      onChange={(e) => onChange("personality", e.target.value)}
+    />
+  </>
+)

--- a/src/components/runner/qualities/dialogs/qualityFormDialog.tsx
+++ b/src/components/runner/qualities/dialogs/qualityFormDialog.tsx
@@ -1,12 +1,9 @@
-import Box from "@mui/material/Box"
-import Button from "@mui/material/Button"
-import Stack from "@mui/material/Stack"
 import type { FC } from "react"
 
 import { QualityFormFields } from "#/components/runner/qualities/form/qualityFormFields.tsx"
 import { useQualityForm } from "#/components/runner/qualities/form/useQualityForm.ts"
 import type { ControlledDialogProps } from "#/components/ui/dialog/controlledDialogProps.ts"
-import { ControlledDialog, Dialog } from "#/components/ui/dialog/dialog.tsx"
+import { FormDialog } from "#/components/ui/dialog/formDialog.tsx"
 import { useDialog } from "#/components/ui/dialog/useDialog.tsx"
 import type { QualityData } from "#/system/qualityData.ts"
 
@@ -27,44 +24,16 @@ const QualityFormDialog: FC<QualityFormDialogProps> = ({
     onSubmit: (savedQuality) => ctrl.close(savedQuality),
   })
 
-  const title = editMode ? "Edit Quality" : "Add Quality"
-
   return (
-    <ControlledDialog
+    <FormDialog
       ctrl={ctrl}
-      maxWidth="sm"
-      onClose={false}
+      title={editMode ? "Edit Quality" : "Add Quality"}
       onClosed={() => form.reset()}
+      onDelete={onDelete}
+      onSubmit={() => form.handleSubmit()}
     >
-      <Dialog.Title>{title}</Dialog.Title>
-      <Dialog.Content>
-        <QualityFormFields form={form} />
-      </Dialog.Content>
-      <Dialog.Actions>
-        <Stack direction="row" sx={{ justifyContent: "space-between", width: "100%" }}>
-          <Box>
-            {onDelete && (
-              <Button
-                color="error"
-                onClick={() => {
-                  onDelete()
-                  ctrl.close()
-                }}
-              >
-                Delete
-              </Button>
-            )}
-          </Box>
-
-          <Box>
-            <Button onClick={() => ctrl.close()}>Cancel</Button>
-            <Button variant="contained" onClick={() => form.handleSubmit()}>
-              Save
-            </Button>
-          </Box>
-        </Stack>
-      </Dialog.Actions>
-    </ControlledDialog>
+      <QualityFormFields form={form} />
+    </FormDialog>
   )
 }
 

--- a/src/components/runner/qualities/dialogs/qualityInfoDialog.tsx
+++ b/src/components/runner/qualities/dialogs/qualityInfoDialog.tsx
@@ -1,10 +1,9 @@
-import Button from "@mui/material/Button"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
 import type { FC } from "react"
 
 import type { ControlledDialogProps } from "#/components/ui/dialog/controlledDialogProps.ts"
-import { ControlledDialog, Dialog } from "#/components/ui/dialog/dialog.tsx"
+import { DetailDialog } from "#/components/ui/dialog/detailDialog.tsx"
 import { useDialog } from "#/components/ui/dialog/useDialog.tsx"
 import { Label } from "#/components/ui/text/label.tsx"
 import type { QualityData } from "#/system/qualityData.ts"
@@ -22,57 +21,51 @@ const QualityInfoDialog: FC<QualityInfoDialogProps> = ({ ctrl, quality }) => {
     : undefined
 
   return (
-    <ControlledDialog ctrl={ctrl} maxWidth="sm">
-      <Dialog.Title>{quality.name}</Dialog.Title>
-      <Dialog.Content>
-        <Stack sx={{ gap: 1.5 }}>
-          <Stack direction="row" sx={{ gap: 1, flexWrap: "wrap" }}>
-            <Stack sx={{ minWidth: 80 }}>
-              <Label label="Type" variant="outlined" />
-              <Typography sx={{ textAlign: "center", textTransform: "capitalize" }}>
-                {quality.type}
-              </Typography>
-            </Stack>
-
-            {quality.bpValue !== undefined && (
-              <Stack sx={{ minWidth: 80 }}>
-                <Label label={bpLabel} variant="outlined" />
-                <Typography sx={{ textAlign: "center" }}>
-                  {quality.bpValue}
-                </Typography>
-              </Stack>
-            )}
-
-            {quality.rating !== undefined && (
-              <Stack sx={{ minWidth: 80 }}>
-                <Label label="Rating" variant="outlined" />
-                <Typography sx={{ textAlign: "center" }}>
-                  {quality.rating}
-                </Typography>
-              </Stack>
-            )}
-
-            {quality.source && (
-              <Stack sx={{ minWidth: 80 }}>
-                <Label label="Source" variant="outlined" />
-                <Typography sx={{ textAlign: "center" }}>
-                  {bookLabel} p.{quality.source.page}
-                </Typography>
-              </Stack>
-            )}
+    <DetailDialog ctrl={ctrl} title={quality.name}>
+      <Stack sx={{ gap: 1.5 }}>
+        <Stack direction="row" sx={{ gap: 1, flexWrap: "wrap" }}>
+          <Stack sx={{ minWidth: 80 }}>
+            <Label label="Type" variant="outlined" />
+            <Typography sx={{ textAlign: "center", textTransform: "capitalize" }}>
+              {quality.type}
+            </Typography>
           </Stack>
 
-          {quality.description && (
-            <Typography color="text.secondary">
-              {quality.description}
-            </Typography>
+          {quality.bpValue !== undefined && (
+            <Stack sx={{ minWidth: 80 }}>
+              <Label label={bpLabel} variant="outlined" />
+              <Typography sx={{ textAlign: "center" }}>
+                {quality.bpValue}
+              </Typography>
+            </Stack>
+          )}
+
+          {quality.rating !== undefined && (
+            <Stack sx={{ minWidth: 80 }}>
+              <Label label="Rating" variant="outlined" />
+              <Typography sx={{ textAlign: "center" }}>
+                {quality.rating}
+              </Typography>
+            </Stack>
+          )}
+
+          {quality.source && (
+            <Stack sx={{ minWidth: 80 }}>
+              <Label label="Source" variant="outlined" />
+              <Typography sx={{ textAlign: "center" }}>
+                {bookLabel} p.{quality.source.page}
+              </Typography>
+            </Stack>
           )}
         </Stack>
-      </Dialog.Content>
-      <Dialog.Actions>
-        <Button onClick={() => ctrl.close()}>Close</Button>
-      </Dialog.Actions>
-    </ControlledDialog>
+
+        {quality.description && (
+          <Typography color="text.secondary">
+            {quality.description}
+          </Typography>
+        )}
+      </Stack>
+    </DetailDialog>
   )
 }
 

--- a/src/components/runner/technomancer/dialogs/complexFormDialog.tsx
+++ b/src/components/runner/technomancer/dialogs/complexFormDialog.tsx
@@ -1,12 +1,10 @@
-import Box from "@mui/material/Box"
-import Button from "@mui/material/Button"
 import Stack from "@mui/material/Stack"
 import type { FC } from "react"
 import { z } from "zod"
 
 import { GameEffectsFieldGroup } from "#/components/system/gameEffects/gameEffectsFieldGroup.tsx"
 import type { ControlledDialogProps } from "#/components/ui/dialog/controlledDialogProps.ts"
-import { ControlledDialog, Dialog } from "#/components/ui/dialog/dialog.tsx"
+import { FormDialog } from "#/components/ui/dialog/formDialog.tsx"
 import { useDialog } from "#/components/ui/dialog/useDialog.tsx"
 import { useAppForm } from "#/integrations/tanstackForm/useAppForm.ts"
 import { NullUuid } from "#/lib/uuidUtils.ts"
@@ -42,84 +40,54 @@ const ComplexFormDialog: FC<ComplexFormDialogProps> = ({
   })
 
   return (
-    <ControlledDialog
+    <FormDialog
       ctrl={ctrl}
-      maxWidth="sm"
-      onClose={false}
+      title={isEditMode ? "Edit Complex Form" : "Add Complex Form"}
       onClosed={() => appForm.reset()}
+      onDelete={onDelete}
+      onSubmit={() => appForm.handleSubmit()}
+      color="secondary"
     >
-      <Dialog.Title>
-        {isEditMode ? "Edit Complex Form" : "Add Complex Form"}
-      </Dialog.Title>
-
-      <Dialog.Content>
-        <appForm.AppForm>
-          <Stack sx={{ gap: 2, pt: 1 }}>
-            <appForm.AppField
-              name="name"
-              validators={{ onChange: z.string().min(1, "Name is required") }}
-            >
-              {(field) => (
-                <field.TextField
-                  label="Program Name"
-                  size="small"
-                  fullWidth
-                  autoFocus
-                />
-              )}
-            </appForm.AppField>
-
-            <appForm.AppField
-              name="rating"
-              validators={{
-                onChange: z
-                  .number()
-                  .int()
-                  .min(1, "Rating must be at least 1")
-                  .max(effectiveMaxRating, `Rating cannot exceed ${effectiveMaxRating}`),
-              }}
-            >
-              {(field) => (
-                <field.NumberField
-                  label="Rating"
-                  size="small"
-                  fullWidth
-                  slotProps={{ htmlInput: { min: 1, max: effectiveMaxRating, step: 1 } }}
-                />
-              )}
-            </appForm.AppField>
-
-            <GameEffectsFieldGroup form={appForm} fields={{ effects: "effects" }} />
-          </Stack>
-        </appForm.AppForm>
-      </Dialog.Content>
-
-      <Dialog.Actions>
-        <Stack direction="row" sx={{ justifyContent: "space-between", width: "100%" }}>
-          <Box>
-            {onDelete && (
-              <Button
-                color="error"
-                onClick={() => {
-                  onDelete()
-                  ctrl.close()
-                }}
-              >
-                Delete
-              </Button>
+      <appForm.AppForm>
+        <Stack sx={{ gap: 2, pt: 1 }}>
+          <appForm.AppField
+            name="name"
+            validators={{ onChange: z.string().min(1, "Name is required") }}
+          >
+            {(field) => (
+              <field.TextField
+                label="Program Name"
+                size="small"
+                fullWidth
+                autoFocus
+              />
             )}
-          </Box>
-          <Box>
-            <Button color="secondary" onClick={() => ctrl.close()}>
-              Cancel
-            </Button>
-            <Button variant="contained" color="secondary" onClick={() => appForm.handleSubmit()}>
-              Save
-            </Button>
-          </Box>
+          </appForm.AppField>
+
+          <appForm.AppField
+            name="rating"
+            validators={{
+              onChange: z
+                .number()
+                .int()
+                .min(1, "Rating must be at least 1")
+                .max(effectiveMaxRating, `Rating cannot exceed ${effectiveMaxRating}`),
+            }}
+          >
+            {(field) => (
+              <field.NumberField
+                label="Rating"
+                size="small"
+                fullWidth
+                slotProps={{ htmlInput: { min: 1, max: effectiveMaxRating, step: 1 } }}
+              />
+            )}
+          </appForm.AppField>
+
+          <GameEffectsFieldGroup form={appForm} fields={{ effects: "effects" }} />
         </Stack>
-      </Dialog.Actions>
-    </ControlledDialog>
+      </appForm.AppForm>
+    </FormDialog>
   )
 }
 

--- a/src/components/system/initiativeTracker/combatantDetailDialog.tsx
+++ b/src/components/system/initiativeTracker/combatantDetailDialog.tsx
@@ -1,10 +1,9 @@
-import Button from "@mui/material/Button"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
 import type { FC } from "react"
 
 import type { ControlledDialogProps } from "#/components/ui/dialog/controlledDialogProps.ts"
-import { ControlledDialog, Dialog } from "#/components/ui/dialog/dialog.tsx"
+import { DetailDialog } from "#/components/ui/dialog/detailDialog.tsx"
 import { useDialog } from "#/components/ui/dialog/useDialog.tsx"
 import { Label } from "#/components/ui/text/label.tsx"
 import type { Combatant } from "#/stores/initiativeTracker/initiativeTrackerData.ts"
@@ -25,90 +24,84 @@ const CombatantDetailDialog: FC<CombatantDetailDialogProps> = ({ ctrl, combatant
     || combatant.resistWil !== undefined
 
   return (
-    <ControlledDialog ctrl={ctrl} maxWidth="sm">
-      <Dialog.Title>{combatant.name}</Dialog.Title>
-      <Dialog.Content dividers>
-        <Stack sx={{ gap: 1.5 }}>
-          <Stack direction="row" sx={{ gap: 2, justifyContent: "center" }}>
-            {combatant.initiativeDice !== undefined && (
-              <Typography color="text.secondary">Initiative: {combatant.initiativeDice}</Typography>
-            )}
-            <Typography color="text.secondary">Score: {combatant.score}</Typography>
-          </Stack>
-
-          {attributeEntries.length > 0 && (
-            <Stack sx={{ gap: 0.5 }}>
-              <Label label="Attributes" />
-              <Stack direction="row" sx={{ gap: 1.5, flexWrap: "wrap", justifyContent: "center" }}>
-                {attributeEntries.map(({ key, label, value }) => (
-                  <Stack key={key} sx={{ alignItems: "center", minWidth: 32 }}>
-                    <Typography variant="overline" color="text.secondary" sx={{ lineHeight: 1 }}>
-                      {label}
-                    </Typography>
-                    <Typography sx={{ fontWeight: "bold" }}>{value}</Typography>
-                  </Stack>
-                ))}
-              </Stack>
-            </Stack>
+    <DetailDialog ctrl={ctrl} title={combatant.name} dividers>
+      <Stack sx={{ gap: 1.5 }}>
+        <Stack direction="row" sx={{ gap: 2, justifyContent: "center" }}>
+          {combatant.initiativeDice !== undefined && (
+            <Typography color="text.secondary">Initiative: {combatant.initiativeDice}</Typography>
           )}
+          <Typography color="text.secondary">Score: {combatant.score}</Typography>
+        </Stack>
 
-          {combatant.skills && combatant.skills.length > 0 && (
-            <Stack sx={{ gap: 0.5 }}>
-              <Label label="Skills" />
-              <Stack sx={{ display: "grid", gridTemplateColumns: "1fr 1fr", rowGap: 0.5, columnGap: 2 }}>
-                {combatant.skills.map((skill) => (
-                  <Stack key={skill.name} direction="row" sx={{ justifyContent: "space-between" }}>
-                    <Typography>{skill.name}</Typography>
-                    <Typography sx={{ fontWeight: "bold" }}>{skill.pool}</Typography>
-                  </Stack>
-                ))}
-              </Stack>
-            </Stack>
-          )}
-
-          {hasResist && (
-            <Stack direction="row" sx={{ gap: 2, flexWrap: "wrap", justifyContent: "center" }}>
-              {combatant.armor !== undefined && <Typography>Armor: {combatant.armor}</Typography>}
-              {combatant.resistBod !== undefined && <Typography>Resist BOD: {combatant.resistBod}</Typography>}
-              {combatant.resistWil !== undefined && <Typography>Resist WIL: {combatant.resistWil}</Typography>}
-            </Stack>
-          )}
-
-          {combatant.damageTracks && combatant.damageTracks.length > 0 && (
-            <Stack sx={{ gap: 0.5 }}>
-              <Label label="Damage" />
-              {combatant.damageTracks.map((track) => (
-                <Stack key={track.label} direction="row" sx={{ gap: 1, alignItems: "center" }}>
-                  <Typography sx={{ minWidth: 16 }}>{track.label}</Typography>
-                  <PassPips
-                    total={track.boxes}
-                    completed={Array.from({ length: track.filled }, (_, boxIndex) => boxIndex)}
-                  />
-                  <Typography sx={{ flexGrow: 1, textAlign: "right" }} color="text.secondary">
-                    Wound Mod: {track.woundMod}
+        {attributeEntries.length > 0 && (
+          <Stack sx={{ gap: 0.5 }}>
+            <Label label="Attributes" />
+            <Stack direction="row" sx={{ gap: 1.5, flexWrap: "wrap", justifyContent: "center" }}>
+              {attributeEntries.map(({ key, label, value }) => (
+                <Stack key={key} sx={{ alignItems: "center", minWidth: 32 }}>
+                  <Typography variant="overline" color="text.secondary" sx={{ lineHeight: 1 }}>
+                    {label}
                   </Typography>
+                  <Typography sx={{ fontWeight: "bold" }}>{value}</Typography>
                 </Stack>
               ))}
             </Stack>
-          )}
+          </Stack>
+        )}
 
-          {combatant.weapons && combatant.weapons.length > 0 && (
-            <Stack sx={{ gap: 0.5 }}>
-              <Label label="Weapons" />
-              {combatant.weapons.map((weapon) => (
-                <Typography key={weapon.name}>
-                  {weapon.name}: {weapon.pool} | DV: {weapon.dv} | AP: {weapon.ap}
-                  {weapon.modes ? ` | ${weapon.modes}` : ""}
-                </Typography>
+        {combatant.skills && combatant.skills.length > 0 && (
+          <Stack sx={{ gap: 0.5 }}>
+            <Label label="Skills" />
+            <Stack sx={{ display: "grid", gridTemplateColumns: "1fr 1fr", rowGap: 0.5, columnGap: 2 }}>
+              {combatant.skills.map((skill) => (
+                <Stack key={skill.name} direction="row" sx={{ justifyContent: "space-between" }}>
+                  <Typography>{skill.name}</Typography>
+                  <Typography sx={{ fontWeight: "bold" }}>{skill.pool}</Typography>
+                </Stack>
               ))}
             </Stack>
-          )}
-        </Stack>
-      </Dialog.Content>
-      <Dialog.Actions>
-        <Button onClick={() => ctrl.close()}>Close</Button>
-      </Dialog.Actions>
-    </ControlledDialog>
+          </Stack>
+        )}
+
+        {hasResist && (
+          <Stack direction="row" sx={{ gap: 2, flexWrap: "wrap", justifyContent: "center" }}>
+            {combatant.armor !== undefined && <Typography>Armor: {combatant.armor}</Typography>}
+            {combatant.resistBod !== undefined && <Typography>Resist BOD: {combatant.resistBod}</Typography>}
+            {combatant.resistWil !== undefined && <Typography>Resist WIL: {combatant.resistWil}</Typography>}
+          </Stack>
+        )}
+
+        {combatant.damageTracks && combatant.damageTracks.length > 0 && (
+          <Stack sx={{ gap: 0.5 }}>
+            <Label label="Damage" />
+            {combatant.damageTracks.map((track) => (
+              <Stack key={track.label} direction="row" sx={{ gap: 1, alignItems: "center" }}>
+                <Typography sx={{ minWidth: 16 }}>{track.label}</Typography>
+                <PassPips
+                  total={track.boxes}
+                  completed={Array.from({ length: track.filled }, (_, boxIndex) => boxIndex)}
+                />
+                <Typography sx={{ flexGrow: 1, textAlign: "right" }} color="text.secondary">
+                  Wound Mod: {track.woundMod}
+                </Typography>
+              </Stack>
+            ))}
+          </Stack>
+        )}
+
+        {combatant.weapons && combatant.weapons.length > 0 && (
+          <Stack sx={{ gap: 0.5 }}>
+            <Label label="Weapons" />
+            {combatant.weapons.map((weapon) => (
+              <Typography key={weapon.name}>
+                {weapon.name}: {weapon.pool} | DV: {weapon.dv} | AP: {weapon.ap}
+                {weapon.modes ? ` | ${weapon.modes}` : ""}
+              </Typography>
+            ))}
+          </Stack>
+        )}
+      </Stack>
+    </DetailDialog>
   )
 }
 

--- a/src/components/ui/dialog/detailDialog.tsx
+++ b/src/components/ui/dialog/detailDialog.tsx
@@ -1,0 +1,27 @@
+import Button from "@mui/material/Button"
+import type { ReactNode } from "react"
+
+import type { ControlledDialogProps } from "./controlledDialogProps.ts"
+import { ControlledDialog, Dialog } from "./dialog.tsx"
+
+export interface DetailDialogProps extends ControlledDialogProps<void> {
+  title: ReactNode
+  /** Render divider lines around the content area. */
+  dividers?: boolean
+  children: ReactNode
+}
+
+/**
+ * Shared shell for read-only detail dialogs: a title, scrollable content,
+ * and a single "Close" action. For editable forms use `FormDialog` (small
+ * single-record forms) or `ItemDialog` (gear items) instead.
+ */
+export const DetailDialog = ({ ctrl, title, dividers, children }: DetailDialogProps) => (
+  <ControlledDialog ctrl={ctrl} maxWidth="sm">
+    <Dialog.Title>{title}</Dialog.Title>
+    <Dialog.Content dividers={dividers}>{children}</Dialog.Content>
+    <Dialog.Actions>
+      <Button onClick={() => ctrl.close()}>Close</Button>
+    </Dialog.Actions>
+  </ControlledDialog>
+)

--- a/src/components/ui/dialog/formDialog.tsx
+++ b/src/components/ui/dialog/formDialog.tsx
@@ -1,0 +1,66 @@
+import Box from "@mui/material/Box"
+import type { ButtonProps } from "@mui/material/Button"
+import Button from "@mui/material/Button"
+import Stack from "@mui/material/Stack"
+import type { ReactNode } from "react"
+
+import type { ControlledDialogProps } from "./controlledDialogProps.ts"
+import { ControlledDialog, Dialog } from "./dialog.tsx"
+
+export interface FormDialogProps<TReturn> extends ControlledDialogProps<TReturn> {
+  title: ReactNode
+  /** Called after the exit animation completes (e.g. to reset form state). */
+  onClosed?: () => void
+  onDelete?: () => void
+  onSubmit: () => void
+  /** Color for the Cancel/Save action buttons. Defaults to the theme's primary. */
+  color?: ButtonProps["color"]
+  children: ReactNode
+}
+
+/**
+ * Shared shell for single-record form dialogs: a title, content, and a
+ * Delete (left) / Cancel + Save (right) action row. For gear item forms use
+ * `ItemDialog` instead — this is for smaller single-form dialogs (qualities,
+ * spells, complex forms, and similar).
+ */
+export const FormDialog = <TReturn,>({
+  ctrl,
+  title,
+  onClosed,
+  onDelete,
+  onSubmit,
+  color,
+  children,
+}: FormDialogProps<TReturn>) => (
+  <ControlledDialog ctrl={ctrl} maxWidth="sm" onClose={false} onClosed={onClosed}>
+    <Dialog.Title>{title}</Dialog.Title>
+    <Dialog.Content>{children}</Dialog.Content>
+    <Dialog.Actions>
+      <Stack direction="row" sx={{ justifyContent: "space-between", width: "100%" }}>
+        <Box>
+          {onDelete && (
+            <Button
+              color="error"
+              onClick={() => {
+                onDelete()
+                ctrl.close()
+              }}
+            >
+              Delete
+            </Button>
+          )}
+        </Box>
+
+        <Box>
+          <Button color={color} onClick={() => ctrl.close()}>
+            Cancel
+          </Button>
+          <Button variant="contained" color={color} onClick={onSubmit}>
+            Save
+          </Button>
+        </Box>
+      </Stack>
+    </Dialog.Actions>
+  </ControlledDialog>
+)

--- a/src/components/ui/ratingChip.tsx
+++ b/src/components/ui/ratingChip.tsx
@@ -1,17 +1,12 @@
 import type { ChipProps } from "@mui/material/Chip"
-import Chip from "@mui/material/Chip"
 import type { FC } from "react"
+
+import { StatChip } from "./statChip.tsx"
 
 interface RatingChipProps extends Omit<ChipProps, "label"> {
   rating: "real" | number | string
 }
 
 export const RatingChip: FC<RatingChipProps> = ({ rating, ...props }) => (
-  <Chip
-    label={rating === "real" ? "Real" : `Rating: ${rating}`}
-    size="small"
-    variant="outlined"
-    sx={{ height: 20, fontSize: "0.7rem" }}
-    {...props}
-  />
+  <StatChip label={rating === "real" ? "Real" : `Rating: ${rating}`} {...props} />
 )

--- a/src/components/ui/statChip.tsx
+++ b/src/components/ui/statChip.tsx
@@ -1,0 +1,18 @@
+import type { ChipProps } from "@mui/material/Chip"
+import Chip from "@mui/material/Chip"
+import type { FC } from "react"
+
+export interface StatChipProps extends Omit<ChipProps, "size" | "variant"> {
+  label: string
+}
+
+/** Small outlined chip used for compact stat/metadata labels (rating, availability, source, etc). */
+export const StatChip: FC<StatChipProps> = ({ label, ...props }) => (
+  <Chip
+    label={label}
+    size="small"
+    variant="outlined"
+    sx={{ height: 20, fontSize: "0.7rem" }}
+    {...props}
+  />
+)


### PR DESCRIPTION
## Summary

Follow-up to a read-only duplicate-UI-component audit of `src/components/`. This PR merges the confirmed duplicates from that audit, except `LicenseCard`/`SinCard` (kept separate — different concepts per the user's request).

- **Chips**: `RatingChip`, `AvailabilityChip`, and `ItemStatChip` all independently implemented the exact same MUI `Chip` styling (`size="small" variant="outlined" sx={{ height: 20, fontSize: "0.7rem" }}`). Extracted a shared `StatChip` primitive (`src/components/ui/statChip.tsx`); the three now format their own label and delegate styling to it.
- **Item cards**: `ArmorItemCard` and `ProgramItemCard` re-inlined the availability/source/edit/remove footer that `GearItemCard` already exists to provide (and that `DeviceItemCard`, `VehicleItemCard`, and `WeaponItemCard` already correctly use). Migrated both onto `GearItemCard`.
- **Form dialogs**: `QualityFormDialog`, `SpellFormDialog`, and `ComplexFormDialog` each hand-rolled the identical `ControlledDialog` → Title → Content → Delete/Cancel/Save action shell that gear dialogs already avoid via the shared `ItemDialog`. Extracted a generic `FormDialog` (`src/components/ui/dialog/formDialog.tsx`) and moved all three onto it.
- **Detail dialogs**: `QualityInfoDialog`, `LegworkInfoDialog`, `CombatantDetailDialog`, and `CritterPowerChip`'s inline popup all repeated the same read-only title + content + single "Close" action layout. Extracted `DetailDialog` (`src/components/ui/dialog/detailDialog.tsx`) and moved all four onto it. `CritterPowerChip` now drives its dialog via `useDialogCtrl` instead of local `useState`, matching the rest of the app's dialog lifecycle (browser-back-to-close, overlay tracking).
- **Profile fields**: the Alias/Name/Archetype/Description/Personality `TextField` block was copy-pasted between the builder's live-bound `ProfileSection` and the viewer's locally-buffered `ProfileEditDialog`. Extracted a shared `ProfileFields` component (`src/components/runner/profile/profileFields.tsx`) parameterized by `value`/`onChange`, used by both.

Net: 18 files touched, ~245 lines removed.

## Test plan

- [x] `yarn tsc` — no type errors
- [x] `yarn eslint` on all changed/new files — no lint errors
- [x] `yarn test:unit` — all 135 tests pass (existing `profileSection.test.tsx` still passes unchanged against the refactored component)
- [x] `yarn build` — production build succeeds

No behavioral changes intended — this is a structural dedup of existing UI, with one incidental improvement: `CritterPowerChip`'s dialog now participates in the app's standard overlay/browser-back lifecycle instead of using ad hoc local state.

---
_Generated by [Claude Code](https://claude.ai/code/session_014HxihdMo8hiwGVb3aT9bx3)_