### PR TITLE
ItemData._state refactor: design docs (glossary, ADR, feature doc)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -283,11 +283,13 @@ merely owned. Currently opt-in per `ItemType`: only weapons and armor forms expo
 `docs/features/0012-item-stashing.md` plans to make Equip a free, per-item opt-in on every
 `ItemType` instead (dropping the per-`ItemType` forcing) as part of unifying it with **Stash**
 into one action menu.
-Read via the `isActivelyEquipped(item)` selector wherever the mechanical effect matters (raw
-`_state.equipped` reads are for the edit form only) — the leading underscore on `_state` marks it
-as internal storage, same convention as `RunnerData._meta_`. `_state` holds only **Equipped** and
-**Stash** — the other per-item booleans (`fixed`, `wireless`) stay top-level on `ItemData` since
-they don't combine with anything else the way Equipped and Stash do (via `isActivelyEquipped`).
+Read via `isEquipped(item)` from `src/system/items/itemUtils.ts` wherever the raw value is needed
+— the leading underscore on `_state` marks it as internal storage, same convention as
+`RunnerData._meta_`. There is deliberately no combined "actively equipped" helper: call sites that
+care whether an item's Equipped effect is actually active check `isEquipped(item) &&
+!isStashed(item)` directly. `_state` holds only **Equipped** and **Stash** — the other per-item
+booleans (`fixed`, `wireless`) stay top-level on `ItemData` since they don't combine with anything
+else the way Equipped and Stash do.
 
 **Stash** _(not yet implemented — see `docs/features/0012-item-stashing.md`)_:
 `ItemData._state.stashed` — whether an item is with the Runner at all right now ("left at the

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -277,20 +277,22 @@ Any physical or digital piece of equipment a Runner owns. Typed by `ItemType` (a
 implant, software, vehicle, etc.).
 
 **Equipped**:
-`ItemData._flags.equipped` — whether an item is actively worn/wielded right now, as opposed to
+`ItemData._state.equipped` — whether an item is actively worn/wielded right now, as opposed to
 merely owned. Currently opt-in per `ItemType`: only weapons and armor forms expose the toggle
 (`equipable: { forced: true }`); other item types don't offer it.
 `docs/features/0012-item-stashing.md` plans to make Equip a free, per-item opt-in on every
 `ItemType` instead (dropping the per-`ItemType` forcing) as part of unifying it with **Stash**
 into one action menu.
 Read via the `isActivelyEquipped(item)` selector wherever the mechanical effect matters (raw
-`_flags.equipped` reads are for the edit form only) — the leading underscore on `_flags` marks it
-as internal storage, same convention as `RunnerData._meta_`.
+`_state.equipped` reads are for the edit form only) — the leading underscore on `_state` marks it
+as internal storage, same convention as `RunnerData._meta_`. `_state` holds only **Equipped** and
+**Stash** — the other per-item booleans (`fixed`, `wireless`) stay top-level on `ItemData` since
+they don't combine with anything else the way Equipped and Stash do (via `isActivelyEquipped`).
 
 **Stash** _(not yet implemented — see `docs/features/0012-item-stashing.md`)_:
-`ItemData._flags.stashed` — whether an item is with the Runner at all right now ("left at the
+`ItemData._state.stashed` — whether an item is with the Runner at all right now ("left at the
 safehouse"), as opposed to **Equipped**, which only asks whether a *present* item is actively
-worn/wielded. Stash and Equipped are independent, coexisting flags — an item can be `_flags: {
+worn/wielded. Stash and Equipped are independent, coexisting flags — an item can be `_state: {
 equipped: true, stashed: true }` at once. Stash overrides Equipped's mechanical effect without
 clearing its stored value (so un-stashing needs no separate restore step). A stashed item is
 greyed out and sorted to the bottom of gear listings, and cascades to its child items (stashing a

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -277,21 +277,24 @@ Any physical or digital piece of equipment a Runner owns. Typed by `ItemType` (a
 implant, software, vehicle, etc.).
 
 **Equipped**:
-`ItemData.equipped` — whether an item is actively worn/wielded right now, as opposed to merely
-owned. Currently opt-in per `ItemType`: only weapons and armor forms expose the toggle
+`ItemData._flags.equipped` — whether an item is actively worn/wielded right now, as opposed to
+merely owned. Currently opt-in per `ItemType`: only weapons and armor forms expose the toggle
 (`equipable: { forced: true }`); other item types don't offer it.
 `docs/features/0012-item-stashing.md` plans to make Equip a free, per-item opt-in on every
 `ItemType` instead (dropping the per-`ItemType` forcing) as part of unifying it with **Stash**
 into one action menu.
+Read via the `isActivelyEquipped(item)` selector wherever the mechanical effect matters (raw
+`_flags.equipped` reads are for the edit form only) — the leading underscore on `_flags` marks it
+as internal storage, same convention as `RunnerData._meta_`.
 
 **Stash** _(not yet implemented — see `docs/features/0012-item-stashing.md`)_:
-`ItemData.stashed` — whether an item is with the Runner at all right now ("left at the
+`ItemData._flags.stashed` — whether an item is with the Runner at all right now ("left at the
 safehouse"), as opposed to **Equipped**, which only asks whether a *present* item is actively
-worn/wielded. Stash and Equipped are independent, coexisting flags — an item can be `equipped:
-true, stashed: true` at once. Stash overrides Equipped's mechanical effect without clearing its
-stored value (so un-stashing needs no separate restore step). A stashed item is greyed out and
-sorted to the bottom of gear listings, and cascades to its child items (stashing a weapon stashes
-its attachments too).
+worn/wielded. Stash and Equipped are independent, coexisting flags — an item can be `_flags: {
+equipped: true, stashed: true }` at once. Stash overrides Equipped's mechanical effect without
+clearing its stored value (so un-stashing needs no separate restore step). A stashed item is
+greyed out and sorted to the bottom of gear listings, and cascades to its child items (stashing a
+weapon stashes its attachments too).
 _Avoid_: unequipped (that's the absence of Equipped, not Stash — an item can be present,
 unequipped, and not stashed, e.g. a spare pistol in a holster)
 

--- a/docs/adr/0006-item-state-scope.md
+++ b/docs/adr/0006-item-state-scope.md
@@ -1,0 +1,14 @@
+# `ItemData._state` scope: only Equipped and Stash, no combined helper
+
+`ItemData._state` groups only `equipped` and `stashed` — not `fixed` or `wireless`, even though
+all four are per-item booleans. Equipped and Stash combine (`isEquipped(item) &&
+!isStashed(item)` determines whether Equipped's mechanical effect is actually active); `fixed`
+and `wireless` don't interact with anything else today, so they stay top-level fields on
+`ItemData` rather than joining `_state`. The leading underscore marks `_state` as internal
+storage (same convention as `RunnerData._meta_`), read through `isEquipped(item)` /
+`isStashed(item)` in `src/system/items/itemUtils.ts` rather than directly.
+
+There is deliberately no `isActivelyEquipped`-style combinator wrapping the two checks — call
+sites compose `isEquipped(item) && !isStashed(item)` inline. If `fixed` or `wireless` later grow
+their own cross-flag logic, they can join `_state` at that point; until then, folding them in
+speculatively would be scope creep with no behavior to justify it.

--- a/docs/features/0012-item-stashing.md
+++ b/docs/features/0012-item-stashing.md
@@ -3,11 +3,14 @@
 > **Status:** Ready to Implement
 >
 > **GitHub Issues / PRs:**
-> - [#388 — Stashed field + isActivelyEquipped everywhere it matters](https://github.com/CptnFizzbin/shadow-sin/issues/388)
+> - [#388 — `ItemData._state` object (equipped, stashed) + itemUtils everywhere it matters](https://github.com/CptnFizzbin/shadow-sin/issues/388)
 > - [#390 — Unified per-item action menu; Equip becomes universal](https://github.com/CptnFizzbin/shadow-sin/issues/390)
 > - [#392 — Multi-select bulk actions](https://github.com/CptnFizzbin/shadow-sin/issues/392)
 > - [`docs/features/0011-license-check-dialog.md`](./0011-license-check-dialog.md) depends on
->   #388 for `ItemData.stashed`
+>   #388 for `ItemData._state.stashed`
+> - See [`docs/adr/0006-item-state-scope.md`](../adr/0006-item-state-scope.md) for why `_state`
+>   holds only `equipped`/`stashed` (not `fixed`/`wireless`), and why there's no combined
+>   "actively equipped" helper
 
 A general, persisted way to mark a piece of carried gear as unavailable for a given run — "left at
 the safehouse" — without deleting it or leaving the Builder. Discovered as a dependency while
@@ -22,25 +25,32 @@ that code) closes a pre-existing gap where item removal has no confirmation step
 
 ## Resolved Questions
 
-- **Persistence:** a new field, `ItemData.stashed?: boolean`. Not local dialog state — it lasts
-  until explicitly toggled back. Available on every `ItemData`, unconditionally (unlike
+- **Persistence:** a new field, `ItemData._state.stashed?: boolean`, alongside the existing
+  `equipped` value which moves into the same `_state` object (`ItemData._state.equipped?:
+  boolean`). `_state` is internal storage (leading underscore, same convention as
+  `RunnerData._meta_`) — read through `isEquipped(item)` / `isStashed(item)` in
+  `src/system/items/itemUtils.ts`, not accessed directly outside the edit form. `fixed` and
+  `wireless` stay top-level fields, unaffected by this change — see
+  [`docs/adr/0006-item-state-scope.md`](../adr/0006-item-state-scope.md). Not local dialog state —
+  it lasts until explicitly toggled back. Available on every `ItemData`, unconditionally (unlike
   `equipped`'s history of being gated per `ItemType`) — any gear, including a SIN's covered
   Licences, can be left behind.
 - **`stashed` and `equipped` are independent, coexisting flags, not mutually exclusive.**
-  `stashed` *overrides* `equipped` — it does not clear it. A weapon can be `equipped: true,
-  stashed: true` at the same time; while stashed it behaves as not-actively-equipped, but the
-  underlying `equipped` value is preserved, so un-stashing "just works" with no separate restore
-  step needed.
-- **`isActivelyEquipped(item)` helper** — a new derived function/selector,
-  `item.equipped && !item.stashed`, that replaces every existing raw `.equipped` read that drives
-  real mechanical behavior, rather than adding `&& !stashed` at each call site individually (see
-  Constraints for the full list). Prevents a missed call site from silently letting a stashed item
-  keep contributing encumbrance, GameEffects, wound modifiers, etc.
+  `stashed` *overrides* `equipped` — it does not clear it. A weapon can be `_state: { equipped:
+  true, stashed: true }` at the same time; while stashed it behaves as not-actively-equipped, but
+  the underlying `equipped` value is preserved, so un-stashing "just works" with no separate
+  restore step needed.
+- **`isEquipped(item)` / `isStashed(item)` utilities** — new plain functions in
+  `src/system/items/itemUtils.ts` that replace every existing raw `.equipped` read that drives
+  real mechanical behavior. There is deliberately no combined "actively equipped" helper — call
+  sites that need to know whether Equipped's effect is actually active check `isEquipped(item) &&
+  !isStashed(item)` directly (see Constraints for the full list). Prevents a missed call site from
+  silently letting a stashed item keep contributing encumbrance, GameEffects, wound modifiers, etc.
 - **Gear-list presentation:** a stashed item is greyed out and sorted to the bottom of its gear
   listing, rather than hidden. The existing "Equipped" display chips (`genericItemCard.tsx`,
   `gearViewItem.tsx`, `weaponItemCard.tsx`, `armorItemCard.tsx`) switch from raw `item.equipped` to
-  `isActivelyEquipped(item)` too, so a stashed-but-equipped item doesn't misleadingly show as
-  Equipped.
+  `isEquipped(item) && !isStashed(item)` too, so a stashed-but-equipped item doesn't misleadingly
+  show as Equipped.
 - **Parent/child cascade:** stashing a parent item (e.g. a weapon with attachments) cascades to
   all of its children — you can't stash the gun but keep the scope active. A child cannot be
   independently un-stashed while its parent is stashed, since the whole assembly is already
@@ -115,7 +125,7 @@ not follow that structure:
 ## Constraints
 
 - `.equipped` is currently read directly (not through a shared helper) at these sites, all of
-  which must switch to `isActivelyEquipped(item)`:
+  which must switch to `isEquipped(item) && !isStashed(item)`:
   - `src/components/system/encumbrance/useEncumbrance.ts`
   - `src/components/system/gameEffects/useGameEffects.ts`
   - `src/components/system/damage/damageUtils.ts` (two call sites)
@@ -127,12 +137,15 @@ not follow that structure:
     `src/components/items/types/weapons/weaponItemCard.tsx`,
     `src/components/items/types/armor/armorItemCard.tsx`
   - `useItemOptions.ts`'s own `.equipped` checks are about the edit-form's field-presence logic,
-    not "is this item mechanically active" — those stay as raw `.equipped` reads, unrelated to
-    this helper.
+    not "is this item mechanically active" — those stay as raw `_state.equipped` reads, unrelated
+    to `itemUtils`.
 - **A new migration is required**, even though `stashed` is purely additive and optional. This
   repo's convention adds a migration for every schema change regardless of triviality — see
   `20260517_addFeatureFlags.ts` and `20260521_addKarmaLog.ts` for recent precedent of migrations
-  for similarly additive fields. Never edit an existing migration file (see `AGENTS.md`).
+  for similarly additive fields. Never edit an existing migration file (see `AGENTS.md`). This
+  migration also moves the existing top-level `equipped` value into `_state.equipped` for every
+  item in `gear`, deleting the stale top-level key; `20260417_setDefaultEquippedWeapons.ts` must be
+  updated to write `_state.equipped` and confirmed to run after this migration.
 - Must not conflict with or duplicate `equipped` at the data level — see "independent, coexisting
   flags" above; this replaces an earlier, incorrect assumption that stashing would force
   `equipped` to `false`.
@@ -140,10 +153,11 @@ not follow that structure:
 ## Domain Notes
 
 **Stash** and **Equipped** are now defined in `CONTEXT.md` (added alongside this doc). Summary:
-`Equipped` (`ItemData.equipped`) says a *present* item is actively worn/wielded; `Stash`
-(`ItemData.stashed`) says an item isn't with the Runner at all right now, and overrides Equipped's
-effect without clearing its stored value. An item can be present, unequipped, and not stashed all
-at once (e.g. a spare pistol in a holster) — the two flags are independent axes, not a spectrum.
+`Equipped` (`ItemData._state.equipped`) says a *present* item is actively worn/wielded; `Stash`
+(`ItemData._state.stashed`) says an item isn't with the Runner at all right now, and overrides
+Equipped's effect without clearing its stored value. An item can be present, unequipped, and not
+stashed all at once (e.g. a spare pistol in a holster) — the two flags are independent axes, not a
+spectrum.
 
 ## Rough Interface Sketches
 
@@ -151,13 +165,22 @@ _High-level shapes only — no implementation code._
 
 ```ts
 interface ItemData {
-  // ...existing fields
-  stashed?: boolean
+  // ...existing fields (fixed, wireless stay top-level, unchanged)
+  _state?: {
+    equipped?: boolean
+    stashed?: boolean
+  }
 }
 
-// Replaces raw `item.equipped` reads everywhere mechanical behavior depends on it
-function isActivelyEquipped(item: ItemData): boolean {
-  return item.equipped === true && item.stashed !== true
+// src/system/items/itemUtils.ts
+// No combined "actively equipped" helper — call sites compose these directly:
+// isEquipped(item) && !isStashed(item)
+function isEquipped(item: ItemData): boolean {
+  return item._state?.equipped === true
+}
+
+function isStashed(item: ItemData): boolean {
+  return item._state?.stashed === true
 }
 ```
 


### PR DESCRIPTION
## Summary

Tracks the design work for #388 (moving `equipped`/`stashed` into an internal `ItemData._state`
object). A `/grill-with-docs` session settled the design; this PR is the doc-only trail of that
session. Implementation happens in a follow-up PR against the finalized #388 acceptance criteria.

Settled design:

- `ItemData._state?: { equipped?: boolean; stashed?: boolean }` — leading underscore marks it as
  internal storage, matching the existing `RunnerData._meta_` convention. Read through
  `isEquipped(item)` / `isStashed(item)` in a new `src/system/items/itemUtils.ts`, not accessed
  directly outside the edit form.
- **`fixed` and `wireless` stay top-level, untouched** — they don't combine with anything the way
  Equipped and Stash do (`isEquipped(item) && !isStashed(item)`), so folding them into `_state`
  would be scope creep with no behavior to justify it.
- **No combined `isActivelyEquipped` helper.** Call sites compose `isEquipped(item) &&
  !isStashed(item)` inline.
- No ESLint enforcement of the `_state` boundary — consistent with `_meta_`, which also ships
  without one.

## Changes in this PR

- `CONTEXT.md` — **Equipped**/**Stash** glossary entries updated to `ItemData._state.equipped` /
  `.stashed`, with a note on why `fixed`/`wireless` are excluded
- `docs/adr/0006-item-state-scope.md` — new ADR recording the scope and no-combinator decisions
- `docs/features/0012-item-stashing.md` — Resolved Questions, Constraints, Domain Notes, and Rough
  Interface Sketch synced to the `_state`/`itemUtils` shape
- #388 itself rewritten to match (title, acceptance criteria, call-site list)

## Test plan

- [x] Doc-only changes — no code in this PR
- [ ] Implementation (per #388's finalized acceptance criteria) lands in a follow-up PR: `_state`
      field + `ArmorDataSchema` update, migration, `itemUtils.ts`, item edit form checkbox, and all
      listed call sites switched over, with `yarn fix` / test suite passing
