### PR TITLE
Simplify License Check dialog: centralize state, extract worker pool queue

### DIFF
--- a/src/components/runner/licenseCheck/licenseCheckContext.tsx
+++ b/src/components/runner/licenseCheck/licenseCheckContext.tsx
@@ -1,33 +1,25 @@
 import type { FC, PropsWithChildren } from "react"
 import { createContext, useContext } from "react"
 
-import type { ItemData } from "#/system/itemData.ts"
+import { OutOfContextError } from "#/lib/errors/outOfContextError.ts"
 
-export interface LicenseCheckState {
-  items: ItemData[]
+import type { LicenseCheckState } from "./licenseCheckState.ts"
+import { useLicenseCheckState } from "./licenseCheckState.ts"
 
-  setItems: (items: ItemData[]) => void
-  addItem: (item: ItemData) => void
-  removeItem: (item: ItemData) => void
-}
+const LicenseCheckContext = createContext<LicenseCheckState | null>(null)
 
-const LicenseCheckContext = createContext<LicenseCheckState>({
-  items: [],
+export const LicenseCheckProvider: FC<PropsWithChildren> = ({ children }) => {
+  const state = useLicenseCheckState()
 
-  setItems: () => {},
-  addItem: () => {},
-  removeItem: () => {},
-})
-
-export const LicenseCheckProvider: FC<PropsWithChildren<{ value: LicenseCheckState }>> = ({
-  value,
-  children,
-}) => {
   return (
-    <LicenseCheckContext.Provider value={value}>
+    <LicenseCheckContext.Provider value={state}>
       {children}
     </LicenseCheckContext.Provider>
   )
 }
 
-export const useLicenseCheck = () => useContext(LicenseCheckContext)
+export const useLicenseCheck = (): LicenseCheckState => {
+  const contextValue = useContext(LicenseCheckContext)
+  if (!contextValue) throw new OutOfContextError("useLicenseCheck", "LicenseCheckProvider")
+  return contextValue
+}

--- a/src/components/runner/licenseCheck/licenseCheckDialog.tsx
+++ b/src/components/runner/licenseCheck/licenseCheckDialog.tsx
@@ -1,103 +1,52 @@
 import Button from "@mui/material/Button"
 import type { FC } from "react"
-import { useMemo, useState } from "react"
 
 import type { ControlledDialogProps } from "#/components/ui/dialog/controlledDialogProps.ts"
 import { ControlledDialog, Dialog } from "#/components/ui/dialog/dialog.tsx"
 import { useDialog } from "#/components/ui/dialog/useDialog.tsx"
-import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
-import type { ItemData } from "#/system/itemData.ts"
 
-import { buildLicenseCheckResult } from "./licenseCheckAlerts.ts"
-import { buildVerificationChecks } from "./licenseCheckChecks.ts"
-import type { LicenseCheckState } from "./licenseCheckContext.tsx"
-import { LicenseCheckProvider } from "./licenseCheckContext.tsx"
+import { LicenseCheckProvider, useLicenseCheck } from "./licenseCheckContext.tsx"
 import { LicenseCheckResultView } from "./licenseCheckResultView.tsx"
 import { LicenseCheckScanView } from "./licenseCheckScanView.tsx"
 import { LicenseCheckSetupView } from "./licenseCheckSetupView.tsx"
-import type { LicenseCheckResult, VerificationCheck, VerificationOutcome } from "./licenseCheckTypes.ts"
-
-type LicenseCheckStep = "setup" | "scanning" | "result"
 
 type LicenseCheckDialogProps = ControlledDialogProps<void>
 
-const LicenseCheckDialog: FC<LicenseCheckDialogProps> = ({ ctrl }) => {
-  const allGear = useRunnerStoreSelector(Selectors.gear.selectGear)
-  const ratingPlusRating = useRunnerStoreSelector(
-    Selectors.houseRules.select("items.licenseCheck.ratingPlusRating"),
-  )
-  const [selectedGear, setSelectedGear] = useState<ItemData[]>(Object.values(allGear))
-  const licenseCheckState = useMemo((): LicenseCheckState => {
-    return {
-      items: selectedGear,
-      setItems: (items) => setSelectedGear(items),
-      addItem: (item) => setSelectedGear((items) => {
-        return [...items, item]
-      }),
-      removeItem: (item) => setSelectedGear((items) => {
-        return items.filter((i) => i.id !== item.id)
-      }),
-    }
-  }, [selectedGear])
-
-  const [step, setStep] = useState<LicenseCheckStep>("setup")
-  const [scannerRating, setScannerRating] = useState(3)
-  const [checks, setChecks] = useState<VerificationCheck[]>([])
-  const [result, setResult] = useState<LicenseCheckResult | null>(null)
-
-  const handleStartScan = () => {
-    // Built fresh here from the Setup checklist's current checked selection, flattened and
-    // shuffled into one queue the worker pool pulls from — unchecked items are never scanned.
-    setChecks(buildVerificationChecks(allGear, selectedGear))
-    setStep("scanning")
-  }
-
-  const handleScanComplete = (outcomes: VerificationOutcome[]) => {
-    setResult(buildLicenseCheckResult(scannerRating, allGear, checks, outcomes))
-    setStep("result")
-  }
+// Inner component that consumes LicenseCheckProvider context
+const LicenseCheckDialogInner: FC<LicenseCheckDialogProps> = ({ ctrl }) => {
+  const { step, result, startScan, reset } = useLicenseCheck()
 
   return (
-    <LicenseCheckProvider value={licenseCheckState}>
-      <ControlledDialog ctrl={ctrl} maxWidth="lg" onClosed={() => setSelectedGear(Object.values(allGear))}>
-        <Dialog.Title>License Check</Dialog.Title>
+    <ControlledDialog ctrl={ctrl} maxWidth="lg" onClosed={reset}>
+      <Dialog.Title>License Check</Dialog.Title>
 
-        <Dialog.Content dividers>
-          {step === "setup" && (
-            <LicenseCheckSetupView
-              gear={allGear}
-              scannerRating={scannerRating}
-              onScannerRatingChange={setScannerRating}
-            />
-          )}
-          {step === "scanning" && (
-            <LicenseCheckScanView
-              checks={checks}
-              gear={allGear}
-              scannerRating={scannerRating}
-              ratingPlusRating={ratingPlusRating}
-              onComplete={handleScanComplete}
-            />
-          )}
-          {step === "result" && result && <LicenseCheckResultView result={result} gear={allGear} />}
-        </Dialog.Content>
+      <Dialog.Content dividers>
+        {step === "setup" && <LicenseCheckSetupView />}
+        {step === "scanning" && <LicenseCheckScanView />}
+        {step === "result" && result && <LicenseCheckResultView />}
+      </Dialog.Content>
 
-        <Dialog.Actions>
-          {step === "setup"
-            ? (
-                <>
-                  <Button onClick={() => ctrl.close()}>Cancel</Button>
-                  <Button variant="contained" onClick={handleStartScan}>Start Scan</Button>
-                </>
-              )
-            : (
-                <Button variant="contained" onClick={() => ctrl.close()}>Close</Button>
-              )}
-        </Dialog.Actions>
-      </ControlledDialog>
-    </LicenseCheckProvider>
+      <Dialog.Actions>
+        {step === "setup"
+          ? (
+              <>
+                <Button onClick={() => ctrl.close()}>Cancel</Button>
+                <Button variant="contained" onClick={startScan}>Start Scan</Button>
+              </>
+            )
+          : (
+              <Button variant="contained" onClick={() => ctrl.close()}>Close</Button>
+            )}
+      </Dialog.Actions>
+    </ControlledDialog>
   )
 }
+
+const LicenseCheckDialog: FC<LicenseCheckDialogProps> = ({ ctrl }) => (
+  <LicenseCheckProvider>
+    <LicenseCheckDialogInner ctrl={ctrl} />
+  </LicenseCheckProvider>
+)
 
 export const useLicenseCheckDialog = () =>
   useDialog<void, void>((ctrl) => <LicenseCheckDialog ctrl={ctrl} />)

--- a/src/components/runner/licenseCheck/licenseCheckResultView.tsx
+++ b/src/components/runner/licenseCheck/licenseCheckResultView.tsx
@@ -4,16 +4,16 @@ import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
 import type { FC } from "react"
 
-import type { ItemData } from "#/system/itemData.ts"
+import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
 
-import type { LicenseCheckResult } from "./licenseCheckTypes.ts"
+import { useLicenseCheck } from "./licenseCheckContext.tsx"
 
-interface LicenseCheckResultViewProps {
-  result: LicenseCheckResult
-  gear: Record<string, ItemData>
-}
+export const LicenseCheckResultView: FC = () => {
+  const { result } = useLicenseCheck()
+  const gear = useRunnerStoreSelector(Selectors.gear.selectGear)
 
-export const LicenseCheckResultView: FC<LicenseCheckResultViewProps> = ({ result, gear }) => {
+  if (!result) return null
+
   const hasAlerts = result.alerts.length > 0
 
   return (

--- a/src/components/runner/licenseCheck/licenseCheckScanView.tsx
+++ b/src/components/runner/licenseCheck/licenseCheckScanView.tsx
@@ -1,51 +1,20 @@
 import Grid from "@mui/material/Grid"
 import type { FC } from "react"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
-import type { ItemData } from "#/system/itemData.ts"
-
-import { createVerificationQueue } from "./licenseCheckQueue.ts"
-import type { VerificationCheck, VerificationOutcome } from "./licenseCheckTypes.ts"
+import { useLicenseCheck } from "./licenseCheckContext.tsx"
 import { LicenseCheckWorkerSlot } from "./licenseCheckWorkerSlot.tsx"
+import { useVerificationQueuePool } from "./useVerificationQueuePool.ts"
 
 const WORKER_COUNT = 1
 
-interface LicenseCheckScanViewProps {
-  checks: VerificationCheck[]
-  gear: Record<string, ItemData>
-  scannerRating: number
-  ratingPlusRating: boolean
-  onComplete: (outcomes: VerificationOutcome[]) => void
-}
-
 /** Runs the scan as a pool of workers pulling checks off one shuffled, shared queue. */
-export const LicenseCheckScanView: FC<LicenseCheckScanViewProps> = ({
-  checks,
-  gear,
-  scannerRating,
-  ratingPlusRating,
-  onComplete,
-}) => {
-  const queue = useMemo(() => createVerificationQueue(checks), [checks])
-  const outcomesRef = useRef<VerificationOutcome[]>([])
-  const [idleWorkers, setIdleWorkers] = useState<ReadonlySet<number>>(new Set())
-  const hasCompletedRef = useRef(false)
-
-  const handleOutcome = useCallback((outcome: VerificationOutcome) => {
-    outcomesRef.current = [...outcomesRef.current, outcome]
-  }, [])
-
-  const handleIdle = useCallback((workerIndex: number) => {
-    setIdleWorkers((prev) => (prev.has(workerIndex) ? prev : new Set(prev).add(workerIndex)))
-  }, [])
-
-  useEffect(() => {
-    if (hasCompletedRef.current) return
-    if (checks.length === 0 || idleWorkers.size === WORKER_COUNT) {
-      hasCompletedRef.current = true
-      onComplete(outcomesRef.current)
-    }
-  }, [checks.length, idleWorkers, onComplete])
+export const LicenseCheckScanView: FC = () => {
+  const { checks, completeScan } = useLicenseCheck()
+  const { queue, handleOutcome, handleWorkerIdle } = useVerificationQueuePool({
+    checks,
+    workerCount: WORKER_COUNT,
+    onComplete: completeScan,
+  })
 
   return (
     <Grid container spacing={2}>
@@ -53,11 +22,8 @@ export const LicenseCheckScanView: FC<LicenseCheckScanViewProps> = ({
         <Grid key={workerIndex} size={{ xs: 12, sm: 6 }}>
           <LicenseCheckWorkerSlot
             queue={queue}
-            gear={gear}
-            scannerRating={scannerRating}
-            ratingPlusRating={ratingPlusRating}
             onOutcome={handleOutcome}
-            onIdle={() => handleIdle(workerIndex)}
+            onIdle={() => handleWorkerIdle(workerIndex)}
           />
         </Grid>
       ))}

--- a/src/components/runner/licenseCheck/licenseCheckSetupView.tsx
+++ b/src/components/runner/licenseCheck/licenseCheckSetupView.tsx
@@ -7,24 +7,18 @@ import type { FC } from "react"
 import { useMemo } from "react"
 
 import { Label } from "#/components/ui/text/label.tsx"
-import type { ItemData } from "#/system/itemData.ts"
+import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
 
 import { LicenseCheckChecklistRow } from "./licenseCheckChecklistRow.tsx"
+import { useLicenseCheck } from "./licenseCheckContext.tsx"
 import { buildVerificationLanes } from "./licenseCheckLanes.ts"
-
-interface LicenseCheckSetupViewProps {
-  gear: Record<string, ItemData>
-  scannerRating: number
-  onScannerRatingChange: (rating: number) => void
-}
 
 const ratingOptions = [1, 2, 3, 4, 5, 6]
 
-export const LicenseCheckSetupView: FC<LicenseCheckSetupViewProps> = ({
-  gear,
-  scannerRating,
-  onScannerRatingChange,
-}) => {
+export const LicenseCheckSetupView: FC = () => {
+  const gear = useRunnerStoreSelector(Selectors.gear.selectGear)
+  const { scannerRating, setScannerRating } = useLicenseCheck()
+
   // Display-only — Start Scan builds its own checked-items-only queue from these lanes.
   const lanes = useMemo(
     () => buildVerificationLanes(gear),
@@ -44,7 +38,7 @@ export const LicenseCheckSetupView: FC<LicenseCheckSetupViewProps> = ({
           size="small"
           value={scannerRating}
           onChange={(_, value: number | null) => {
-            if (value !== null) onScannerRatingChange(value)
+            if (value !== null) setScannerRating(value)
           }}
         >
           {ratingOptions.map((rating) => (

--- a/src/components/runner/licenseCheck/licenseCheckState.ts
+++ b/src/components/runner/licenseCheck/licenseCheckState.ts
@@ -1,0 +1,74 @@
+import { useMemo, useState } from "react"
+
+import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
+import type { ItemData } from "#/system/itemData.ts"
+
+import { buildLicenseCheckResult } from "./licenseCheckAlerts.ts"
+import { buildVerificationChecks } from "./licenseCheckChecks.ts"
+import type { LicenseCheckResult, VerificationCheck, VerificationOutcome } from "./licenseCheckTypes.ts"
+
+export type LicenseCheckStep = "setup" | "scanning" | "result"
+
+export interface LicenseCheckState {
+  step: LicenseCheckStep
+
+  scannerRating: number
+  setScannerRating: (rating: number) => void
+
+  items: ItemData[]
+  setItems: (items: ItemData[]) => void
+  addItem: (item: ItemData) => void
+  removeItem: (item: ItemData) => void
+
+  checks: VerificationCheck[]
+  result: LicenseCheckResult | null
+
+  startScan: () => void
+  completeScan: (outcomes: VerificationOutcome[]) => void
+  reset: () => void
+}
+
+/**
+ * Owns every piece of state the License Check dialog's steps share — setup selection, the
+ * in-progress scan's queue, and the settled result — so views read it from `LicenseCheckProvider`
+ * instead of receiving it as drilled props.
+ */
+export function useLicenseCheckState(): LicenseCheckState {
+  const allGear = useRunnerStoreSelector(Selectors.gear.selectGear)
+
+  const [step, setStep] = useState<LicenseCheckStep>("setup")
+  const [scannerRating, setScannerRating] = useState(3)
+  const [items, setItems] = useState<ItemData[]>(() => Object.values(allGear))
+  const [checks, setChecks] = useState<VerificationCheck[]>([])
+  const [result, setResult] = useState<LicenseCheckResult | null>(null)
+
+  return useMemo((): LicenseCheckState => ({
+    step,
+
+    scannerRating,
+    setScannerRating,
+
+    items,
+    setItems,
+    addItem: (item) => setItems((current) => [...current, item]),
+    removeItem: (item) => setItems((current) => current.filter((i) => i.id !== item.id)),
+
+    checks,
+    result,
+
+    startScan: () => {
+      // Built fresh here from the Setup checklist's current checked selection, flattened and
+      // shuffled into one queue the worker pool pulls from — unchecked items are never scanned.
+      setChecks(buildVerificationChecks(allGear, items))
+      setStep("scanning")
+    },
+    completeScan: (outcomes) => {
+      setResult(buildLicenseCheckResult(scannerRating, allGear, checks, outcomes))
+      setStep("result")
+    },
+    reset: () => {
+      setStep("setup")
+      setItems(Object.values(allGear))
+    },
+  }), [step, scannerRating, items, checks, result, allGear])
+}

--- a/src/components/runner/licenseCheck/licenseCheckWorkerSlot.tsx
+++ b/src/components/runner/licenseCheck/licenseCheckWorkerSlot.tsx
@@ -2,8 +2,9 @@ import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
 import type { FC } from "react"
 
-import type { ItemData } from "#/system/itemData.ts"
+import { Selectors, useRunnerStoreSelector } from "#/stores/runner/runnerStore.selectors.ts"
 
+import { useLicenseCheck } from "./licenseCheckContext.tsx"
 import { LicenseCheckDiceGroup } from "./licenseCheckDiceGroup.tsx"
 import type { VerificationQueue } from "./licenseCheckQueue.ts"
 import type { VerificationCheck, VerificationOutcome } from "./licenseCheckTypes.ts"
@@ -33,9 +34,6 @@ function getOutcomeLabel(currentOutcome: VerificationOutcome | null): string {
 
 interface LicenseCheckWorkerSlotProps {
   queue: VerificationQueue
-  gear: Record<string, ItemData>
-  scannerRating: number
-  ratingPlusRating: boolean
   onOutcome: (outcome: VerificationOutcome) => void
   onIdle: () => void
 }
@@ -43,12 +41,15 @@ interface LicenseCheckWorkerSlotProps {
 /** The single active/settled check slot within a worker: item name, dice, and the clear/flagged status. */
 export const LicenseCheckWorkerSlot: FC<LicenseCheckWorkerSlotProps> = ({
   queue,
-  gear,
-  scannerRating,
-  ratingPlusRating,
   onOutcome,
   onIdle,
 }) => {
+  const { scannerRating } = useLicenseCheck()
+  const gear = useRunnerStoreSelector(Selectors.gear.selectGear)
+  const ratingPlusRating = useRunnerStoreSelector(
+    Selectors.houseRules.select("items.licenseCheck.ratingPlusRating"),
+  )
+
   const { currentCheck, currentOutcome, credentialDice, scannerDice } = useLicenseCheckWorker({
     queue,
     scannerRating,

--- a/src/components/runner/licenseCheck/useVerificationQueuePool.ts
+++ b/src/components/runner/licenseCheck/useVerificationQueuePool.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+import type { VerificationQueue } from "./licenseCheckQueue.ts"
+import { createVerificationQueue } from "./licenseCheckQueue.ts"
+import type { VerificationCheck, VerificationOutcome } from "./licenseCheckTypes.ts"
+
+interface UseVerificationQueuePoolArgs {
+  checks: VerificationCheck[]
+  workerCount: number
+  onComplete: (outcomes: VerificationOutcome[]) => void
+}
+
+interface UseVerificationQueuePoolResult {
+  queue: VerificationQueue
+  handleOutcome: (outcome: VerificationOutcome) => void
+  handleWorkerIdle: (workerIndex: number) => void
+}
+
+/**
+ * Coordinates a fixed-size worker pool pulling from one shared `VerificationQueue`: collects
+ * outcomes as workers report them and fires `onComplete` once every worker has gone idle — or
+ * immediately when there's nothing to scan.
+ */
+export function useVerificationQueuePool({
+  checks,
+  workerCount,
+  onComplete,
+}: UseVerificationQueuePoolArgs): UseVerificationQueuePoolResult {
+  const queue = useMemo(() => createVerificationQueue(checks), [checks])
+  const outcomesRef = useRef<VerificationOutcome[]>([])
+  const [idleWorkers, setIdleWorkers] = useState<ReadonlySet<number>>(new Set())
+  const hasCompletedRef = useRef(false)
+
+  const handleOutcome = useCallback((outcome: VerificationOutcome) => {
+    outcomesRef.current = [...outcomesRef.current, outcome]
+  }, [])
+
+  const handleWorkerIdle = useCallback((workerIndex: number) => {
+    setIdleWorkers((prev) => (prev.has(workerIndex) ? prev : new Set(prev).add(workerIndex)))
+  }, [])
+
+  useEffect(() => {
+    if (hasCompletedRef.current) return
+    if (checks.length === 0 || idleWorkers.size === workerCount) {
+      hasCompletedRef.current = true
+      onComplete(outcomesRef.current)
+    }
+  }, [checks.length, idleWorkers, workerCount, onComplete])
+
+  return { queue, handleOutcome, handleWorkerIdle }
+}


### PR DESCRIPTION
## Summary

Simplifies the License Check dialog (`src/components/runner/licenseCheck/`) along three lines:

- **Extract worker queue utilities** — pulled the pool-coordination logic (collecting outcomes, tracking idle workers, detecting completion) out of `licenseCheckScanView.tsx` into a new `useVerificationQueuePool.ts` hook built on top of the existing `licenseCheckQueue.ts`. The view is now just "render N worker slots against the pool."
- **Reduce prop drilling (use selectors)** — `gear` and `ratingPlusRating` are now read directly from the runner store via `useRunnerStoreSelector` in the components that actually need them (`LicenseCheckSetupView`, `LicenseCheckWorkerSlot`, `LicenseCheckResultView`), instead of being threaded down as props. `scannerRating` and `ratingPlusRating` were previously drilled through 3 component levels (`licenseCheckDialog` → `LicenseCheckScanView` → `LicenseCheckWorkerSlot` → `useLicenseCheckWorker`); that chain is now just a context read.
- **`licenseCheckState` + context** — all of the dialog's step/scan/result state (previously scattered `useState` calls in `licenseCheckDialog.tsx`) now lives in one `useLicenseCheckState` hook (`licenseCheckState.ts`). `LicenseCheckContext` was expanded to carry that full state instead of just the checklist's item selection, and now follows the same `createContext<T | null>(null)` + `OutOfContextError` guard convention used by other dialog-scoped contexts in the app (e.g. `spendKarmaDialogContext.tsx`), with the Provider owning/constructing its own state rather than receiving it as a `value` prop.

No behavior changes — `licenseCheckDialog.tsx`'s exported `useLicenseCheckDialog()` API is unchanged, and the dialog's step flow (setup → scanning → result), scan mechanics, and result rendering all work exactly as before.

## Test plan

- [x] `yarn tsc` — clean
- [x] `yarn eslint src/components/runner/licenseCheck` — clean
- [x] `yarn vitest run` — full suite passes (843 tests)
- [ ] Manual click-through of the dialog (setup → start scan → result) in a browser

---
_Generated by [Claude Code](https://claude.ai/code/session_01WL6Mrh7JTLrWDTQ1UjpTD2)_