### PR TITLE
Add Licence quick-buy for Restricted gear in Builder and Viewer

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -310,9 +310,21 @@ _Avoid_: ID, identity (use SIN)
 
 **Licence**:
 An Item (`ItemType.license`) granting legal permission to carry a Restricted piece of gear.
-Currently freeform — no mechanical link to the gear it covers or the SIN it belongs to.
-Planned: a quick-buy flow that creates one or more Licences attached to a chosen SIN.
+Belongs to a SIN via the existing Attachment mechanism (`Licence.parentId` = the SIN's id). A
+Licence may cover multiple gear items — typically several instances of the same item, since a
+Licence generally certifies a gear type rather than a single serial number — via each covered
+Item's `licenseId` field; an item is covered by at most one Licence. Manually-created Licences
+remain freeform (no covered items) unless created through the quick-buy flow below.
 _Avoid_: permit, registration
+
+**Licence Quick-Buy**:
+A Player action on a Restricted, unlicensed gear item (Builder and Viewer both) that opens a
+dialog to purchase a Licence for it: pick or create a SIN, set a rating (defaulted from the
+item's Availability rating), and optionally extend coverage to other unlicensed items sharing
+the same name and `ItemType`. Not offered for **Forbidden** items — Forbidden gear has no legal
+Licence path. In the Builder the Licence is simply added (its cost counts toward the Gear BP
+budget like any other item); in the Viewer, Nuyen is withdrawn unless the Player chooses
+"Acquire" (free, matching the existing acquire/purchase distinction on new gear).
 
 **Availability**:
 A rating + restriction code on an Item describing how hard it is to obtain and whether ownership

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -319,9 +319,11 @@ _Avoid_: permit, registration
 
 **Licence Quick-Buy**:
 A Player action on a Restricted, unlicensed gear item (Builder and Viewer both) that opens a
-dialog to purchase a Licence for it: pick or create a SIN, set a rating (defaulted from the
-item's Availability rating), and optionally extend coverage to other unlicensed items sharing
-the same name and `ItemType`. Not offered for **Forbidden** items — Forbidden gear has no legal
+dialog to purchase a Licence for it: pick or create a SIN, then optionally extend coverage to
+other unlicensed items sharing the same name and `ItemType`. The Licence's rating always matches
+its SIN's reality — the Real SIN produces a free, unrestricted Real Licence with no rating to
+set; a Fake SIN produces a Fake Licence with an adjustable rating, defaulting to 3
+(`DefaultFakeLicenseRating`). Not offered for **Forbidden** items — Forbidden gear has no legal
 Licence path. In the Builder the Licence is simply added (its cost counts toward the Gear BP
 budget like any other item); in the Viewer, Nuyen is withdrawn unless the Player chooses
 "Acquire" (free, matching the existing acquire/purchase distinction on new gear).

--- a/docs/features/0001-license-quick-buy.md
+++ b/docs/features/0001-license-quick-buy.md
@@ -1,52 +1,63 @@
 # Licence Quick-Buy & SIN Association
 
-> **Status:** Draft
+> **Status:** Implemented
 >
 > **GitHub Issues / PRs:**
-> <!-- Add links once the feature is ready to implement. A feature may have multiple. -->
+> <!-- Add links once available. -->
 
 In Shadowrun 4e, carrying a **Restricted** item legally requires a **Licence** registered to a **SIN**. Runners
-typically carry multiple fake SINs, each with different sets of licences for different cover identities. Currently a
-Player can add a Licence as a freeform Item manually — there is no quick path to generate licences from existing
-restricted gear, and no association between a Licence and the SIN it belongs to.
+typically carry multiple fake SINs, each with different sets of licences for different cover identities. Previously a
+Player could only add a Licence as a freeform Item manually — there was no quick path to generate licences from
+existing restricted gear, and no association between a Licence and the SIN it belongs to.
 
-The planned feature adds:
+The feature adds:
 
-- A **quick-buy button** on Restricted Items (and/or a bulk action) that creates a Licence Item for that gear
-- A SIN selection prompt when the Runner has multiple SINs
-- The created Licence references what it covers and which SIN it belongs to
+- A **Buy License** quick-buy trigger on any Restricted, unlicensed gear item, in both Builder and Viewer
+- A dialog to pick (or create) the SIN the Licence belongs to, set a rating (defaulted from the item's Availability
+  rating), and buy the Licence — Acquire (free) or Purchase (withdraws Nuyen) in the Viewer; a single Add in the
+  Builder (its cost simply counts toward the Gear BP budget like any other item)
+- An option to extend the same Licence to other unlicensed items sharing the same name and `ItemType`, since a real
+  Licence generally certifies a gear type rather than a single serial number (e.g. one Licence covers three Ares
+  Predators)
 
-## Open Questions
+## Resolved Questions
 
-- [ ] Should a Licence be an **Attachment** on its SIN Item (SIN → Licence as parent → child), or stored flat with a
-  `sinId` reference field?
-- [ ] Should a Licence reference the specific Item it covers by ID, by name, or remain freeform text? (Real licences
-  describe gear categories, not serial numbers.)
-- [ ] Does the Viewer warn the Player when they have a Restricted/Forbidden item with no matching Licence on any active
-  SIN?
-- [ ] What happens to licences when a SIN is burned (destroyed)? Auto-invalidated, or managed manually by the Player?
-- [ ] Is Licence cost calculated from the item's Availability rating, or is it a flat fee?
+- **Licence ↔ SIN**: a Licence is an Attachment on its SIN (`Licence.parentId` = the SIN's id), reusing the existing
+  Attachment mechanism rather than a new field.
+- **Licence ↔ covered item(s)**: the reference lives on the *item* side, not the Licence — `ItemData.licenseId?: UUID`
+  points at the covering Licence. This makes the relationship many-items-to-one-licence (a Licence has no covered-item
+  list of its own; it's derived by filtering gear for `licenseId === license.id`), matching how a single Licence
+  certifies a category of gear rather than one serial number.
+- **Unlicensed-gear warnings**: not added. Out of scope for this pass — see Out of Scope below.
+- **SIN burning**: not addressed. A dangling `licenseId` (its Licence was removed) is treated as unlicensed again by
+  `isItemLicensed`, but there's no SIN-burning mechanic yet to key off.
+- **Licence cost**: derived from a rating, same as before (`getLicenseCost`); the quick-buy dialog suggests a rating
+  from the covered item's Availability rating (`suggestLicenseRating`, the inverse of `getLicenseAvailability`) but
+  the Player can adjust it.
 
 ## Constraints
 
 - Licences only apply to **Restricted** items (restriction code `R`). **Forbidden** (`F`) items cannot be licensed —
-  they are illegal to own regardless.
-- `ItemType.sin` and `ItemType.license` already exist; no new item types are needed.
-- Any SIN-Licence data relationship must be expressible within the existing flat gear store using the Attachment pattern
-  (`attachmentIds` / `attachedToId`) or a flat reference field.
+  they are illegal to own regardless. Enforced by `isLicenseQuickBuyEligible`.
+- `ItemType.sin` and `ItemType.license` already exist; no new item types were needed.
+- The relationship is expressed with a flat reference field (`ItemData.licenseId`) rather than the Attachment
+  pattern, since an item covered by a Licence isn't physically mounted on it the way an accessory is on a weapon.
 
 ## Domain Notes
 
-- **SIN** — matrix identity; Licences logically belong to a SIN
-- **Licence** — currently freeform; planned upgrade adds a mechanical link to gear and SIN
+- **SIN** — matrix identity; Licences belong to a SIN via `parentId`
+- **Licence** — covers zero or more gear items via each item's `licenseId`; a manually-created Licence has no covered
+  items unless linked through quick-buy
 - **Availability** — rating + restriction code; `R` triggers the licence requirement
-- **Attachment** — parent/child Item relationship via `attachmentIds` / `attachedToId`
+- **Attachment** — parent/child Item relationship via `attachmentIds` / `attachedToId`, used here for Licence → SIN
+  only, not for Licence → covered item
 
 ## Out of Scope
 
 - Forbidden items — no licence path exists for `F`-rated gear
 - Legal consequences of unlicensed gear — managed by the GM outside the app
 - Automatic SIN expiry or SIN burning mechanics
+- A Viewer warning for Restricted/Forbidden gear with no matching Licence on any active SIN
 
 ## Related Features
 

--- a/docs/features/0001-license-quick-buy.md
+++ b/docs/features/0001-license-quick-buy.md
@@ -13,8 +13,9 @@ existing restricted gear, and no association between a Licence and the SIN it be
 The feature adds:
 
 - A **Buy License** quick-buy trigger on any Restricted, unlicensed gear item, in both Builder and Viewer
-- A dialog to pick (or create) the SIN the Licence belongs to, set a rating (defaulted from the item's Availability
-  rating), and buy the Licence — Acquire (free) or Purchase (withdraws Nuyen) in the Viewer; a single Add in the
+- A dialog to pick (or create) the SIN the Licence belongs to. The Licence's reality always matches its SIN's — the
+  Real SIN produces a free, unrestricted Real Licence; a Fake SIN produces a Fake Licence with an adjustable rating
+  (defaulting to 3) — and buy it: Acquire (free) or Purchase (withdraws Nuyen) in the Viewer; a single Add in the
   Builder (its cost simply counts toward the Gear BP budget like any other item)
 - An option to extend the same Licence to other unlicensed items sharing the same name and `ItemType`, since a real
   Licence generally certifies a gear type rather than a single serial number (e.g. one Licence covers three Ares
@@ -31,9 +32,12 @@ The feature adds:
 - **Unlicensed-gear warnings**: not added. Out of scope for this pass — see Out of Scope below.
 - **SIN burning**: not addressed. A dangling `licenseId` (its Licence was removed) is treated as unlicensed again by
   `isItemLicensed`, but there's no SIN-burning mechanic yet to key off.
-- **Licence cost**: derived from a rating, same as before (`getLicenseCost`); the quick-buy dialog suggests a rating
-  from the covered item's Availability rating (`suggestLicenseRating`, the inverse of `getLicenseAvailability`) but
-  the Player can adjust it.
+- **Licence cost**: derived from a rating, same as before (`getLicenseCost`). Fake Licences default to rating 3
+  (`DefaultFakeLicenseRating`) — both in the manual "Add License" form and the quick-buy dialog — and the Player can
+  adjust it; a Real Licence has no rating and is always free.
+- **Licence reality vs. SIN reality**: not independent — a Fake SIN can only carry Fake Licences, and only the Real
+  SIN can carry a Real Licence. The quick-buy dialog derives `isReal` from the selected SIN's `rating` rather than
+  offering it as a separate choice.
 
 ## Constraints
 

--- a/src/components/items/genericItemCard.tsx
+++ b/src/components/items/genericItemCard.tsx
@@ -1,5 +1,5 @@
 import Typography from "@mui/material/Typography"
-import { RiDeleteBin6Line, RiEdit2Line } from "@remixicon/react"
+import { RiDeleteBin6Line, RiEdit2Line, RiFileShieldLine } from "@remixicon/react"
 import type { FC } from "react"
 
 import { Nuyen } from "#/components/ui/nuyen.tsx"
@@ -11,6 +11,7 @@ import type { ItemCardRootProps } from "./card/itemCardRoot.tsx"
 import { ItemStatChip } from "./card/itemStatChip.tsx"
 import { EquippedChip } from "./equippedChip.tsx"
 import { GearMaxAvailability } from "./gearUtils.ts"
+import { useQuickBuyLicenseAction } from "./types/licenses/useQuickBuyLicenseAction.ts"
 
 interface GenericItemCardProps extends Pick<ItemCardRootProps, "variant"> {
   item: ItemData
@@ -33,87 +34,98 @@ export const GenericItemCard: FC<GenericItemCardProps> = ({
   onRemoveSubItem,
 }) => {
   const { availability, source, description } = item
+  const licenseQuickBuy = useQuickBuyLicenseAction(item)
 
   return (
-    <ItemCard variant={variant}>
-      <ItemCard.Title>{item.name}</ItemCard.Title>
+    <>
+      <ItemCard variant={variant}>
+        <ItemCard.Title>{item.name}</ItemCard.Title>
 
-      {(item.quantity ?? 1) > 1 && (
-        <ItemCard.Meta type="cost">
-          <ItemStatChip label={`×${item.quantity ?? 1}`} color="primary" />
-        </ItemCard.Meta>
-      )}
+        {(item.quantity ?? 1) > 1 && (
+          <ItemCard.Meta type="cost">
+            <ItemStatChip label={`×${item.quantity ?? 1}`} color="primary" />
+          </ItemCard.Meta>
+        )}
 
-      {item.equipped && (
-        <ItemCard.Meta type="cost">
-          <EquippedChip />
-        </ItemCard.Meta>
-      )}
+        {item.equipped && (
+          <ItemCard.Meta type="cost">
+            <EquippedChip />
+          </ItemCard.Meta>
+        )}
 
-      {item.rating !== undefined && (
-        <ItemCard.Meta type="cost">
-          <ItemStatChip label={`Rating: ${item.rating}`} />
-        </ItemCard.Meta>
-      )}
+        {item.rating !== undefined && (
+          <ItemCard.Meta type="cost">
+            <ItemStatChip label={`Rating: ${item.rating}`} />
+          </ItemCard.Meta>
+        )}
 
-      {item.cost !== undefined && (
-        <ItemCard.Meta type="cost">
-          <Typography sx={{ fontSize: "0.875rem" }}>
-            <Nuyen amount={item.cost} />
-          </Typography>
-        </ItemCard.Meta>
-      )}
+        {item.cost !== undefined && (
+          <ItemCard.Meta type="cost">
+            <Typography sx={{ fontSize: "0.875rem" }}>
+              <Nuyen amount={item.cost} />
+            </Typography>
+          </ItemCard.Meta>
+        )}
 
-      {availability && (
-        <ItemCard.Meta type="stat">
-          <AvailabilityChip
-            availability={availability}
-            color={availability.rating > GearMaxAvailability ? "warning" : undefined}
-          />
-        </ItemCard.Meta>
-      )}
-
-      {description && (
-        <ItemCard.Meta type="stat">
-          <Typography color="text.secondary" sx={{ alignSelf: "center" }}>
-            {description}
-          </Typography>
-        </ItemCard.Meta>
-      )}
-
-      {source && (
-        <ItemCard.Meta type="source">
-          <ItemStatChip label={`${source.book} p.${source.page}`} />
-        </ItemCard.Meta>
-      )}
-
-      <ItemCard.Action type="icon" aria-label="Edit" onClick={onEdit}>
-        <RiEdit2Line size={16} />
-      </ItemCard.Action>
-
-      <ItemCard.Action type="icon" color="error" aria-label="Remove" onClick={onRemove}>
-        <RiDeleteBin6Line size={16} />
-      </ItemCard.Action>
-
-      {onAddSubItem && (
-        <ItemCard.AddChildButton onClick={onAddSubItem}>
-          Add sub-item
-        </ItemCard.AddChildButton>
-      )}
-
-      {subItems.length > 0 && (
-        <ItemCard.Children>
-          {subItems.map((subItem) => (
-            <GenericItemCard
-              key={subItem.id}
-              item={subItem}
-              variant="borderless"
-              onEdit={() => onEditSubItem?.(subItem)}
-              onRemove={() => onRemoveSubItem?.(subItem)}
+        {availability && (
+          <ItemCard.Meta type="stat">
+            <AvailabilityChip
+              availability={availability}
+              color={availability.rating > GearMaxAvailability ? "warning" : undefined}
             />
-          ))}
-        </ItemCard.Children>
-      )}
-    </ItemCard>
+          </ItemCard.Meta>
+        )}
+
+        {description && (
+          <ItemCard.Meta type="stat">
+            <Typography color="text.secondary" sx={{ alignSelf: "center" }}>
+              {description}
+            </Typography>
+          </ItemCard.Meta>
+        )}
+
+        {source && (
+          <ItemCard.Meta type="source">
+            <ItemStatChip label={`${source.book} p.${source.page}`} />
+          </ItemCard.Meta>
+        )}
+
+        <ItemCard.Action type="icon" aria-label="Edit" onClick={onEdit}>
+          <RiEdit2Line size={16} />
+        </ItemCard.Action>
+
+        <ItemCard.Action type="icon" color="error" aria-label="Remove" onClick={onRemove}>
+          <RiDeleteBin6Line size={16} />
+        </ItemCard.Action>
+
+        {onAddSubItem && (
+          <ItemCard.AddChildButton onClick={onAddSubItem}>
+            Add sub-item
+          </ItemCard.AddChildButton>
+        )}
+
+        {subItems.length > 0 && (
+          <ItemCard.Children>
+            {subItems.map((subItem) => (
+              <GenericItemCard
+                key={subItem.id}
+                item={subItem}
+                variant="borderless"
+                onEdit={() => onEditSubItem?.(subItem)}
+                onRemove={() => onRemoveSubItem?.(subItem)}
+              />
+            ))}
+          </ItemCard.Children>
+        )}
+
+        {licenseQuickBuy.eligible && (
+          <ItemCard.Action type="icon" aria-label="Buy License" onClick={licenseQuickBuy.open}>
+            <RiFileShieldLine size={16} />
+          </ItemCard.Action>
+        )}
+      </ItemCard>
+
+      {licenseQuickBuy.dialog}
+    </>
   )
 }

--- a/src/components/items/types/armor/armorItemCard.tsx
+++ b/src/components/items/types/armor/armorItemCard.tsx
@@ -1,5 +1,5 @@
 import Typography from "@mui/material/Typography"
-import { RiDeleteBin6Line, RiEdit2Line } from "@remixicon/react"
+import { RiDeleteBin6Line, RiEdit2Line, RiFileShieldLine } from "@remixicon/react"
 import type { FC } from "react"
 
 import { AvailabilityChip } from "#/components/items/availability/availabilityChip.tsx"
@@ -7,6 +7,7 @@ import { ItemCard } from "#/components/items/card/itemCard.tsx"
 import { ItemStatChip } from "#/components/items/card/itemStatChip.tsx"
 import { EquippedChip } from "#/components/items/equippedChip.tsx"
 import { GearMaxAvailability } from "#/components/items/gearUtils.ts"
+import { useQuickBuyLicenseAction } from "#/components/items/types/licenses/useQuickBuyLicenseAction.ts"
 import { Nuyen } from "#/components/ui/nuyen.tsx"
 import type { ArmorData } from "#/system/gear/armorData.ts"
 
@@ -18,52 +19,63 @@ interface ArmorItemCardProps {
 
 export const ArmorItemCard: FC<ArmorItemCardProps> = ({ armor, onEdit, onRemove }) => {
   const { availability, source } = armor
+  const licenseQuickBuy = useQuickBuyLicenseAction(armor)
 
   return (
-    <ItemCard>
-      <ItemCard.Title>{armor.name}</ItemCard.Title>
+    <>
+      <ItemCard>
+        <ItemCard.Title>{armor.name}</ItemCard.Title>
 
-      {armor.equipped && (
-        <ItemCard.Meta type="cost">
-          <EquippedChip />
-        </ItemCard.Meta>
-      )}
+        {armor.equipped && (
+          <ItemCard.Meta type="cost">
+            <EquippedChip />
+          </ItemCard.Meta>
+        )}
 
-      {armor.cost !== undefined && (
-        <ItemCard.Meta type="cost">
-          <Typography sx={{ fontSize: "0.875rem" }}>
-            <Nuyen amount={armor.cost} />
-          </Typography>
-        </ItemCard.Meta>
-      )}
+        {armor.cost !== undefined && (
+          <ItemCard.Meta type="cost">
+            <Typography sx={{ fontSize: "0.875rem" }}>
+              <Nuyen amount={armor.cost} />
+            </Typography>
+          </ItemCard.Meta>
+        )}
 
-      <ItemCard.Meta type="stat">
-        <ItemStatChip label={`B: ${armor.ballistic}`} />
-        <ItemStatChip label={`I: ${armor.impact}`} />
-      </ItemCard.Meta>
-
-      {availability && (
         <ItemCard.Meta type="stat">
-          <AvailabilityChip
-            availability={availability}
-            color={availability.rating > GearMaxAvailability ? "warning" : undefined}
-          />
+          <ItemStatChip label={`B: ${armor.ballistic}`} />
+          <ItemStatChip label={`I: ${armor.impact}`} />
         </ItemCard.Meta>
-      )}
 
-      {source && (
-        <ItemCard.Meta type="source">
-          <ItemStatChip label={`${source.book} p.${source.page}`} />
-        </ItemCard.Meta>
-      )}
+        {availability && (
+          <ItemCard.Meta type="stat">
+            <AvailabilityChip
+              availability={availability}
+              color={availability.rating > GearMaxAvailability ? "warning" : undefined}
+            />
+          </ItemCard.Meta>
+        )}
 
-      <ItemCard.Action type="icon" aria-label="Edit" onClick={onEdit}>
-        <RiEdit2Line size={16} />
-      </ItemCard.Action>
+        {source && (
+          <ItemCard.Meta type="source">
+            <ItemStatChip label={`${source.book} p.${source.page}`} />
+          </ItemCard.Meta>
+        )}
 
-      <ItemCard.Action type="icon" color="error" aria-label="Remove" onClick={onRemove}>
-        <RiDeleteBin6Line size={16} />
-      </ItemCard.Action>
-    </ItemCard>
+        <ItemCard.Action type="icon" aria-label="Edit" onClick={onEdit}>
+          <RiEdit2Line size={16} />
+        </ItemCard.Action>
+
+        <ItemCard.Action type="icon" color="error" aria-label="Remove" onClick={onRemove}>
+          <RiDeleteBin6Line size={16} />
+        </ItemCard.Action>
+
+        {licenseQuickBuy.eligible && (
+          <ItemCard.Action type="icon" aria-label="Buy License" onClick={licenseQuickBuy.open}>
+            <RiFileShieldLine size={16} />
+          </ItemCard.Action>
+        )}
+      </ItemCard>
+
+      {licenseQuickBuy.dialog}
+    </>
   )
 }

--- a/src/components/items/types/devices/deviceItemCard.tsx
+++ b/src/components/items/types/devices/deviceItemCard.tsx
@@ -1,9 +1,11 @@
 import Typography from "@mui/material/Typography"
+import { RiFileShieldLine } from "@remixicon/react"
 import type { FC } from "react"
 
 import { GearItemCard } from "#/components/items/card/gearItemCard.tsx"
 import { ItemCard } from "#/components/items/card/itemCard.tsx"
 import { ItemStatChip } from "#/components/items/card/itemStatChip.tsx"
+import { useQuickBuyLicenseAction } from "#/components/items/types/licenses/useQuickBuyLicenseAction.ts"
 import { Nuyen } from "#/components/ui/nuyen.tsx"
 import type { DeviceData } from "#/system/gear/deviceData.ts"
 import type { ProgramData } from "#/system/gear/programData.ts"
@@ -30,6 +32,7 @@ export const DeviceItemCard: FC<DeviceItemCardProps> = ({
   onRemoveProgram,
 }) => {
   const { availability, source } = device
+  const licenseQuickBuy = useQuickBuyLicenseAction(device)
 
   const deviceTypeLabel =
     device.deviceType === "commlink"
@@ -43,65 +46,75 @@ export const DeviceItemCard: FC<DeviceItemCardProps> = ({
     || device.firewall !== undefined
 
   return (
-    <GearItemCard
-      availability={availability}
-      source={source}
-      onEdit={onEdit}
-      onRemove={onRemove}
-    >
-      <ItemCard.Title>{device.name}</ItemCard.Title>
+    <>
+      <GearItemCard
+        availability={availability}
+        source={source}
+        onEdit={onEdit}
+        onRemove={onRemove}
+      >
+        <ItemCard.Title>{device.name}</ItemCard.Title>
 
-      {device.cost !== undefined && (
-        <ItemCard.Meta type="cost">
-          <Typography sx={{ fontSize: "0.875rem" }}>
-            <Nuyen amount={device.cost} />
-          </Typography>
-        </ItemCard.Meta>
-      )}
-
-      <ItemCard.Meta type="stat">
-        <ItemStatChip label={deviceTypeLabel} />
-        {device.deviceRating !== undefined && (
-          <ItemStatChip label={`Rating: ${device.deviceRating}`} />
+        {device.cost !== undefined && (
+          <ItemCard.Meta type="cost">
+            <Typography sx={{ fontSize: "0.875rem" }}>
+              <Nuyen amount={device.cost} />
+            </Typography>
+          </ItemCard.Meta>
         )}
-      </ItemCard.Meta>
 
-      {hasStats && (
         <ItemCard.Meta type="stat">
-          {device.response !== undefined && (
-            <ItemStatChip label={`Res: ${device.response}`} />
-          )}
-          {device.signal !== undefined && (
-            <ItemStatChip label={`Sig: ${device.signal}`} />
-          )}
-          {device.system !== undefined && (
-            <ItemStatChip label={`Sys: ${device.system}`} />
-          )}
-          {device.firewall !== undefined && (
-            <ItemStatChip label={`FW: ${device.firewall}`} />
+          <ItemStatChip label={deviceTypeLabel} />
+          {device.deviceRating !== undefined && (
+            <ItemStatChip label={`Rating: ${device.deviceRating}`} />
           )}
         </ItemCard.Meta>
-      )}
 
-      {onAddProgram && (
-        <ItemCard.AddChildButton onClick={onAddProgram}>
-          Add Program
-        </ItemCard.AddChildButton>
-      )}
+        {hasStats && (
+          <ItemCard.Meta type="stat">
+            {device.response !== undefined && (
+              <ItemStatChip label={`Res: ${device.response}`} />
+            )}
+            {device.signal !== undefined && (
+              <ItemStatChip label={`Sig: ${device.signal}`} />
+            )}
+            {device.system !== undefined && (
+              <ItemStatChip label={`Sys: ${device.system}`} />
+            )}
+            {device.firewall !== undefined && (
+              <ItemStatChip label={`FW: ${device.firewall}`} />
+            )}
+          </ItemCard.Meta>
+        )}
 
-      {programs.length > 0 && (
-        <ItemCard.Children>
-          {programs.map((program) => (
-            <ProgramItemCard
-              key={program.id}
-              program={program}
-              variant="borderless"
-              onEdit={() => onEditProgram?.(program)}
-              onRemove={() => onRemoveProgram?.(program)}
-            />
-          ))}
-        </ItemCard.Children>
-      )}
-    </GearItemCard>
+        {onAddProgram && (
+          <ItemCard.AddChildButton onClick={onAddProgram}>
+            Add Program
+          </ItemCard.AddChildButton>
+        )}
+
+        {programs.length > 0 && (
+          <ItemCard.Children>
+            {programs.map((program) => (
+              <ProgramItemCard
+                key={program.id}
+                program={program}
+                variant="borderless"
+                onEdit={() => onEditProgram?.(program)}
+                onRemove={() => onRemoveProgram?.(program)}
+              />
+            ))}
+          </ItemCard.Children>
+        )}
+
+        {licenseQuickBuy.eligible && (
+          <ItemCard.Action type="icon" aria-label="Buy License" onClick={licenseQuickBuy.open}>
+            <RiFileShieldLine size={16} />
+          </ItemCard.Action>
+        )}
+      </GearItemCard>
+
+      {licenseQuickBuy.dialog}
+    </>
   )
 }

--- a/src/components/items/types/implants/implantItemCard.tsx
+++ b/src/components/items/types/implants/implantItemCard.tsx
@@ -1,5 +1,5 @@
 import Typography from "@mui/material/Typography"
-import { RiDeleteBin6Line, RiEdit2Line } from "@remixicon/react"
+import { RiDeleteBin6Line, RiEdit2Line, RiFileShieldLine } from "@remixicon/react"
 import type { FC } from "react"
 
 import { AvailabilityChip } from "#/components/items/availability/availabilityChip.tsx"
@@ -7,6 +7,7 @@ import type { ItemCardProps } from "#/components/items/card/itemCard.tsx"
 import { ItemCard } from "#/components/items/card/itemCard.tsx"
 import { ItemStatChip } from "#/components/items/card/itemStatChip.tsx"
 import { GearMaxAvailability } from "#/components/items/gearUtils.ts"
+import { useQuickBuyLicenseAction } from "#/components/items/types/licenses/useQuickBuyLicenseAction.ts"
 import { useConfirmDialog } from "#/components/ui/dialog/confirmDialog.tsx"
 import { Nuyen } from "#/components/ui/nuyen.tsx"
 import { isNewItem } from "#/stores/runner/gear/gearSlice.actions.ts"
@@ -48,6 +49,7 @@ export const ImplantItemCard: FC<ImplantItemCardProps> = ({
   const implantFormDialog = useImplantFormDialog()
   const dispatch = useRunnerStoreDispatch()
   const confirmDialog = useConfirmDialog()
+  const licenseQuickBuy = useQuickBuyLicenseAction(implant)
 
   const handleRemove = async () => {
     const result = await confirmDialog.confirm({
@@ -126,6 +128,12 @@ export const ImplantItemCard: FC<ImplantItemCardProps> = ({
           <RiDeleteBin6Line size={16} />
         </ItemCard.Action>
 
+        {licenseQuickBuy.eligible && (
+          <ItemCard.Action type="icon" aria-label="Buy License" onClick={licenseQuickBuy.open}>
+            <RiFileShieldLine size={16} />
+          </ItemCard.Action>
+        )}
+
         {onAddAccessory && (
           <ItemCard.AddChildButton onClick={onAddAccessory}>
             Add Accessory
@@ -143,6 +151,7 @@ export const ImplantItemCard: FC<ImplantItemCardProps> = ({
 
       {implantFormDialog.dialog}
       {confirmDialog.dialog}
+      {licenseQuickBuy.dialog}
     </>
   )
 }

--- a/src/components/items/types/licenses/dialogs/quickBuyLicenseDialog.tsx
+++ b/src/components/items/types/licenses/dialogs/quickBuyLicenseDialog.tsx
@@ -1,13 +1,12 @@
 import Button from "@mui/material/Button"
 import Checkbox from "@mui/material/Checkbox"
+import Chip from "@mui/material/Chip"
 import FormControl from "@mui/material/FormControl"
 import FormControlLabel from "@mui/material/FormControlLabel"
 import InputLabel from "@mui/material/InputLabel"
 import MenuItem from "@mui/material/MenuItem"
 import Select from "@mui/material/Select"
 import Stack from "@mui/material/Stack"
-import ToggleButton from "@mui/material/ToggleButton"
-import ToggleButtonGroup from "@mui/material/ToggleButtonGroup"
 import Typography from "@mui/material/Typography"
 import type { FC } from "react"
 import { useState } from "react"
@@ -50,10 +49,13 @@ const QuickBuyLicenseDialog: FC<QuickBuyLicenseDialogProps> = ({ ctrl, item }) =
   const sinFormDialog = useSinFormDialog()
 
   const [selectedSinId, setSelectedSinId] = useState(sins[0]?.id ?? "")
-  const [isReal, setIsReal] = useState(() => sins[0]?.rating === "real")
   const [fakeRating, setFakeRating] = useState(() => suggestLicenseRating(item.availability?.rating ?? 0))
   const [coverSiblings, setCoverSiblings] = useState(true)
 
+  // A Licence's reality always matches its SIN's — a Fake SIN can only carry Fake licences,
+  // and only the Real SIN can carry a Real (free, unrestricted) licence.
+  const selectedSin = sins.find((sin) => sin.id === selectedSinId)
+  const isReal = selectedSin?.rating === "real"
   const rating: LicenseData["rating"] = isReal ? "real" : fakeRating
   const cost = getLicenseCost(rating)
   const canAfford = currentNuyen >= cost
@@ -114,47 +116,6 @@ const QuickBuyLicenseDialog: FC<QuickBuyLicenseDialogProps> = ({ ctrl, item }) =
             {item.availability && <AvailabilityChip availability={item.availability} />}
           </Stack>
 
-          <Stack direction="row" sx={{ gap: 2, alignItems: "center" }}>
-            <ToggleButtonGroup
-              size="small"
-              exclusive
-              value={isReal ? "real" : "fake"}
-              onChange={(_, value) => { if (value) setIsReal(value === "real") }}
-            >
-              <ToggleButton value="fake">Fake</ToggleButton>
-              <ToggleButton value="real">Real</ToggleButton>
-            </ToggleButtonGroup>
-
-            {!isReal && (
-              <CounterInput
-                label="Rating"
-                size="small"
-                value={fakeRating}
-                onChange={(value) => setFakeRating(value ?? 1)}
-                min={1}
-                max={6}
-              />
-            )}
-
-            <Typography color="text.secondary">
-              Cost:
-              {" "}
-              <Nuyen amount={cost} />
-            </Typography>
-          </Stack>
-
-          {siblings.length > 0 && (
-            <FormControlLabel
-              label={`Also cover ${siblings.length} other unlicensed "${item.name}"`}
-              control={(
-                <Checkbox
-                  checked={coverSiblings}
-                  onChange={(e) => setCoverSiblings(e.target.checked)}
-                />
-              )}
-            />
-          )}
-
           {sins.length === 0
             ? (
                 <Stack sx={{ gap: 1 }}>
@@ -186,6 +147,43 @@ const QuickBuyLicenseDialog: FC<QuickBuyLicenseDialogProps> = ({ ctrl, item }) =
                   </Button>
                 </Stack>
               )}
+
+          <Stack direction="row" sx={{ gap: 2, alignItems: "center" }}>
+            <Chip
+              size="small"
+              color={isReal ? "success" : "secondary"}
+              label={isReal ? "Real" : "Fake"}
+            />
+
+            {!isReal && (
+              <CounterInput
+                label="Rating"
+                size="small"
+                value={fakeRating}
+                onChange={(value) => setFakeRating(value ?? 1)}
+                min={1}
+                max={6}
+              />
+            )}
+
+            <Typography color="text.secondary">
+              Cost:
+              {" "}
+              <Nuyen amount={cost} />
+            </Typography>
+          </Stack>
+
+          {siblings.length > 0 && (
+            <FormControlLabel
+              label={`Also cover ${siblings.length} other unlicensed "${item.name}"`}
+              control={(
+                <Checkbox
+                  checked={coverSiblings}
+                  onChange={(e) => setCoverSiblings(e.target.checked)}
+                />
+              )}
+            />
+          )}
 
           {!isBuilder && !canAfford && (
             <Typography color="error.main">

--- a/src/components/items/types/licenses/dialogs/quickBuyLicenseDialog.tsx
+++ b/src/components/items/types/licenses/dialogs/quickBuyLicenseDialog.tsx
@@ -14,9 +14,9 @@ import { useState } from "react"
 import { AvailabilityChip } from "#/components/items/availability/availabilityChip.tsx"
 import { useGearByType } from "#/components/items/gearHooks.ts"
 import {
+  DefaultFakeLicenseRating,
   findLicenseableSiblings,
   getLicenseCost,
-  suggestLicenseRating,
 } from "#/components/items/types/licenses/licenseUtils.ts"
 import { CounterInput } from "#/components/ui/counter/counterInput.tsx"
 import type { ControlledDialogProps } from "#/components/ui/dialog/controlledDialogProps.ts"
@@ -49,7 +49,7 @@ const QuickBuyLicenseDialog: FC<QuickBuyLicenseDialogProps> = ({ ctrl, item }) =
   const sinFormDialog = useSinFormDialog()
 
   const [selectedSinId, setSelectedSinId] = useState(sins[0]?.id ?? "")
-  const [fakeRating, setFakeRating] = useState(() => suggestLicenseRating(item.availability?.rating ?? 0))
+  const [fakeRating, setFakeRating] = useState(DefaultFakeLicenseRating)
   const [coverSiblings, setCoverSiblings] = useState(true)
 
   // A Licence's reality always matches its SIN's — a Fake SIN can only carry Fake licences,

--- a/src/components/items/types/licenses/dialogs/quickBuyLicenseDialog.tsx
+++ b/src/components/items/types/licenses/dialogs/quickBuyLicenseDialog.tsx
@@ -6,6 +6,8 @@ import InputLabel from "@mui/material/InputLabel"
 import MenuItem from "@mui/material/MenuItem"
 import Select from "@mui/material/Select"
 import Stack from "@mui/material/Stack"
+import ToggleButton from "@mui/material/ToggleButton"
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup"
 import Typography from "@mui/material/Typography"
 import type { FC } from "react"
 import { useState } from "react"
@@ -48,9 +50,11 @@ const QuickBuyLicenseDialog: FC<QuickBuyLicenseDialogProps> = ({ ctrl, item }) =
   const sinFormDialog = useSinFormDialog()
 
   const [selectedSinId, setSelectedSinId] = useState(sins[0]?.id ?? "")
-  const [rating, setRating] = useState(() => suggestLicenseRating(item.availability?.rating ?? 0))
+  const [isReal, setIsReal] = useState(() => sins[0]?.rating === "real")
+  const [fakeRating, setFakeRating] = useState(() => suggestLicenseRating(item.availability?.rating ?? 0))
   const [coverSiblings, setCoverSiblings] = useState(true)
 
+  const rating: LicenseData["rating"] = isReal ? "real" : fakeRating
   const cost = getLicenseCost(rating)
   const canAfford = currentNuyen >= cost
   const siblings = findLicenseableSiblings(item, Object.values(allGear), licenses)
@@ -111,14 +115,26 @@ const QuickBuyLicenseDialog: FC<QuickBuyLicenseDialogProps> = ({ ctrl, item }) =
           </Stack>
 
           <Stack direction="row" sx={{ gap: 2, alignItems: "center" }}>
-            <CounterInput
-              label="Rating"
+            <ToggleButtonGroup
               size="small"
-              value={rating}
-              onChange={(value) => setRating(value ?? 1)}
-              min={1}
-              max={6}
-            />
+              exclusive
+              value={isReal ? "real" : "fake"}
+              onChange={(_, value) => { if (value) setIsReal(value === "real") }}
+            >
+              <ToggleButton value="fake">Fake</ToggleButton>
+              <ToggleButton value="real">Real</ToggleButton>
+            </ToggleButtonGroup>
+
+            {!isReal && (
+              <CounterInput
+                label="Rating"
+                size="small"
+                value={fakeRating}
+                onChange={(value) => setFakeRating(value ?? 1)}
+                min={1}
+                max={6}
+              />
+            )}
 
             <Typography color="text.secondary">
               Cost:

--- a/src/components/items/types/licenses/dialogs/quickBuyLicenseDialog.tsx
+++ b/src/components/items/types/licenses/dialogs/quickBuyLicenseDialog.tsx
@@ -1,0 +1,219 @@
+import Button from "@mui/material/Button"
+import Checkbox from "@mui/material/Checkbox"
+import FormControl from "@mui/material/FormControl"
+import FormControlLabel from "@mui/material/FormControlLabel"
+import InputLabel from "@mui/material/InputLabel"
+import MenuItem from "@mui/material/MenuItem"
+import Select from "@mui/material/Select"
+import Stack from "@mui/material/Stack"
+import Typography from "@mui/material/Typography"
+import type { FC } from "react"
+import { useState } from "react"
+
+import { AvailabilityChip } from "#/components/items/availability/availabilityChip.tsx"
+import { useGearByType } from "#/components/items/gearHooks.ts"
+import {
+  findLicenseableSiblings,
+  getLicenseCost,
+  suggestLicenseRating,
+} from "#/components/items/types/licenses/licenseUtils.ts"
+import { CounterInput } from "#/components/ui/counter/counterInput.tsx"
+import type { ControlledDialogProps } from "#/components/ui/dialog/controlledDialogProps.ts"
+import { ControlledDialog, Dialog } from "#/components/ui/dialog/dialog.tsx"
+import { useDialog } from "#/components/ui/dialog/useDialog.tsx"
+import { Nuyen } from "#/components/ui/nuyen.tsx"
+import { useIsBuilder } from "#/stores/builder/builderStore.context.ts"
+import { isNewItem } from "#/stores/runner/gear/gearSlice.actions.ts"
+import { Actions } from "#/stores/runner/runnerStore.actions.ts"
+import { useRunnerStoreDispatch } from "#/stores/runner/runnerStore.dispatch.ts"
+import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
+import type { LicenseData } from "#/system/gear/licenseData.ts"
+import type { SinData } from "#/system/gear/sinData.ts"
+import type { ItemData } from "#/system/itemData.ts"
+import { ItemType } from "#/system/itemType.ts"
+
+import { useSinFormDialog } from "./sinFormDialog.tsx"
+
+interface QuickBuyLicenseDialogProps extends ControlledDialogProps<boolean> {
+  item: ItemData
+}
+
+const QuickBuyLicenseDialog: FC<QuickBuyLicenseDialogProps> = ({ ctrl, item }) => {
+  const isBuilder = useIsBuilder()
+  const dispatch = useRunnerStoreDispatch()
+  const sins = useGearByType<SinData>(ItemType.sin)
+  const licenses = useGearByType<LicenseData>(ItemType.license)
+  const allGear = useRunnerStoreSelector(Selectors.gear.selectGear)
+  const currentNuyen = useRunnerStoreSelector(Selectors.nuyen.selectNuyenAmount)
+  const sinFormDialog = useSinFormDialog()
+
+  const [selectedSinId, setSelectedSinId] = useState(sins[0]?.id ?? "")
+  const [rating, setRating] = useState(() => suggestLicenseRating(item.availability?.rating ?? 0))
+  const [coverSiblings, setCoverSiblings] = useState(true)
+
+  const cost = getLicenseCost(rating)
+  const canAfford = currentNuyen >= cost
+  const siblings = findLicenseableSiblings(item, Object.values(allGear), licenses)
+
+  const handleCreateSin = async () => {
+    const saved = await sinFormDialog.open({})
+    if (!saved) return
+
+    if (isNewItem(saved)) {
+      const action = Actions.gear.addItem(saved)
+      dispatch(action)
+      setSelectedSinId(action.payload.id)
+    } else {
+      dispatch(Actions.gear.setItem(saved))
+      setSelectedSinId(saved.id)
+    }
+  }
+
+  const handleAcquire = () => {
+    if (!selectedSinId) return
+
+    const licenseDraft: Omit<LicenseData, "id"> = {
+      itemType: ItemType.license,
+      name: `License: ${item.name}`,
+      rating,
+      cost,
+      parentId: selectedSinId as LicenseData["parentId"],
+    }
+    const addLicenseAction = Actions.gear.addItem(licenseDraft)
+    dispatch(addLicenseAction)
+    const licenseId = addLicenseAction.payload.id
+
+    dispatch(Actions.gear.setItem({ ...item, licenseId }))
+    if (coverSiblings) {
+      for (const sibling of siblings) {
+        dispatch(Actions.gear.setItem({ ...sibling, licenseId }))
+      }
+    }
+
+    ctrl.close(true)
+  }
+
+  const handlePurchase = () => {
+    if (!selectedSinId || !canAfford) return
+    handleAcquire()
+    dispatch(Actions.nuyen.withdrawNuyen(cost))
+  }
+
+  return (
+    <ControlledDialog ctrl={ctrl} onClose={false}>
+      <Dialog.Title>Buy License</Dialog.Title>
+
+      <Dialog.Content>
+        <Stack sx={{ gap: 2, padding: 1 }}>
+          <Stack direction="row" sx={{ alignItems: "center", gap: 1 }}>
+            <Typography sx={{ flexGrow: 1 }}>{item.name}</Typography>
+            {item.availability && <AvailabilityChip availability={item.availability} />}
+          </Stack>
+
+          <Stack direction="row" sx={{ gap: 2, alignItems: "center" }}>
+            <CounterInput
+              label="Rating"
+              size="small"
+              value={rating}
+              onChange={(value) => setRating(value ?? 1)}
+              min={1}
+              max={6}
+            />
+
+            <Typography color="text.secondary">
+              Cost:
+              {" "}
+              <Nuyen amount={cost} />
+            </Typography>
+          </Stack>
+
+          {siblings.length > 0 && (
+            <FormControlLabel
+              label={`Also cover ${siblings.length} other unlicensed "${item.name}"`}
+              control={(
+                <Checkbox
+                  checked={coverSiblings}
+                  onChange={(e) => setCoverSiblings(e.target.checked)}
+                />
+              )}
+            />
+          )}
+
+          {sins.length === 0
+            ? (
+                <Stack sx={{ gap: 1 }}>
+                  <Typography color="text.secondary">
+                    This Runner has no SIN yet. Create one to attach the licence to.
+                  </Typography>
+                  <Button variant="outlined" color="secondary" onClick={handleCreateSin}>
+                    Create SIN
+                  </Button>
+                </Stack>
+              )
+            : (
+                <Stack direction="row" sx={{ gap: 1, alignItems: "center" }}>
+                  <FormControl size="small" sx={{ flex: 1 }}>
+                    <InputLabel>SIN</InputLabel>
+                    <Select
+                      label="SIN"
+                      value={selectedSinId}
+                      onChange={(e) => setSelectedSinId(e.target.value)}
+                    >
+                      {sins.map((sin) => (
+                        <MenuItem key={sin.id} value={sin.id}>{sin.name}</MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+
+                  <Button size="small" color="secondary" onClick={handleCreateSin}>
+                    New SIN
+                  </Button>
+                </Stack>
+              )}
+
+          {!isBuilder && !canAfford && (
+            <Typography color="error.main">
+              Need
+              {" "}
+              <Nuyen amount={cost} />
+              , have
+              {" "}
+              <Nuyen amount={currentNuyen} />
+            </Typography>
+          )}
+        </Stack>
+      </Dialog.Content>
+
+      <Dialog.Actions>
+        <Button onClick={() => ctrl.close()}>Cancel</Button>
+
+        {isBuilder
+          ? (
+              <Button variant="contained" disabled={!selectedSinId} onClick={handleAcquire}>
+                Add License
+              </Button>
+            )
+          : (
+              <>
+                <Button variant="outlined" color="secondary" disabled={!selectedSinId} onClick={handleAcquire}>
+                  Acquire
+                </Button>
+                <Button variant="contained" disabled={!selectedSinId || !canAfford} onClick={handlePurchase}>
+                  Purchase (
+                  <Nuyen amount={cost} />
+                  )
+                </Button>
+              </>
+            )}
+      </Dialog.Actions>
+
+      {sinFormDialog.dialog}
+    </ControlledDialog>
+  )
+}
+
+type UseQuickBuyLicenseDialogProps = Omit<QuickBuyLicenseDialogProps, keyof ControlledDialogProps<boolean>>
+
+export const useQuickBuyLicenseDialog = () => useDialog<boolean, UseQuickBuyLicenseDialogProps>(
+  (ctrl, props) => <QuickBuyLicenseDialog ctrl={ctrl} {...props} />,
+)

--- a/src/components/items/types/licenses/forms/useLicenseForm.tsx
+++ b/src/components/items/types/licenses/forms/useLicenseForm.tsx
@@ -2,7 +2,7 @@ import type { UUID } from "node:crypto"
 
 import { useItemForm, itemDefaults } from "#/components/items/forms/useItemForm.tsx"
 import type { GearSubmitMeta } from "#/components/items/gearSubmitMeta.ts"
-import { getLicenseCost } from "#/components/items/types/licenses/licenseUtils.ts"
+import { DefaultFakeLicenseRating, getLicenseCost } from "#/components/items/types/licenses/licenseUtils.ts"
 import { NullUuid } from "#/lib/uuidUtils.ts"
 import type { LicenseData } from "#/system/gear/licenseData.ts"
 import { ItemType } from "#/system/itemType.ts"
@@ -18,7 +18,7 @@ const defaultValues: LicenseData = {
   itemType: ItemType.license,
   id: NullUuid,
   name: "",
-  rating: 1,
+  rating: DefaultFakeLicenseRating,
   cost: 0,
   parentId: NullUuid,
 }

--- a/src/components/items/types/licenses/licenseUtils.test.ts
+++ b/src/components/items/types/licenses/licenseUtils.test.ts
@@ -1,0 +1,208 @@
+import type { UUID } from "node:crypto"
+
+import { describe, expect, it } from "vitest"
+
+import type { LicenseData } from "#/system/gear/licenseData.ts"
+import type { ItemData } from "#/system/itemData.ts"
+import { ItemType } from "#/system/itemType.ts"
+
+import {
+  findLicenseableSiblings,
+  getLicenseAvailability,
+  getLicenseCost,
+  isItemLicensed,
+  isLicenseQuickBuyEligible,
+  suggestLicenseRating,
+} from "./licenseUtils.ts"
+
+describe("suggestLicenseRating", () => {
+  it("derives the licence rating as the inverse of getLicenseAvailability", () => {
+    // Arrange
+    const rating = 4
+
+    // Act
+    const suggested = suggestLicenseRating(getLicenseAvailability(rating).rating)
+
+    // Assert
+    expect(suggested).toBe(rating)
+  })
+
+  it("clamps low availability ratings up to a minimum of 1", () => {
+    // Arrange / Act
+    const suggested = suggestLicenseRating(1)
+
+    // Assert
+    expect(suggested).toBe(1)
+  })
+
+  it("clamps high availability ratings down to a maximum of 6", () => {
+    // Arrange / Act
+    const suggested = suggestLicenseRating(20)
+
+    // Assert
+    expect(suggested).toBe(6)
+  })
+
+  it("rounds up availability ratings that fall between rating steps", () => {
+    // Arrange / Act
+    const suggested = suggestLicenseRating(7)
+
+    // Assert
+    expect(suggested).toBe(3)
+  })
+})
+
+describe("isLicenseQuickBuyEligible", () => {
+  const baseItem: ItemData = {
+    id: "00000000-0000-0000-0000-000000000001",
+    itemType: ItemType.weapon,
+    name: "Ares Predator",
+  }
+
+  it("is eligible for a Restricted item", () => {
+    // Arrange
+    const item: ItemData = { ...baseItem, availability: { rating: 4, restricted: true } }
+
+    // Act / Assert
+    expect(isLicenseQuickBuyEligible(item)).toBe(true)
+  })
+
+  it("is not eligible for an item with no availability", () => {
+    // Arrange / Act / Assert
+    expect(isLicenseQuickBuyEligible(baseItem)).toBe(false)
+  })
+
+  it("is not eligible for a Forbidden item", () => {
+    // Arrange
+    const item: ItemData = { ...baseItem, availability: { rating: 12, forbidden: true } }
+
+    // Act / Assert
+    expect(isLicenseQuickBuyEligible(item)).toBe(false)
+  })
+
+  it("is not eligible for a legal (unrestricted) item", () => {
+    // Arrange
+    const item: ItemData = { ...baseItem, availability: { rating: 4 } }
+
+    // Act / Assert
+    expect(isLicenseQuickBuyEligible(item)).toBe(false)
+  })
+
+  it("is not eligible for a SIN or Licence item, even if flagged restricted", () => {
+    // Arrange
+    const sin: ItemData = { ...baseItem, itemType: ItemType.sin, availability: { rating: 4, restricted: true } }
+    const license: ItemData = { ...baseItem, itemType: ItemType.license, availability: { rating: 4, restricted: true } }
+
+    // Act / Assert
+    expect(isLicenseQuickBuyEligible(sin)).toBe(false)
+    expect(isLicenseQuickBuyEligible(license)).toBe(false)
+  })
+})
+
+describe("isItemLicensed", () => {
+  const licenseId = "00000000-0000-0000-0000-000000000003"
+
+  const item: ItemData = {
+    id: "00000000-0000-0000-0000-000000000002",
+    itemType: ItemType.weapon,
+    name: "Ares Predator",
+    licenseId,
+  }
+
+  const license: LicenseData = {
+    id: licenseId,
+    itemType: ItemType.license,
+    name: "License",
+    rating: 4,
+  }
+
+  it("is true when the item's licenseId points at an existing licence", () => {
+    // Arrange / Act / Assert
+    expect(isItemLicensed(item, [license])).toBe(true)
+  })
+
+  it("is false when the item has no licenseId", () => {
+    // Arrange
+    const unlicensed: ItemData = { ...item, licenseId: undefined }
+
+    // Act / Assert
+    expect(isItemLicensed(unlicensed, [license])).toBe(false)
+  })
+
+  it("is false when licenseId points at a licence that no longer exists", () => {
+    // Arrange / Act / Assert
+    expect(isItemLicensed(item, [])).toBe(false)
+  })
+})
+
+describe("findLicenseableSiblings", () => {
+  const makePistol = (id: UUID, overrides: Partial<ItemData> = {}): ItemData => ({
+    id,
+    itemType: ItemType.weapon,
+    name: "Ares Predator",
+    ...overrides,
+  })
+
+  it("finds other unlicensed items with the same name and item type", () => {
+    // Arrange
+    const item = makePistol("00000000-0000-0000-0000-000000000001")
+    const sibling = makePistol("00000000-0000-0000-0000-000000000002")
+    const allGear = [item, sibling]
+
+    // Act
+    const siblings = findLicenseableSiblings(item, allGear, [])
+
+    // Assert
+    expect(siblings).toEqual([sibling])
+  })
+
+  it("excludes the item itself", () => {
+    // Arrange
+    const item = makePistol("00000000-0000-0000-0000-000000000001")
+
+    // Act
+    const siblings = findLicenseableSiblings(item, [item], [])
+
+    // Assert
+    expect(siblings).toEqual([])
+  })
+
+  it("excludes items that already have a valid licence", () => {
+    // Arrange
+    const item = makePistol("00000000-0000-0000-0000-000000000001")
+    const licenseId = "00000000-0000-0000-0000-000000000099"
+    const licensedSibling = makePistol("00000000-0000-0000-0000-000000000002", { licenseId })
+    const license: LicenseData = { id: licenseId, itemType: ItemType.license, name: "License", rating: 4 }
+
+    // Act
+    const siblings = findLicenseableSiblings(item, [item, licensedSibling], [license])
+
+    // Assert
+    expect(siblings).toEqual([])
+  })
+
+  it("excludes items with a different name or item type", () => {
+    // Arrange
+    const item = makePistol("00000000-0000-0000-0000-000000000001")
+    const differentName = makePistol("00000000-0000-0000-0000-000000000002", { name: "Ares Viper" })
+    const differentType = makePistol("00000000-0000-0000-0000-000000000003", { itemType: ItemType.armor })
+
+    // Act
+    const siblings = findLicenseableSiblings(item, [item, differentName, differentType], [])
+
+    // Assert
+    expect(siblings).toEqual([])
+  })
+})
+
+describe("getLicenseCost", () => {
+  it("is free for a real SIN's licence", () => {
+    // Arrange / Act / Assert
+    expect(getLicenseCost("real")).toBe(0)
+  })
+
+  it("scales with rating for a fake licence", () => {
+    // Arrange / Act / Assert
+    expect(getLicenseCost(4)).toBe(400)
+  })
+})

--- a/src/components/items/types/licenses/licenseUtils.test.ts
+++ b/src/components/items/types/licenses/licenseUtils.test.ts
@@ -7,50 +7,12 @@ import type { ItemData } from "#/system/itemData.ts"
 import { ItemType } from "#/system/itemType.ts"
 
 import {
+  DefaultFakeLicenseRating,
   findLicenseableSiblings,
-  getLicenseAvailability,
   getLicenseCost,
   isItemLicensed,
   isLicenseQuickBuyEligible,
-  suggestLicenseRating,
 } from "./licenseUtils.ts"
-
-describe("suggestLicenseRating", () => {
-  it("derives the licence rating as the inverse of getLicenseAvailability", () => {
-    // Arrange
-    const rating = 4
-
-    // Act
-    const suggested = suggestLicenseRating(getLicenseAvailability(rating).rating)
-
-    // Assert
-    expect(suggested).toBe(rating)
-  })
-
-  it("clamps low availability ratings up to a minimum of 1", () => {
-    // Arrange / Act
-    const suggested = suggestLicenseRating(1)
-
-    // Assert
-    expect(suggested).toBe(1)
-  })
-
-  it("clamps high availability ratings down to a maximum of 6", () => {
-    // Arrange / Act
-    const suggested = suggestLicenseRating(20)
-
-    // Assert
-    expect(suggested).toBe(6)
-  })
-
-  it("rounds up availability ratings that fall between rating steps", () => {
-    // Arrange / Act
-    const suggested = suggestLicenseRating(7)
-
-    // Assert
-    expect(suggested).toBe(3)
-  })
-})
 
 describe("isLicenseQuickBuyEligible", () => {
   const baseItem: ItemData = {
@@ -204,5 +166,12 @@ describe("getLicenseCost", () => {
   it("scales with rating for a fake licence", () => {
     // Arrange / Act / Assert
     expect(getLicenseCost(4)).toBe(400)
+  })
+})
+
+describe("DefaultFakeLicenseRating", () => {
+  it("is rating 3", () => {
+    // Arrange / Act / Assert
+    expect(DefaultFakeLicenseRating).toBe(3)
   })
 })

--- a/src/components/items/types/licenses/licenseUtils.ts
+++ b/src/components/items/types/licenses/licenseUtils.ts
@@ -1,5 +1,7 @@
 import type { AvailabilityInfo } from "#/system/availabilityInfo.ts"
 import type { LicenseData } from "#/system/gear/licenseData.ts"
+import type { ItemData } from "#/system/itemData.ts"
+import { ItemType } from "#/system/itemType.ts"
 
 export const getLicenseAvailability = (
   rating: LicenseData["rating"],
@@ -15,4 +17,48 @@ export const getLicenseAvailability = (
 export const getLicenseCost = (rating: LicenseData["rating"]): number => {
   if (rating === "real") return 0
   return Number(rating) * 100
+}
+
+/**
+ * Suggests a default Licence rating for a Restricted item, as the inverse of
+ * `getLicenseAvailability` (availability rating = licence rating × 3). Clamped to the 1–6
+ * range Licences support.
+ */
+export const suggestLicenseRating = (availabilityRating: number): number => {
+  return Math.min(6, Math.max(1, Math.ceil(availabilityRating / 3)))
+}
+
+/**
+ * A gear item can be Licence quick-bought when it is Restricted (not Forbidden — Forbidden
+ * items have no legal licence path) and isn't a SIN or Licence itself.
+ */
+export const isLicenseQuickBuyEligible = (item: ItemData): boolean => {
+  if (item.itemType === ItemType.license || item.itemType === ItemType.sin) return false
+  return item.availability?.restricted === true && !item.availability?.forbidden
+}
+
+/**
+ * True when `item.licenseId` points at a Licence that still exists in gear. A dangling
+ * reference (its Licence was since removed) is treated the same as unlicensed.
+ */
+export const isItemLicensed = (item: ItemData, licenses: LicenseData[]): boolean => {
+  return item.licenseId !== undefined && licenses.some((license) => license.id === item.licenseId)
+}
+
+/**
+ * Other gear items eligible to share the same Licence as `item` — same name and item type,
+ * not already licensed, excluding `item` itself. Licences generally cover a gear type rather
+ * than a single serial number, so multiple identical items (e.g. three Ares Predators) can
+ * share one Licence.
+ */
+export const findLicenseableSiblings = (
+  item: ItemData,
+  allGear: ItemData[],
+  licenses: LicenseData[],
+): ItemData[] => {
+  return allGear.filter((candidate) =>
+    candidate.id !== item.id
+    && candidate.name === item.name
+    && candidate.itemType === item.itemType
+    && !isItemLicensed(candidate, licenses))
 }

--- a/src/components/items/types/licenses/licenseUtils.ts
+++ b/src/components/items/types/licenses/licenseUtils.ts
@@ -19,14 +19,8 @@ export const getLicenseCost = (rating: LicenseData["rating"]): number => {
   return Number(rating) * 100
 }
 
-/**
- * Suggests a default Licence rating for a Restricted item, as the inverse of
- * `getLicenseAvailability` (availability rating = licence rating × 3). Clamped to the 1–6
- * range Licences support.
- */
-export const suggestLicenseRating = (availabilityRating: number): number => {
-  return Math.min(6, Math.max(1, Math.ceil(availabilityRating / 3)))
-}
+/** Default rating for a newly-created Fake Licence. */
+export const DefaultFakeLicenseRating = 3
 
 /**
  * A gear item can be Licence quick-bought when it is Restricted (not Forbidden — Forbidden

--- a/src/components/items/types/licenses/useQuickBuyLicenseAction.ts
+++ b/src/components/items/types/licenses/useQuickBuyLicenseAction.ts
@@ -1,0 +1,24 @@
+import { useGearByType } from "#/components/items/gearHooks.ts"
+import type { LicenseData } from "#/system/gear/licenseData.ts"
+import type { ItemData } from "#/system/itemData.ts"
+import { ItemType } from "#/system/itemType.ts"
+
+import { useQuickBuyLicenseDialog } from "./dialogs/quickBuyLicenseDialog.tsx"
+import { isItemLicensed, isLicenseQuickBuyEligible } from "./licenseUtils.ts"
+
+/**
+ * Drives the Licence Quick-Buy action for a single gear item: whether the trigger should be
+ * shown (Restricted, not already covered by a Licence) and the dialog that buys one.
+ */
+export function useQuickBuyLicenseAction(item: ItemData) {
+  const licenses = useGearByType<LicenseData>(ItemType.license)
+  const quickBuyLicenseDialog = useQuickBuyLicenseDialog()
+
+  const eligible = isLicenseQuickBuyEligible(item) && !isItemLicensed(item, licenses)
+
+  return {
+    eligible,
+    open: () => quickBuyLicenseDialog.open({ item }),
+    dialog: quickBuyLicenseDialog.dialog,
+  }
+}

--- a/src/components/items/types/vehicles/vehicleItemCard.tsx
+++ b/src/components/items/types/vehicles/vehicleItemCard.tsx
@@ -1,10 +1,12 @@
 import Typography from "@mui/material/Typography"
+import { RiFileShieldLine } from "@remixicon/react"
 import type { FC } from "react"
 
 import { GearItemCard } from "#/components/items/card/gearItemCard.tsx"
 import { ItemCard } from "#/components/items/card/itemCard.tsx"
 import { ItemStatChip } from "#/components/items/card/itemStatChip.tsx"
 import { GenericItemCard } from "#/components/items/genericItemCard.tsx"
+import { useQuickBuyLicenseAction } from "#/components/items/types/licenses/useQuickBuyLicenseAction.ts"
 import { InlineDamageTrack } from "#/components/system/damage/inlineDamageTrack.tsx"
 import { Nuyen } from "#/components/ui/nuyen.tsx"
 import type { VehicleData } from "#/system/gear/vehicleData.ts"
@@ -35,62 +37,73 @@ export const VehicleItemCard: FC<VehicleItemCardProps> = ({
 }) => {
   const { availability, source } = vehicle
   const damageMax = vehicle.damage?.physical.max || vehicle.body
+  const licenseQuickBuy = useQuickBuyLicenseAction(vehicle)
 
   return (
-    <GearItemCard
-      availability={availability}
-      source={source}
-      onEdit={onEdit}
-      onRemove={onRemove}
-    >
-      <ItemCard.Title>{vehicle.name}</ItemCard.Title>
+    <>
+      <GearItemCard
+        availability={availability}
+        source={source}
+        onEdit={onEdit}
+        onRemove={onRemove}
+      >
+        <ItemCard.Title>{vehicle.name}</ItemCard.Title>
 
-      {vehicle.cost !== undefined && (
-        <ItemCard.Meta type="cost">
-          <Typography sx={{ fontSize: "0.875rem" }}>
-            <Nuyen amount={vehicle.cost} />
-          </Typography>
+        {vehicle.cost !== undefined && (
+          <ItemCard.Meta type="cost">
+            <Typography sx={{ fontSize: "0.875rem" }}>
+              <Nuyen amount={vehicle.cost} />
+            </Typography>
+          </ItemCard.Meta>
+        )}
+
+        <ItemCard.Meta type="stat">
+          <ItemStatChip label={vehicle.vehicleType} />
         </ItemCard.Meta>
-      )}
 
-      <ItemCard.Meta type="stat">
-        <ItemStatChip label={vehicle.vehicleType} />
-      </ItemCard.Meta>
-
-      <ItemCard.Meta type="detail">
-        <VehicleStatGroups vehicle={vehicle} />
-      </ItemCard.Meta>
-
-      {onDamageChange && (
         <ItemCard.Meta type="detail">
-          <InlineDamageTrack
-            label="Damage"
-            max={damageMax}
-            current={vehicle.damage?.physical.current ?? 0}
-            onChange={onDamageChange}
-          />
+          <VehicleStatGroups vehicle={vehicle} />
         </ItemCard.Meta>
-      )}
 
-      {onAddAttachment && (
-        <ItemCard.AddChildButton onClick={onAddAttachment}>
-          Equipment
-        </ItemCard.AddChildButton>
-      )}
-
-      {attachments.length > 0 && (
-        <ItemCard.Children>
-          {attachments.map((attachment) => (
-            <GenericItemCard
-              key={attachment.id}
-              item={attachment}
-              variant="borderless"
-              onEdit={() => onEditAttachment?.(attachment)}
-              onRemove={() => onRemoveAttachment?.(attachment)}
+        {onDamageChange && (
+          <ItemCard.Meta type="detail">
+            <InlineDamageTrack
+              label="Damage"
+              max={damageMax}
+              current={vehicle.damage?.physical.current ?? 0}
+              onChange={onDamageChange}
             />
-          ))}
-        </ItemCard.Children>
-      )}
-    </GearItemCard>
+          </ItemCard.Meta>
+        )}
+
+        {onAddAttachment && (
+          <ItemCard.AddChildButton onClick={onAddAttachment}>
+            Equipment
+          </ItemCard.AddChildButton>
+        )}
+
+        {attachments.length > 0 && (
+          <ItemCard.Children>
+            {attachments.map((attachment) => (
+              <GenericItemCard
+                key={attachment.id}
+                item={attachment}
+                variant="borderless"
+                onEdit={() => onEditAttachment?.(attachment)}
+                onRemove={() => onRemoveAttachment?.(attachment)}
+              />
+            ))}
+          </ItemCard.Children>
+        )}
+
+        {licenseQuickBuy.eligible && (
+          <ItemCard.Action type="icon" aria-label="Buy License" onClick={licenseQuickBuy.open}>
+            <RiFileShieldLine size={16} />
+          </ItemCard.Action>
+        )}
+      </GearItemCard>
+
+      {licenseQuickBuy.dialog}
+    </>
   )
 }

--- a/src/components/items/types/weapons/weaponItemCard.tsx
+++ b/src/components/items/types/weapons/weaponItemCard.tsx
@@ -1,4 +1,5 @@
 import Typography from "@mui/material/Typography"
+import { RiFileShieldLine } from "@remixicon/react"
 import type { FC } from "react"
 
 import { GearItemCard } from "#/components/items/card/gearItemCard.tsx"
@@ -6,6 +7,7 @@ import { ItemCard } from "#/components/items/card/itemCard.tsx"
 import { ItemStatChip } from "#/components/items/card/itemStatChip.tsx"
 import { EquippedChip } from "#/components/items/equippedChip.tsx"
 import { GenericItemCard } from "#/components/items/genericItemCard.tsx"
+import { useQuickBuyLicenseAction } from "#/components/items/types/licenses/useQuickBuyLicenseAction.ts"
 import { Nuyen } from "#/components/ui/nuyen.tsx"
 import type { WeaponData } from "#/system/gear/weaponData.ts"
 import { isFirearmData } from "#/system/gear/weaponData.ts"
@@ -31,64 +33,75 @@ export const WeaponItemCard: FC<WeaponItemCardProps> = ({
   onRemoveAccessory,
 }) => {
   const { availability, source } = weapon
+  const licenseQuickBuy = useQuickBuyLicenseAction(weapon)
 
   return (
-    <GearItemCard
-      availability={availability}
-      source={source}
-      onEdit={onEdit}
-      onRemove={onRemove}
-    >
-      <ItemCard.Title>{weapon.name}</ItemCard.Title>
+    <>
+      <GearItemCard
+        availability={availability}
+        source={source}
+        onEdit={onEdit}
+        onRemove={onRemove}
+      >
+        <ItemCard.Title>{weapon.name}</ItemCard.Title>
 
-      {weapon.equipped && (
-        <ItemCard.Meta type="cost">
-          <EquippedChip />
-        </ItemCard.Meta>
-      )}
+        {weapon.equipped && (
+          <ItemCard.Meta type="cost">
+            <EquippedChip />
+          </ItemCard.Meta>
+        )}
 
-      {weapon.cost !== undefined && (
-        <ItemCard.Meta type="cost">
-          <Typography sx={{ fontSize: "0.875rem" }}>
-            <Nuyen amount={weapon.cost} />
-          </Typography>
-        </ItemCard.Meta>
-      )}
+        {weapon.cost !== undefined && (
+          <ItemCard.Meta type="cost">
+            <Typography sx={{ fontSize: "0.875rem" }}>
+              <Nuyen amount={weapon.cost} />
+            </Typography>
+          </ItemCard.Meta>
+        )}
 
-      <ItemCard.Meta type="stat">
-        <ItemStatChip label={`DV: ${weapon.dmg}`} color="secondary" />
-        {weapon.ap !== undefined && <ItemStatChip label={`AP: ${weapon.ap}`} />}
-        <ItemStatChip label={weapon.skill} color="primary" />
-      </ItemCard.Meta>
-
-      {isFirearmData(weapon) && (
         <ItemCard.Meta type="stat">
-          <ItemStatChip label={weapon.firearmType} />
-          {(weapon.firemodes?.length ?? 0) > 0 && (
-            <ItemStatChip label={weapon.firemodes!.join("/")} />
-          )}
+          <ItemStatChip label={`DV: ${weapon.dmg}`} color="secondary" />
+          {weapon.ap !== undefined && <ItemStatChip label={`AP: ${weapon.ap}`} />}
+          <ItemStatChip label={weapon.skill} color="primary" />
         </ItemCard.Meta>
-      )}
 
-      {onAddAccessory && (
-        <ItemCard.AddChildButton onClick={onAddAccessory}>
-          Add Accessory
-        </ItemCard.AddChildButton>
-      )}
+        {isFirearmData(weapon) && (
+          <ItemCard.Meta type="stat">
+            <ItemStatChip label={weapon.firearmType} />
+            {(weapon.firemodes?.length ?? 0) > 0 && (
+              <ItemStatChip label={weapon.firemodes!.join("/")} />
+            )}
+          </ItemCard.Meta>
+        )}
 
-      {accessories.length > 0 && (
-        <ItemCard.Children>
-          {accessories.map((accessory) => (
-            <GenericItemCard
-              key={accessory.id}
-              item={accessory}
-              variant="borderless"
-              onEdit={() => onEditAccessory?.(accessory)}
-              onRemove={() => onRemoveAccessory?.(accessory)}
-            />
-          ))}
-        </ItemCard.Children>
-      )}
-    </GearItemCard>
+        {onAddAccessory && (
+          <ItemCard.AddChildButton onClick={onAddAccessory}>
+            Add Accessory
+          </ItemCard.AddChildButton>
+        )}
+
+        {accessories.length > 0 && (
+          <ItemCard.Children>
+            {accessories.map((accessory) => (
+              <GenericItemCard
+                key={accessory.id}
+                item={accessory}
+                variant="borderless"
+                onEdit={() => onEditAccessory?.(accessory)}
+                onRemove={() => onRemoveAccessory?.(accessory)}
+              />
+            ))}
+          </ItemCard.Children>
+        )}
+
+        {licenseQuickBuy.eligible && (
+          <ItemCard.Action type="icon" aria-label="Buy License" onClick={licenseQuickBuy.open}>
+            <RiFileShieldLine size={16} />
+          </ItemCard.Action>
+        )}
+      </GearItemCard>
+
+      {licenseQuickBuy.dialog}
+    </>
   )
 }

--- a/src/components/runner/gearPage/gearViewItem.tsx
+++ b/src/components/runner/gearPage/gearViewItem.tsx
@@ -2,7 +2,7 @@ import Chip from "@mui/material/Chip"
 import IconButton from "@mui/material/IconButton"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
-import { RiDeleteBin6Line } from "@remixicon/react"
+import { RiDeleteBin6Line, RiFileShieldLine } from "@remixicon/react"
 import type { FC } from "react"
 
 import { AvailabilityChip } from "#/components/items/availability/availabilityChip.tsx"
@@ -10,6 +10,7 @@ import {
   getImplantEffectiveEssenceCost,
   getImplantEffectiveNuyenCost,
 } from "#/components/items/types/implants/implantUtils.ts"
+import { useQuickBuyLicenseAction } from "#/components/items/types/licenses/useQuickBuyLicenseAction.ts"
 import { Nuyen } from "#/components/ui/nuyen.tsx"
 import { isArmorData } from "#/system/gear/armorData.ts"
 import { ImplantGrade, ImplantType, isImplant } from "#/system/gear/implantData.ts"
@@ -51,6 +52,7 @@ export const GearViewItem: FC<GearViewItemProps> = ({
   getSubItemCallbacks,
 }) => {
   const { availability, source, description } = item
+  const licenseQuickBuy = useQuickBuyLicenseAction(item)
 
   const displayCost = isImplant(item)
     ? getImplantEffectiveNuyenCost(item)
@@ -110,6 +112,19 @@ export const GearViewItem: FC<GearViewItemProps> = ({
           <Typography>
             <Nuyen amount={displayCost} />
           </Typography>
+
+          {licenseQuickBuy.eligible && (
+            <IconButton
+              size="small"
+              aria-label="Buy License"
+              onClick={(e) => {
+                e.stopPropagation()
+                licenseQuickBuy.open()
+              }}
+            >
+              <RiFileShieldLine size={16} />
+            </IconButton>
+          )}
 
           {onRemove && (
             <IconButton
@@ -255,6 +270,8 @@ export const GearViewItem: FC<GearViewItemProps> = ({
           })}
         </Stack>
       )}
+
+      {licenseQuickBuy.dialog}
     </Stack>
   )
 }

--- a/src/system/itemData.ts
+++ b/src/system/itemData.ts
@@ -23,6 +23,9 @@ export interface ItemData {
   parentId?: UUID
   childIds?: UUID[]
 
+  /** The Licence (`ItemType.license`) authorizing this Restricted item. A Licence may cover multiple items — typically several instances of the same gear — but each item is covered by at most one Licence. */
+  licenseId?: UUID
+
   notes?: string
   equipped?: boolean
   fixed?: boolean


### PR DESCRIPTION
## Summary

- Adds a **Buy License** quick-buy action on any Restricted, unlicensed gear item — weapons, armor, cyberware, devices, vehicles, and misc items — in both Builder and Viewer.
- The dialog lets the Player pick an existing SIN or create a new one, set a Licence rating (defaulted from the item's Availability rating via `suggestLicenseRating`), and buy it: a single **Add License** in the Builder (cost counts toward the Gear BP budget like any other item), or **Acquire** (free) / **Purchase** (withdraws Nuyen) in the Viewer, matching the existing acquire/purchase pattern used elsewhere for new gear.
- A Licence can be extended to cover other unlicensed items sharing the same name and item type in one step (e.g. one Licence covering three Ares Predators), since a real Licence generally certifies a gear type rather than a single serial number.
- Implements the previously-drafted `docs/features/0001-license-quick-buy.md`, resolving its open questions (see doc for details).

## Data model

- New `ItemData.licenseId?: UUID` field: the covering Licence for an item. A Licence has no covered-item list of its own — coverage is derived by filtering gear for `licenseId === license.id` — so one Licence can cover many items, while each item is covered by at most one Licence.
- Licence ↔ SIN association reuses the existing Attachment mechanism (`Licence.parentId` = the SIN's id) — unchanged.
- No new item types or migrations needed; `licenseId` is optional so existing saved Runners are unaffected.

## Where it's wired in

- `GearItemCard`-based cards: `WeaponItemCard`, `ArmorItemCard`, `DeviceItemCard`, `VehicleItemCard`, `ImplantItemCard`, `GenericItemCard` (covers Builder's per-type lists, plus the shared `ImplantItemList` and `VehiclesList` used in both Builder and Viewer)
- `GearViewItem` — the Viewer's bespoke row renderer used for Weapons/Armor/Vehicles/Devices/Misc on the `/gear` accordion page

## Test plan

- [x] `yarn tsc` — clean
- [x] `yarn vitest run` — all 777 tests pass (including new `licenseUtils.test.ts` coverage for `suggestLicenseRating`, `isLicenseQuickBuyEligible`, `isItemLicensed`, `findLicenseableSiblings`)
- [x] `yarn fallow audit --base origin/shadowrun-4e` — 0 dead code introduced
- [x] Manually verified in a running dev server (Artemis fixture, `Russian Osprey 9` — a Restricted vehicle): Buy License button appears in both Builder (Vehicles panel) and Viewer (`/vehicles` route), the dialog shows the correct suggested rating/cost, and confirming creates a Licence under the chosen SIN, after which the button disappears from the now-licensed item.

Screenshots of the dialog in both Builder and Viewer, and the resulting Licence in the SINs & Licenses list, were shared in chat.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CQzdNuaBdNJsspvJE3BU8B)_