### PR TITLE
Fix skill dialog attribute selector not updating its dice pool

### DIFF
--- a/src/components/runner/skills/activeSkills/activeSkillsListItem.test.tsx
+++ b/src/components/runner/skills/activeSkills/activeSkillsListItem.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen, within } from "@testing-library/react"
+import type { FC, PropsWithChildren } from "react"
+import { describe, expect, it } from "vitest"
+
+import { RunnerDataStore } from "#/components/runner/sheet/runnerDataStore.ts"
+import { RunnerStoreProvider } from "#/components/runner/sheet/runnerStoreProvider.tsx"
+import { runnerDataFactory } from "#/system/runnerData.factory.ts"
+import { SkillKey } from "#/system/skills/skillKey.ts"
+
+import { ActiveSkillsListItem } from "./activeSkillsListItem.tsx"
+
+function renderPistols() {
+  const runnerData = runnerDataFactory((data) => {
+    data.attributes.agility = 3
+    data.attributes.logic = 6
+    data.skills.activeSkills = [{ name: SkillKey.pistols, rating: 4 }]
+    return data
+  })
+  const store = new RunnerDataStore(runnerData)
+
+  const Wrapper: FC<PropsWithChildren> = ({ children }) => (
+    <RunnerStoreProvider store={store}>{children}</RunnerStoreProvider>
+  )
+
+  render(<ActiveSkillsListItem skillKey={SkillKey.pistols} rating={4} />, { wrapper: Wrapper })
+}
+
+describe("ActiveSkillsListItem", () => {
+  it("opens a dialog whose dice pool reacts to changing the attribute selection", () => {
+    // Arrange
+    renderPistols()
+    fireEvent.click(screen.getByText(SkillKey.pistols))
+    const dialog = within(screen.getByRole("dialog"))
+
+    // Assert: defaults to the skill's attribute (agility 3 + pistols 4). DicePool renders
+    // its total twice — the always-visible header and the (hidden but mounted) expanded
+    // ledger — same as in resistanceDicePools.test.tsx.
+    expect(dialog.getAllByText("7")).toHaveLength(2)
+
+    // Act: switch to a different attribute (logic 6 + pistols 4)
+    fireEvent.mouseDown(dialog.getByRole("combobox"))
+    fireEvent.click(screen.getByRole("option", { name: "LOG — logic" }))
+
+    // Assert: the pool shown in the dialog updates to reflect the new attribute
+    expect(dialog.getAllByText("10")).toHaveLength(2)
+    expect(dialog.queryByText("7")).toBeNull()
+  })
+})

--- a/src/components/runner/skills/activeSkills/activeSkillsListItem.tsx
+++ b/src/components/runner/skills/activeSkills/activeSkillsListItem.tsx
@@ -2,11 +2,12 @@ import FormControl from "@mui/material/FormControl"
 import InputLabel from "@mui/material/InputLabel"
 import MenuItem from "@mui/material/MenuItem"
 import Select from "@mui/material/Select"
+import Stack from "@mui/material/Stack"
 import type { FC } from "react"
 import { useState } from "react"
 
 import { SkillListItem } from "#/components/runner/skills/skillListItem.tsx"
-import { useViewSkillDialog } from "#/components/runner/skills/viewSkillDialog.tsx"
+import { DicePoolsStack, useViewSkillDialog } from "#/components/runner/skills/viewSkillDialog.tsx"
 import { useActiveSkillDicePool } from "#/lib/hooks/runner/skills/skillDicePools.ts"
 import { useRunnerStoreSelector } from "#/lib/stores/runner/runnerStore.selectors.ts"
 import { AttributeKey, AttributeLabels } from "#/system/attributeKey.ts"
@@ -22,13 +23,51 @@ const selectableAttributes = Object.values(AttributeKey).filter(
   (key) => key !== AttributeKey.essence,
 )
 
-export const ActiveSkillsListItem: FC<ActiveSkillsListItemProps> = ({ skillKey, rating }) => {
+/**
+ * Owns the attribute-selection state itself so the dialog's dice pools stay live as the
+ * user changes the attribute, rather than being frozen at the props passed when the dialog
+ * was opened.
+ */
+const ActiveSkillDialogBody: FC<{ skillKey: SkillKey, specialization?: string }> = ({
+  skillKey,
+  specialization,
+}) => {
   const skillInfo = skillList[skillKey]
-  const isDefaulted = rating === 0 && (skillInfo.defaultable ?? true)
-
   const [selectedAttr, setSelectedAttr] = useState<AttributeKey>(skillInfo.attr)
 
   const skillDicePool = useActiveSkillDicePool({ skillKey, attrOverride: selectedAttr })
+  const specializationDicePool = useActiveSkillDicePool({ skillKey, specialization, attrOverride: selectedAttr })
+
+  return (
+    <Stack spacing={1}>
+      <FormControl size="small" fullWidth>
+        <InputLabel>Attribute</InputLabel>
+        <Select
+          label="Attribute"
+          value={selectedAttr}
+          onChange={(event) => setSelectedAttr(event.target.value as AttributeKey)}
+        >
+          {selectableAttributes.map((attrKey) => (
+            <MenuItem key={attrKey} value={attrKey}>
+              {AttributeLabels[attrKey]} — {attrKey}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      <DicePoolsStack
+        dicePools={[
+          skillDicePool,
+          specialization ? specializationDicePool : false,
+        ]}
+      />
+    </Stack>
+  )
+}
+
+export const ActiveSkillsListItem: FC<ActiveSkillsListItemProps> = ({ skillKey, rating }) => {
+  const skillInfo = skillList[skillKey]
+  const isDefaulted = rating === 0 && (skillInfo.defaultable ?? true)
 
   const specialization = useRunnerStoreSelector((sheet) => {
     return sheet.skills
@@ -37,26 +76,7 @@ export const ActiveSkillsListItem: FC<ActiveSkillsListItemProps> = ({ skillKey, 
       ?.specialization
   })
 
-  const specializationDicePool = useActiveSkillDicePool({ skillKey, specialization, attrOverride: selectedAttr })
-
   const viewSkillDialog = useViewSkillDialog()
-
-  const attributeSelector = (
-    <FormControl size="small" fullWidth>
-      <InputLabel>Attribute</InputLabel>
-      <Select
-        label="Attribute"
-        value={selectedAttr}
-        onChange={(event) => setSelectedAttr(event.target.value as AttributeKey)}
-      >
-        {selectableAttributes.map((attrKey) => (
-          <MenuItem key={attrKey} value={attrKey}>
-            {AttributeLabels[attrKey]} — {attrKey}
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
-  )
 
   return (
     <>
@@ -64,15 +84,11 @@ export const ActiveSkillsListItem: FC<ActiveSkillsListItemProps> = ({ skillKey, 
         name={skillKey}
         rating={rating}
         specialization={specialization}
-        attr={selectedAttr}
+        attr={skillInfo.attr}
         isDefaulted={isDefaulted}
         onClick={() => viewSkillDialog.open({
           name: skillKey,
-          body: attributeSelector,
-          dicePools: [
-            skillDicePool,
-            specialization ? specializationDicePool : false,
-          ],
+          body: <ActiveSkillDialogBody skillKey={skillKey} specialization={specialization} />,
         })}
       />
       {viewSkillDialog.dialog}

--- a/src/components/runner/skills/activeSkills/activeSkillsListItem.tsx
+++ b/src/components/runner/skills/activeSkills/activeSkillsListItem.tsx
@@ -23,11 +23,6 @@ const selectableAttributes = Object.values(AttributeKey).filter(
   (key) => key !== AttributeKey.essence,
 )
 
-/**
- * Owns the attribute-selection state itself so the dialog's dice pools stay live as the
- * user changes the attribute, rather than being frozen at the props passed when the dialog
- * was opened.
- */
 const ActiveSkillDialogBody: FC<{ skillKey: SkillKey, specialization?: string }> = ({
   skillKey,
   specialization,
@@ -45,7 +40,7 @@ const ActiveSkillDialogBody: FC<{ skillKey: SkillKey, specialization?: string }>
         <Select
           label="Attribute"
           value={selectedAttr}
-          onChange={(event) => setSelectedAttr(event.target.value as AttributeKey)}
+          onChange={(event) => setSelectedAttr(event.target.value)}
         >
           {selectableAttributes.map((attrKey) => (
             <MenuItem key={attrKey} value={attrKey}>

--- a/src/components/runner/skills/viewSkillDialog.tsx
+++ b/src/components/runner/skills/viewSkillDialog.tsx
@@ -13,6 +13,20 @@ interface ViewSkillDialogProps extends ControlledDialogProps<void> {
   dicePools?: (false | DicePoolData)[]
 }
 
+/** Renders dice pools side by side, stacking into a column on narrow (mobile) viewports. */
+export const DicePoolsStack: FC<{ dicePools: (false | DicePoolData)[] }> = ({ dicePools }) => (
+  <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
+    {dicePools
+      .filter((item): item is DicePoolData => Boolean(item))
+      .map((pool) => (
+        <DicePool
+          key={pool.name}
+          {...pool}
+        />
+      ))}
+  </Stack>
+)
+
 const ViewSkillDialog: FC<ViewSkillDialogProps> = ({
   ctrl,
   name,
@@ -26,16 +40,7 @@ const ViewSkillDialog: FC<ViewSkillDialogProps> = ({
         <Stack spacing={1}>
           {body}
 
-          <Stack direction="row">
-            {dicePools
-              .filter((item): item is DicePoolData => Boolean(item))
-              .map((pool) => (
-                <DicePool
-                  key={pool.name}
-                  {...pool}
-                />
-              ))}
-          </Stack>
+          <DicePoolsStack dicePools={dicePools} />
         </Stack>
       </Dialog.Content>
     </ControlledDialog>


### PR DESCRIPTION
## Summary
- The "view skill" dialog for active skills has an attribute selector, but it was frozen in place: `useDialog` snapshots `body`/`dicePools` at the moment the dialog is opened, so changing the Select afterward never re-rendered the dice pool (or the Select itself) shown inside the dialog — only the background skill row updated. Fixed by moving the attribute-selection state into a new `ActiveSkillDialogBody` component that's mounted inside the dialog, so its own re-renders keep the displayed pool live.
- Extracted the dice-pools layout into a reusable `DicePoolsStack` component and changed its `Stack` direction to `{ xs: "column", sm: "row" }`, so pools stack into a column on mobile instead of being squeezed into a row.

## Test plan
- [x] Added `activeSkillsListItem.test.tsx`: opens the dialog, confirms the initial pool total, switches the attribute in the Select, and confirms the pool total updates accordingly.
- [x] `yarn vitest run` — full suite passes (132 files, 892 tests).
- [x] `yarn tsc --noEmit` — no errors.
- [x] `yarn lint` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xus5vcf8EnoU64pPkkjmAi)_