### PR TITLE
Only colour dice and show glitch/crit-glitch once dice settle

### DIFF
--- a/src/components/items/types/weapons/attackCalculator/weaponAttackPanel.tsx
+++ b/src/components/items/types/weapons/attackCalculator/weaponAttackPanel.tsx
@@ -25,6 +25,7 @@ import { Label } from "#/components/ui/text/label.tsx"
 import { UnderConstruction } from "#/components/ui/underConstruction.tsx"
 import { AttributeKey } from "#/system/attributeKey.ts"
 import {
+  selectAllSettled,
   selectHits,
   selectIsCriticalGlitch,
   selectIsGlitch,
@@ -145,6 +146,7 @@ export const WeaponAttackPanel: FC<WeaponAttackPanelProps> = ({ weapon }) => {
   const rolledHits = useDiceRollerSelector(diceRoller, selectHits)
   const isGlitch = useDiceRollerSelector(diceRoller, selectIsGlitch)
   const isCriticalGlitch = useDiceRollerSelector(diceRoller, selectIsCriticalGlitch)
+  const isSettled = useDiceRollerSelector(diceRoller, selectAllSettled)
 
   const netHits = hasRolled ? rolledHits - defenseHits : null
   const totalDV = netHits === null ? null : (netHits > 0 ? applyNetHitsToDamage(weapon.dmg, netHits) : "Miss")
@@ -304,8 +306,12 @@ export const WeaponAttackPanel: FC<WeaponAttackPanelProps> = ({ weapon }) => {
           <Stack sx={{ alignItems: "center", gap: 1 }}>
             <DiceResult roller={diceRoller} iconSize={32} />
 
-            {isCriticalGlitch && <Label label="CRITICAL GLITCH!" color="error.main" variant="contained" />}
-            {!isCriticalGlitch && isGlitch && <Label label="Glitch!" color="error.main" variant="text" />}
+            {isSettled && isCriticalGlitch && (
+              <Label label="CRITICAL GLITCH!" color="error.main" variant="contained" />
+            )}
+            {isSettled && !isCriticalGlitch && isGlitch && (
+              <Label label="Glitch!" color="error.main" variant="text" />
+            )}
 
             <Button
               variant="contained"

--- a/src/components/system/dice/diceResult.tsx
+++ b/src/components/system/dice/diceResult.tsx
@@ -1,7 +1,12 @@
 import Stack from "@mui/material/Stack"
 import type { FC } from "react"
 
-import { selectAllDice, selectIsGlitch, useDiceRollerSelector } from "#/system/dice/diceRoller.selectors.ts"
+import {
+  selectAllDice,
+  selectAllSettled,
+  selectIsGlitch,
+  useDiceRollerSelector,
+} from "#/system/dice/diceRoller.selectors.ts"
 import type { DiceRoller } from "#/system/dice/diceRoller.ts"
 
 import { getDiceOffset } from "./diceUtils.ts"
@@ -28,11 +33,12 @@ export const DiceResult: FC<DiceResultProps> = ({
 }) => {
   const allDice = useDiceRollerSelector(roller, selectAllDice)
   const isGlitch = useDiceRollerSelector(roller, selectIsGlitch)
+  const allSettled = useDiceRollerSelector(roller, selectAllSettled)
   const dice = (startIndex !== undefined || endIndex !== undefined)
     ? allDice.slice(startIndex ?? 0, endIndex)
     : allDice
 
-  const diceDefaultColor = (isGlitch && highlightGlitches) ? "error.main" : "secondary.main"
+  const diceDefaultColor = (allSettled && isGlitch && highlightGlitches) ? "error.main" : "secondary.main"
 
   return (
     <Stack
@@ -49,8 +55,8 @@ export const DiceResult: FC<DiceResultProps> = ({
         <DieFace
           key={index}
           value={die.value}
-          highlightHit={highlightHits}
-          highlightGlitch={highlightGlitches}
+          highlightHit={highlightHits && !die.isRolling}
+          highlightGlitch={highlightGlitches && !die.isRolling}
           style={getDiceOffset(die.isRolling)}
           size={iconSize}
         />


### PR DESCRIPTION
## Summary
- Dice were being coloured (hit/glitch highlight) and the pool's overall glitch tint based on the die's `value`, but during a roll each die's value is randomly cycled every 100ms while `isRolling` is true — so dice flashed red/green mid-animation instead of only once they'd stopped.
- `DiceResult` now only passes `highlightHit`/`highlightGlitch` to a `DieFace` once that die has stopped rolling, and the pool's overall glitch colour only applies once every die has settled (`selectAllSettled`).
- `WeaponAttackPanel`'s "Glitch!" / "CRITICAL GLITCH!" labels had the same issue (computed straight from `selectIsGlitch`/`selectIsCriticalGlitch` with no settled gate) and are now gated on `selectAllSettled` too. `DiceTrayResultLabels` already gated correctly via `selectRollState`, so it was left as-is.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx eslint` on the two changed files
- [x] `npx vitest run src/system/dice` (47 passed)
- [ ] Manual check in the browser that dice no longer flash colour while rolling and glitch labels only appear once the roll settles


---
_Generated by [Claude Code](https://claude.ai/code/session_01B3gowFYNJKdAQ3X6weiK3j)_