### PR TITLE
Add per-type selectors and action creators for all gear item types

### DIFF
--- a/src/stores/runner/gear/gearSlice.actions.test.ts
+++ b/src/stores/runner/gear/gearSlice.actions.test.ts
@@ -6,7 +6,21 @@ import type { LicenseData } from "#/system/gear/licenseData.ts"
 import type { ItemData } from "#/system/itemData.ts"
 import { ItemType } from "#/system/itemType.ts"
 
-import { licenses } from "./gearSlice.actions.ts"
+import {
+  armor,
+  credsticks,
+  devices,
+  firearmAccessories,
+  firearms,
+  implants,
+  licenses,
+  other,
+  programs,
+  sins,
+  software,
+  vehicles,
+  weapons,
+} from "./gearSlice.actions.ts"
 import { gearReducer } from "./gearSlice.ts"
 
 const makeItem = (overrides: Partial<ItemData> = {}): ItemData => ({
@@ -118,5 +132,48 @@ describe("licenses.clearLicenseForItem", () => {
 
     // Assert
     expect(next[item.id]).toEqual({ ...item, licenseId: null })
+  })
+})
+
+describe.each([
+  { name: "armor", namespace: armor, itemType: ItemType.armor },
+  { name: "implants", namespace: implants, itemType: ItemType.implant },
+  { name: "firearms", namespace: firearms, itemType: ItemType.firearm },
+  { name: "software", namespace: software, itemType: ItemType.software },
+  { name: "vehicles", namespace: vehicles, itemType: ItemType.vehicle },
+  { name: "weapons", namespace: weapons, itemType: ItemType.weapon },
+  { name: "devices", namespace: devices, itemType: ItemType.device },
+  { name: "firearmAccessories", namespace: firearmAccessories, itemType: ItemType.firearmAccessory },
+  { name: "sins", namespace: sins, itemType: ItemType.sin },
+  { name: "credsticks", namespace: credsticks, itemType: ItemType.credstick },
+  { name: "programs", namespace: programs, itemType: ItemType.program },
+  { name: "other", namespace: other, itemType: ItemType.other },
+])("$name", ({ namespace, itemType }) => {
+  describe("create", () => {
+    it("adds the item under a freshly generated id", () => {
+      // Arrange
+      const draft = { itemType, name: "Test Item" }
+
+      // Act
+      const next = gearReducer({}, namespace.create(draft as never))
+
+      // Assert
+      const [stored] = Object.values(next)
+      expect(stored).toMatchObject(draft)
+      expect(stored.id).toBeDefined()
+    })
+  })
+
+  describe("destroy", () => {
+    it("removes the item", () => {
+      // Arrange
+      const item = makeItem({ itemType })
+
+      // Act
+      const next = gearReducer({ [item.id]: item }, namespace.destroy(item.id))
+
+      // Assert
+      expect(next[item.id]).toBeUndefined()
+    })
   })
 })

--- a/src/stores/runner/gear/gearSlice.actions.ts
+++ b/src/stores/runner/gear/gearSlice.actions.ts
@@ -3,7 +3,16 @@ import type { UUID } from "node:crypto"
 import { createAction } from "@reduxjs/toolkit"
 
 import { NullUuid } from "#/lib/uuidUtils.ts"
+import type { ArmorData } from "#/system/gear/armorData.ts"
+import type { CredstickData } from "#/system/gear/credstickData.ts"
+import type { DeviceData } from "#/system/gear/deviceData.ts"
+import type { ImplantData } from "#/system/gear/implantData.ts"
 import type { LicenseData } from "#/system/gear/licenseData.ts"
+import type { ProgramData } from "#/system/gear/programData.ts"
+import type { SinData } from "#/system/gear/sinData.ts"
+import type { SoftwareData } from "#/system/gear/softwareData.ts"
+import type { VehicleData } from "#/system/gear/vehicleData.ts"
+import type { FirearmAccessoryData, WeaponData } from "#/system/gear/weaponData.ts"
 import type { ItemData } from "#/system/itemData.ts"
 
 export const addItem = createAction("gear/add", (item: Omit<ItemData, "id">) => {
@@ -53,3 +62,28 @@ export const licenses = {
     return patchItem({ itemId, data: { licenseId: null } })
   },
 }
+
+function makeTypeActions<TItem extends ItemData>() {
+  return {
+    create: (item: Omit<TItem, "id">) => {
+      return addItem(item)
+    },
+
+    destroy: (id: TItem["id"]) => {
+      return removeItem({ id })
+    },
+  }
+}
+
+export const armor = makeTypeActions<ArmorData>()
+export const implants = makeTypeActions<ImplantData>()
+export const firearms = makeTypeActions<ItemData>()
+export const software = makeTypeActions<SoftwareData>()
+export const vehicles = makeTypeActions<VehicleData>()
+export const weapons = makeTypeActions<WeaponData>()
+export const devices = makeTypeActions<DeviceData>()
+export const firearmAccessories = makeTypeActions<FirearmAccessoryData>()
+export const sins = makeTypeActions<SinData>()
+export const credsticks = makeTypeActions<CredstickData>()
+export const programs = makeTypeActions<ProgramData>()
+export const other = makeTypeActions<ItemData>()

--- a/src/stores/runner/gear/gearSlice.selectors.test.ts
+++ b/src/stores/runner/gear/gearSlice.selectors.test.ts
@@ -8,7 +8,15 @@ import { ItemType } from "#/system/itemType.ts"
 import { runnerDataFactory } from "#/system/runnerData.factory.ts"
 
 import {
+  armor,
+  credsticks,
+  devices,
+  firearmAccessories,
+  firearms,
+  implants,
   licenses,
+  other,
+  programs,
   selectAllGear,
   selectAvailable,
   selectById,
@@ -16,6 +24,10 @@ import {
   selectGear,
   selectGearOfType,
   selectStashed,
+  sins,
+  software,
+  vehicles,
+  weapons,
 } from "./gearSlice.selectors.ts"
 
 const item = { id: NullUuid, name: "Test Item", itemType: ItemType.other }
@@ -122,8 +134,8 @@ describe("selectGearOfType", () => {
   it("filters gear down to the given item type", () => {
     // Arrange
     const weapon = makeItem({ itemType: ItemType.weapon })
-    const armor = makeItem({ itemType: ItemType.armor })
-    const runner = withGear(weapon, armor)
+    const armorItem = makeItem({ itemType: ItemType.armor })
+    const runner = withGear(weapon, armorItem)
 
     // Act / Assert
     expect(selectGearOfType(ItemType.weapon)(runner)).toEqual({ [weapon.id]: weapon })
@@ -213,5 +225,39 @@ describe("licenses.selectItemsForId", () => {
 
     // Act / Assert
     expect(licenses.selectItemsForId(crypto.randomUUID() as UUID)(runner)).toEqual([])
+  })
+})
+
+describe.each([
+  { name: "armor", namespace: armor, itemType: ItemType.armor },
+  { name: "implants", namespace: implants, itemType: ItemType.implant },
+  { name: "firearms", namespace: firearms, itemType: ItemType.firearm },
+  { name: "software", namespace: software, itemType: ItemType.software },
+  { name: "vehicles", namespace: vehicles, itemType: ItemType.vehicle },
+  { name: "weapons", namespace: weapons, itemType: ItemType.weapon },
+  { name: "devices", namespace: devices, itemType: ItemType.device },
+  { name: "firearmAccessories", namespace: firearmAccessories, itemType: ItemType.firearmAccessory },
+  { name: "sins", namespace: sins, itemType: ItemType.sin },
+  { name: "credsticks", namespace: credsticks, itemType: ItemType.credstick },
+  { name: "programs", namespace: programs, itemType: ItemType.program },
+  { name: "other", namespace: other, itemType: ItemType.other },
+])("$name.selectById", ({ namespace, itemType }) => {
+  it("finds an item of the matching type by id", () => {
+    // Arrange
+    const typedItem = makeItem({ itemType })
+    const runner = withGear(typedItem)
+
+    // Act / Assert
+    expect(namespace.selectById(typedItem.id)(runner)).toEqual(typedItem)
+  })
+
+  it("does not return an item of a different type even with a matching id", () => {
+    // Arrange
+    const otherType = itemType === ItemType.weapon ? ItemType.armor : ItemType.weapon
+    const gearItem = makeItem({ itemType: otherType })
+    const runner = withGear(gearItem)
+
+    // Act / Assert
+    expect(namespace.selectById(gearItem.id)(runner)).toBeUndefined()
   })
 })

--- a/src/stores/runner/gear/gearSlice.selectors.ts
+++ b/src/stores/runner/gear/gearSlice.selectors.ts
@@ -84,3 +84,26 @@ export const licenses = {
     },
   ),
 }
+
+function makeSelectByIdOfType(type: ItemType) {
+  return createCurriedSelector(
+    [
+      selectGearOfType(type),
+      (_, id: UUID) => id,
+    ],
+    (itemsOfType, id) => itemsOfType[id],
+  )
+}
+
+export const armor = { selectById: makeSelectByIdOfType(ItemType.armor) }
+export const implants = { selectById: makeSelectByIdOfType(ItemType.implant) }
+export const firearms = { selectById: makeSelectByIdOfType(ItemType.firearm) }
+export const software = { selectById: makeSelectByIdOfType(ItemType.software) }
+export const vehicles = { selectById: makeSelectByIdOfType(ItemType.vehicle) }
+export const weapons = { selectById: makeSelectByIdOfType(ItemType.weapon) }
+export const devices = { selectById: makeSelectByIdOfType(ItemType.device) }
+export const firearmAccessories = { selectById: makeSelectByIdOfType(ItemType.firearmAccessory) }
+export const sins = { selectById: makeSelectByIdOfType(ItemType.sin) }
+export const credsticks = { selectById: makeSelectByIdOfType(ItemType.credstick) }
+export const programs = { selectById: makeSelectByIdOfType(ItemType.program) }
+export const other = { selectById: makeSelectByIdOfType(ItemType.other) }


### PR DESCRIPTION
## Summary
- `gearSlice.selectors.ts` gains an `armor` / `implants` / `firearms` / `software` / `vehicles` / `weapons` / `devices` / `firearmAccessories` / `sins` / `credsticks` / `programs` / `other` namespace, each exposing a `selectById` scoped to that `ItemType`, mirroring the existing `licenses.selectById`.
- `gearSlice.actions.ts` gains matching namespaces with `create` / `destroy` action creators typed against each type's data interface (`ArmorData`, `WeaponData`, etc.), mirroring `licenses.create` / `licenses.destroy`.
- License-specific relational selectors/actions (`selectForItem`, `selectItemsForId`, `setLicenseForItem`, `clearLicenseForItem`) aren't duplicated since they model the license↔item link, which doesn't generalize to other item types.

## Test plan
- [x] `yarn tsc`
- [x] `yarn eslint:lint` on changed files
- [x] `yarn test:unit` (891 tests passing, including new parameterized cases for every item type's `selectById`/`create`/`destroy`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CQSf97SMW1RZGe8rjsiuLd)_