### PR TITLE
Clean up deprecated methods

### DIFF
--- a/src/components/builder/buildPoints/attributeUtils.ts
+++ b/src/components/builder/buildPoints/attributeUtils.ts
@@ -1,8 +1,0 @@
-import { BuilderConfig } from "#/components/builder/builderConfig.ts"
-
-/** @deprecated Use `BuilderConfig.attributes.bpAllowance` instead. */
-export const AttributeBpAllowance = BuilderConfig.attributes.bpAllowance
-/** @deprecated Use `BuilderConfig.attributes.bpCost.base` instead. */
-export const AttributeBpCostBase = BuilderConfig.attributes.bpCost.base
-/** @deprecated Use `BuilderConfig.attributes.bpCost.maxOut` instead. */
-export const AttributeBpCostMaxOut = BuilderConfig.attributes.bpCost.maxOut

--- a/src/components/builder/saveRunnerButton.tsx
+++ b/src/components/builder/saveRunnerButton.tsx
@@ -21,7 +21,7 @@ export const SaveRunnerButton: FC<SaveRunnerButtonProps> = ({ requireValid = tru
 
   const saveRunner = useMutation({
     mutationFn: async () => {
-      let runner = store.get()
+      let runner = store.getState()
 
       if (runner.id === NullUuid) {
         runner = { ...runner, id: crypto.randomUUID() }

--- a/src/components/builder/sections/biology/biologySection.test.tsx
+++ b/src/components/builder/sections/biology/biologySection.test.tsx
@@ -54,7 +54,7 @@ describe("BiologySection", () => {
     fireEvent.click(screen.getByRole("option", { name: /Troll/ }))
 
     // Assert: state updated...
-    expect(store.state.biology.metatype).toBe(MetatypeType.Troll)
+    expect(store.getState().biology.metatype).toBe(MetatypeType.Troll)
     // ...and the UI re-rendered off that same state.
     expect(metatypeCombobox().textContent).toContain("Troll")
   })
@@ -77,7 +77,7 @@ describe("BiologySection", () => {
     fireEvent.click(screen.getByRole("option", { name: /Magician/ }))
 
     // Assert
-    expect(store.state.biology.awakening).toBe(AwakeningType.Magician)
+    expect(store.getState().biology.awakening).toBe(AwakeningType.Magician)
     expect(awakeningCombobox().textContent).toContain("Magician")
   })
 })

--- a/src/components/builder/sections/contacts/contactsBuilderUtils.ts
+++ b/src/components/builder/sections/contacts/contactsBuilderUtils.ts
@@ -1,11 +1,6 @@
 import { BuilderConfig } from "#/components/builder/builderConfig.ts"
 import type { ContactData } from "#/system/contactData.ts"
 
-/** @deprecated Use `BuilderConfig.contacts.bpCost.perConnection` instead. */
-export const ContactCostPerConnection = BuilderConfig.contacts.bpCost.perConnection
-/** @deprecated Use `BuilderConfig.contacts.bpCost.perLoyalty` instead. */
-export const ContactCostPerLoyalty = BuilderConfig.contacts.bpCost.perLoyalty
-
 export const getContactBpCost = (contact: ContactData): number => {
   return (
     contact.connection * BuilderConfig.contacts.bpCost.perConnection

--- a/src/components/builder/sections/gear/gearSection.tsx
+++ b/src/components/builder/sections/gear/gearSection.tsx
@@ -147,7 +147,7 @@ const GearSectionContent: FC<{
 const GearSectionNuyen: FC<{
   section: SectionHeader
 }> = ({ section }) => {
-  const allGearItems = useRunnerStoreSelector(Selectors.gear.selectGear)
+  const allGearItems = useRunnerStoreSelector(Selectors.gear.selectAllGear)
 
   const lifestyleInfo = useRunnerStoreSelector(Selectors.profile.selectLifestyleInfo)
   const lifestyleMonths = useRunnerStoreSelector(Selectors.profile.selectLifestyleMonthsPaid) ?? 1

--- a/src/components/builder/sections/gear/lifestyle/lifestylePanel.test.tsx
+++ b/src/components/builder/sections/gear/lifestyle/lifestylePanel.test.tsx
@@ -53,7 +53,7 @@ describe("LifestylePanel", () => {
     fireEvent.click(screen.getByRole("option", { name: LifestyleType.Middle }))
 
     // Assert: state updated...
-    await waitFor(() => expect(store.state.profile.lifestyle?.quality).toBe(LifestyleType.Middle))
+    await waitFor(() => expect(store.getState().profile.lifestyle?.quality).toBe(LifestyleType.Middle))
     // ...and the UI re-rendered off that same state.
     expect(screen.getByRole("combobox").textContent).toBe(LifestyleType.Middle)
   })
@@ -66,6 +66,6 @@ describe("LifestylePanel", () => {
     fireEvent.change(screen.getByLabelText("Months prepaid"), { target: { value: "5" } })
 
     // Assert
-    await waitFor(() => expect(store.state.profile.lifestyle?.monthsPaid).toBe(5))
+    await waitFor(() => expect(store.getState().profile.lifestyle?.monthsPaid).toBe(5))
   })
 })

--- a/src/components/builder/sections/gear/startingNuyenSection.tsx
+++ b/src/components/builder/sections/gear/startingNuyenSection.tsx
@@ -8,12 +8,10 @@ import Typography from "@mui/material/Typography"
 import type { FC } from "react"
 import { useEffect } from "react"
 
+import { BuilderConfig } from "#/components/builder/builderConfig.ts"
 import { DiceResult } from "#/components/system/dice/diceResult.tsx"
 import { formatNuyen, Nuyen } from "#/components/ui/nuyen.tsx"
-import {
-  GearNuyenPerBuildPoint,
-  useGearTotalCost,
-} from "#/lib/hooks/builder/buildPoints/useGearBuildPoints.ts"
+import { useGearTotalCost } from "#/lib/hooks/builder/buildPoints/useGearBuildPoints.ts"
 import { useDiceRoller } from "#/lib/hooks/system/dice/useDiceRoller.ts"
 import { Actions as BuilderActions } from "#/lib/stores/builder/builderStore.actions.ts"
 import { useBuilderStoreDispatch } from "#/lib/stores/builder/builderStore.dispatch.ts"
@@ -31,8 +29,8 @@ export const StartingNuyenSection: FC = () => {
   const totalNuyen = useGearTotalCost()
   // Unspent nuyen is the leftover from the last BP purchased.
   // e.g. spent 24,700¥ → buys 5 BP (25,000¥) → 300¥ unspent → +3 bonus
-  const bpsPurchased = Math.ceil(totalNuyen / GearNuyenPerBuildPoint)
-  const nuyenAllocated = bpsPurchased * GearNuyenPerBuildPoint
+  const bpsPurchased = Math.ceil(totalNuyen / BuilderConfig.gear.nuyenPerBp)
+  const nuyenAllocated = bpsPurchased * BuilderConfig.gear.nuyenPerBp
   const unspentNuyen = totalNuyen === 0 ? 0 : nuyenAllocated - totalNuyen
   const maxBonus = numDice * 3
   const bonus = Math.min(Math.floor(unspentNuyen / 100), maxBonus)

--- a/src/components/builder/sections/profile/profileSection.test.tsx
+++ b/src/components/builder/sections/profile/profileSection.test.tsx
@@ -43,7 +43,7 @@ describe("ProfileSection", () => {
     fireEvent.change(screen.getByLabelText("Alias"), { target: { value: "Wraith" } })
 
     // Assert: state updated...
-    await waitFor(() => expect(store.state.profile.alias).toBe("Wraith"))
+    await waitFor(() => expect(store.getState().profile.alias).toBe("Wraith"))
     // ...and the UI re-rendered off that same state.
     expect((screen.getByLabelText("Alias") as HTMLInputElement).value).toBe("Wraith")
   })
@@ -52,12 +52,12 @@ describe("ProfileSection", () => {
     // Arrange
     const store = renderSection()
     fireEvent.change(screen.getByLabelText("Archetype"), { target: { value: "Street Samurai" } })
-    await waitFor(() => expect(store.state.profile.archetype).toBe("Street Samurai"))
+    await waitFor(() => expect(store.getState().profile.archetype).toBe("Street Samurai"))
 
     // Act
     fireEvent.change(screen.getByLabelText("Archetype"), { target: { value: "" } })
 
     // Assert
-    await waitFor(() => expect(store.state.profile.archetype).toBeNull())
+    await waitFor(() => expect(store.getState().profile.archetype).toBeNull())
   })
 })

--- a/src/components/builder/sections/qualities/qualitiesList.test.tsx
+++ b/src/components/builder/sections/qualities/qualitiesList.test.tsx
@@ -51,7 +51,7 @@ describe("QualitiesList", () => {
     fireEvent.click(screen.getByRole("button", { name: "Remove quality Toughness" }))
 
     // Assert: state updated...
-    await waitFor(() => expect(store.state.qualities).toHaveLength(0))
+    await waitFor(() => expect(store.getState().qualities).toHaveLength(0))
     // ...and the UI re-rendered off that same state.
     expect(screen.queryByText("Toughness")).toBeNull()
     expect(screen.getByText("No Qualities qualities added")).toBeDefined()
@@ -71,7 +71,7 @@ describe("QualitiesList", () => {
     fireEvent.click(within(dialog).getByRole("button", { name: /save/i }))
 
     // Assert: state updated...
-    await waitFor(() => expect(store.state.qualities[0].bpValue).toBe(15))
+    await waitFor(() => expect(store.getState().qualities[0].bpValue).toBe(15))
     // ...and the UI re-rendered off that same state.
     expect(await screen.findByText("15 BP")).toBeDefined()
     expect(screen.queryByText("10 BP")).toBeNull()

--- a/src/components/builder/sections/qualities/qualitiesSection.test.tsx
+++ b/src/components/builder/sections/qualities/qualitiesSection.test.tsx
@@ -25,7 +25,7 @@ describe("QualitiesSection", () => {
   it("adding a quality dispatches addQuality and updates the store", async () => {
     // Arrange
     const store = renderSection()
-    expect(store.state.qualities).toHaveLength(0)
+    expect(store.getState().qualities).toHaveLength(0)
 
     // Act
     fireEvent.click(screen.getByRole("button", { name: /add quality/i }))
@@ -36,8 +36,8 @@ describe("QualitiesSection", () => {
     fireEvent.click(within(dialog).getByRole("button", { name: /save/i }))
 
     // Assert: state updated...
-    await waitFor(() => expect(store.state.qualities).toHaveLength(1))
-    expect(store.state.qualities[0].name).toBe("Danger Sense")
+    await waitFor(() => expect(store.getState().qualities).toHaveLength(1))
+    expect(store.getState().qualities[0].name).toBe("Danger Sense")
     // ...and the UI re-rendered off that same state.
     expect(await screen.findByText("Danger Sense")).toBeDefined()
   })

--- a/src/components/builder/sections/qualities/qualitiesUtils.ts
+++ b/src/components/builder/sections/qualities/qualitiesUtils.ts
@@ -1,4 +1,0 @@
-import { BuilderConfig } from "#/components/builder/builderConfig.ts"
-
-/** @deprecated Use `BuilderConfig.qualities.maxNegativeBpBonus` instead. */
-export const QualitiesMaxNegativeBpBonus = BuilderConfig.qualities.maxNegativeBpBonus

--- a/src/components/builder/sections/resources/magician/spellsList.test.tsx
+++ b/src/components/builder/sections/resources/magician/spellsList.test.tsx
@@ -74,8 +74,8 @@ describe("SpellsList", () => {
     fireEvent.click(within(dialog).getByRole("button", { name: /save/i }))
 
     // Assert: state updated...
-    await waitFor(() => expect(store.state.spells).toHaveLength(1))
-    expect(store.state.spells[0].name).toBe("Fireball")
+    await waitFor(() => expect(store.getState().spells).toHaveLength(1))
+    expect(store.getState().spells[0].name).toBe("Fireball")
     // ...and the UI re-rendered off that same state.
     expect(await screen.findByText("Fireball")).toBeDefined()
   })
@@ -90,7 +90,7 @@ describe("SpellsList", () => {
     fireEvent.click(within(dialog).getByRole("button", { name: "Delete" }))
 
     // Assert: state updated...
-    await waitFor(() => expect(store.state.spells).toHaveLength(0))
+    await waitFor(() => expect(store.getState().spells).toHaveLength(0))
     // ...and the UI re-rendered off that same state.
     expect(screen.queryByText("Manabolt")).toBeNull()
   })

--- a/src/components/builder/sections/resources/magician/traditionCard.test.tsx
+++ b/src/components/builder/sections/resources/magician/traditionCard.test.tsx
@@ -71,7 +71,7 @@ describe("TraditionCard", () => {
     fireEvent.click(within(dialog).getByRole("button", { name: /save/i }))
 
     // Assert: state updated...
-    await waitFor(() => expect(store.state.tradition?.name).toBe("Shamanic"), { timeout: 3000 })
+    await waitFor(() => expect(store.getState().tradition?.name).toBe("Shamanic"), { timeout: 3000 })
     // ...and the UI re-rendered off that same state.
     expect(await screen.findByText("Shamanic")).toBeDefined()
     expect(screen.queryByText("Hermetic")).toBeNull()

--- a/src/components/builder/sections/resources/technomancer/complexForms/complexFormsList.test.tsx
+++ b/src/components/builder/sections/resources/technomancer/complexForms/complexFormsList.test.tsx
@@ -59,8 +59,8 @@ describe("ComplexFormsList", () => {
     fireEvent.click(within(dialog).getByRole("button", { name: /save/i }))
 
     // Assert: state updated...
-    await waitFor(() => expect(store.state.complexForms).toHaveLength(1))
-    expect(store.state.complexForms[0].name).toBe("Puppeteer")
+    await waitFor(() => expect(store.getState().complexForms).toHaveLength(1))
+    expect(store.getState().complexForms[0].name).toBe("Puppeteer")
     // ...and the UI re-rendered off that same state.
     expect(await screen.findByText("Puppeteer")).toBeDefined()
   })
@@ -74,7 +74,7 @@ describe("ComplexFormsList", () => {
     fireEvent.click(deleteButton!)
 
     // Assert: state updated...
-    await waitFor(() => expect(store.state.complexForms).toHaveLength(0))
+    await waitFor(() => expect(store.getState().complexForms).toHaveLength(0))
     // ...and the UI re-rendered off that same state.
     expect(screen.queryByText("Diagnostics")).toBeNull()
   })

--- a/src/components/builder/sections/resources/technomancer/sprites/spritesList.test.tsx
+++ b/src/components/builder/sections/resources/technomancer/sprites/spritesList.test.tsx
@@ -59,8 +59,8 @@ describe("SpritesList", () => {
     fireEvent.click(within(dialog).getByRole("button", { name: /save/i }))
 
     // Assert: state updated...
-    await waitFor(() => expect(store.state.sprites).toHaveLength(1))
-    expect(store.state.sprites[0].name).toBe("Fault")
+    await waitFor(() => expect(store.getState().sprites).toHaveLength(1))
+    expect(store.getState().sprites[0].name).toBe("Fault")
     // ...and the UI re-rendered off that same state.
     expect(await screen.findByText("Fault")).toBeDefined()
   })
@@ -74,7 +74,7 @@ describe("SpritesList", () => {
     fireEvent.click(deleteButton!)
 
     // Assert: state updated...
-    await waitFor(() => expect(store.state.sprites).toHaveLength(0))
+    await waitFor(() => expect(store.getState().sprites).toHaveLength(0))
     // ...and the UI re-rendered off that same state.
     expect(screen.queryByText("Courier")).toBeNull()
   })

--- a/src/components/builder/sections/skills/skillsBuilderUtils.ts
+++ b/src/components/builder/sections/skills/skillsBuilderUtils.ts
@@ -4,23 +4,6 @@ import type { KnowledgeSkillData } from "#/system/skills/knowledgeSkillData"
 import type { LanguageSkillData } from "#/system/skills/languageSkillData"
 import type { SkillGroupData } from "#/system/skills/skillGroupData"
 
-/** @deprecated Use `BuilderConfig.skills.active.bpCost.perRating` instead. */
-export const ActiveSkillBpPerRating = BuilderConfig.skills.active.bpCost.perRating
-/** @deprecated Use `BuilderConfig.skills.group.bpCost.perRating` instead. */
-export const ActiveSkillGroupBpPerRating = BuilderConfig.skills.group.bpCost.perRating
-/** @deprecated Use `BuilderConfig.skills.active.bpCost.specialization` instead. */
-export const ActiveSkillSpecializationBp = BuilderConfig.skills.active.bpCost.specialization
-/** @deprecated Use `BuilderConfig.skills.knowledge.spCost.perRating` instead. */
-export const KnowledgeSkillSpPerRating = BuilderConfig.skills.knowledge.spCost.perRating
-/** @deprecated Use `BuilderConfig.skills.language.spCost.perRating` instead. */
-export const LanguageSkillSpPerRating = BuilderConfig.skills.language.spCost.perRating
-/** @deprecated Use `BuilderConfig.skills.knowledge.spCost.specialization` instead. */
-export const KnowledgeSpecializationSp = BuilderConfig.skills.knowledge.spCost.specialization
-/** @deprecated Use `BuilderConfig.skills.language.spCost.specialization` instead. */
-export const LanguageSpecializationSp = BuilderConfig.skills.language.spCost.specialization
-/** @deprecated Use `BuilderConfig.skills.knowledge.bpCost.extraSkillPoint` instead. */
-export const ExtraSkillPointBpCost = BuilderConfig.skills.knowledge.bpCost.extraSkillPoint
-
 export const getFreeSkillPoints = (
   logic: number,
   intuition: number,

--- a/src/components/dice/diceTrayApi.test.ts
+++ b/src/components/dice/diceTrayApi.test.ts
@@ -24,15 +24,15 @@ describe("DiceTrayApi", () => {
 
       api.setDice(8)
 
-      expect(api.store.state.open).toBe(true)
-      expect(api.store.state.poolSize).toBe(8)
-      expect(api.store.state.edgeSpent).toBe(false)
+      expect(api.store.getState().open).toBe(true)
+      expect(api.store.getState().poolSize).toBe(8)
+      expect(api.store.getState().edgeSpent).toBe(false)
     })
 
     it("clamps pool size to a minimum of 0", () => {
       api.setDice(0)
 
-      expect(api.store.state.poolSize).toBe(0)
+      expect(api.store.getState().poolSize).toBe(0)
     })
   })
 
@@ -42,7 +42,7 @@ describe("DiceTrayApi", () => {
     it("marks edge as spent and delegates to the roller", () => {
       api.rollEdge(3)
 
-      expect(api.store.state.edgeSpent).toBe(true)
+      expect(api.store.getState().edgeSpent).toBe(true)
       expect(vi.mocked(api.roller.addDice)).toHaveBeenCalledWith(3)
     })
 
@@ -57,7 +57,7 @@ describe("DiceTrayApi", () => {
     it("is a no-op when edge count is 0 or less", () => {
       api.rollEdge(0)
 
-      expect(api.store.state.edgeSpent).toBe(false)
+      expect(api.store.getState().edgeSpent).toBe(false)
       expect(vi.mocked(api.roller.addDice)).not.toHaveBeenCalled()
     })
   })
@@ -68,7 +68,7 @@ describe("DiceTrayApi", () => {
     it("marks edge as spent and delegates to the roller", () => {
       api.rerollMisses()
 
-      expect(api.store.state.edgeSpent).toBe(true)
+      expect(api.store.getState().edgeSpent).toBe(true)
       expect(vi.mocked(api.roller.rollMisses)).toHaveBeenCalled()
     })
 
@@ -88,7 +88,7 @@ describe("DiceTrayApi", () => {
       api.open()
       api.close()
 
-      expect(api.store.state.open).toBe(false)
+      expect(api.store.getState().open).toBe(false)
     })
   })
 
@@ -104,8 +104,8 @@ describe("DiceTrayApi", () => {
 
       api.reset()
 
-      expect(api.store.state.edgeSpent).toBe(false)
-      expect(api.store.state.extendedHistory).toHaveLength(0)
+      expect(api.store.getState().edgeSpent).toBe(false)
+      expect(api.store.getState().extendedHistory).toHaveLength(0)
     })
   })
 
@@ -118,11 +118,11 @@ describe("DiceTrayApi", () => {
 
       api.setTestType(TestType.Extended)
 
-      expect(api.store.state.testType).toBe(TestType.Extended)
-      expect(api.store.state.poolSize).toBe(10)
-      expect(api.store.state.physicalMode).toBe(true)
-      expect(api.store.state.open).toBe(true)
-      expect(api.store.state.edgeSpent).toBe(false)
+      expect(api.store.getState().testType).toBe(TestType.Extended)
+      expect(api.store.getState().poolSize).toBe(10)
+      expect(api.store.getState().physicalMode).toBe(true)
+      expect(api.store.getState().open).toBe(true)
+      expect(api.store.getState().edgeSpent).toBe(false)
     })
   })
 })

--- a/src/components/dice/diceTrayApi.ts
+++ b/src/components/dice/diceTrayApi.ts
@@ -118,7 +118,7 @@ export class DiceTrayApi {
     // Reset all values except for the dice pool size and the digital/physical
     // mode. Switching test type starts a fresh test from the user's chosen
     // dice count.
-    const { poolSize, physicalMode, open } = this.store.get()
+    const { poolSize, physicalMode, open } = this.store.getState()
     const fresh = createInitialState()
     this.store.setState(() => ({
       ...fresh,
@@ -180,7 +180,7 @@ export class DiceTrayApi {
   // called on the useDiceTray() instance in diceTrayActions.tsx
   // fallow-ignore-next-line unused-class-member
   recordExtendedRoll(currentHits: number): void {
-    const { edgeSpent, shrinkingPool, poolSize } = this.store.get()
+    const { edgeSpent, shrinkingPool, poolSize } = this.store.getState()
 
     this.store.setState(produce((state) => {
       state.extendedHistory.push({ hits: currentHits, edgeUsed: edgeSpent })
@@ -194,12 +194,12 @@ export class DiceTrayApi {
     if (shrinkingPool && poolSize > 1) {
       this.setPoolSize(poolSize - 1)
     } else {
-      this.roller.setPoolSize(this.store.get().poolSize)
+      this.roller.setPoolSize(this.store.getState().poolSize)
     }
   }
 
   open(): void {
-    if (!this.store.get().open) {
+    if (!this.store.getState().open) {
       markOverlayOpened()
     }
     this.store.setState(produce((state) => {
@@ -208,7 +208,7 @@ export class DiceTrayApi {
   }
 
   close(): void {
-    if (this.store.get().open) {
+    if (this.store.getState().open) {
       markOverlayClosed()
     }
     this.store.setState(produce((state) => {
@@ -222,13 +222,13 @@ export class DiceTrayApi {
    * permanently count as "open".
    */
   dispose(): void {
-    if (this.store.get().open) {
+    if (this.store.getState().open) {
       markOverlayClosed()
     }
   }
 
   reset(): void {
-    const { poolSize } = this.store.get()
+    const { poolSize } = this.store.getState()
     this.roller.reset().setPoolSize(poolSize)
     this.store.setState(produce((state) => {
       state.edgeSpent = false
@@ -245,7 +245,7 @@ export class DiceTrayApi {
   rollStandard(): void {
     // Drop any leftover edge dice from a previous roll so the user starts
     // from the configured pool size.
-    const { poolSize } = this.store.get()
+    const { poolSize } = this.store.getState()
     this.roller.setPoolSize(poolSize)
     this.roller.rollAll()
   }
@@ -255,14 +255,14 @@ export class DiceTrayApi {
    * Starts the rolling animation and stores results when it completes.
    */
   rollEdge(edge: number): void {
-    const { edgeSpent } = this.store.get()
+    const { edgeSpent } = this.store.getState()
     if (edgeSpent || edge <= 0) return
 
     this.store.setState(produce((state) => {
       state.edgeSpent = true
     }))
 
-    const wasRolled = selectWasRolled(this.roller.store.get())
+    const wasRolled = selectWasRolled(this.roller.store.getState())
     if (wasRolled) {
       this.roller.addDice(edge).rollDice(edge * -1, Infinity, { explodes: true })
     } else {
@@ -271,7 +271,7 @@ export class DiceTrayApi {
   }
 
   rerollMisses(): void {
-    const { edgeSpent } = this.store.get()
+    const { edgeSpent } = this.store.getState()
     if (edgeSpent) return
 
     this.store.setState(produce((state) => {

--- a/src/components/dice/diceTrayEdgeControls.test.tsx
+++ b/src/components/dice/diceTrayEdgeControls.test.tsx
@@ -66,7 +66,7 @@ describe("DiceTrayEdgeControls", () => {
     fireEvent.click(screen.getByRole("button", { name: "Roll Edge" }))
 
     // Assert: state updated (setCurrentEdge is an async thunk)...
-    await waitFor(() => expect(store.state.edge.current).toBe(1))
+    await waitFor(() => expect(store.getState().edge.current).toBe(1))
     // ...and the UI re-rendered off that same state.
     expect(screen.getByText("Edge (1/4)")).toBeDefined()
   })
@@ -77,9 +77,9 @@ describe("DiceTrayEdgeControls", () => {
 
     // Act
     fireEvent.click(screen.getByRole("button", { name: "Roll Edge" }))
-    await waitFor(() => expect(store.state.edge.current).toBe(1))
+    await waitFor(() => expect(store.getState().edge.current).toBe(1))
 
     // Assert: rollEdge() marked the dice tray as edgeSpent, so a second click is a no-op
-    expect(diceTrayApi.store.state.edgeSpent).toBe(true)
+    expect(diceTrayApi.store.getState().edgeSpent).toBe(true)
   })
 })

--- a/src/components/dice/diceTrayEdgeControls.tsx
+++ b/src/components/dice/diceTrayEdgeControls.tsx
@@ -29,13 +29,13 @@ export const DiceTrayEdgeControls: FC = () => {
   if (physicalMode) return null
 
   const handleRerollMisses = () => {
-    if (diceTrayApi.store.state.edgeSpent) return
+    if (diceTrayApi.store.getState().edgeSpent) return
     diceTrayApi.rerollMisses()
     dispatch(Actions.edge.setCurrentEdge(currentEdge - 1))
   }
 
   const handleEdge = () => {
-    if (diceTrayApi.store.state.edgeSpent) return
+    if (diceTrayApi.store.getState().edgeSpent) return
     diceTrayApi.rollEdge(maxEdge)
     dispatch(Actions.edge.setCurrentEdge(currentEdge - 1))
   }

--- a/src/components/items/dialogs/itemDialog.tsx
+++ b/src/components/items/dialogs/itemDialog.tsx
@@ -83,7 +83,7 @@ export const ItemDialog: FC<ItemDialogProps> = ({
   const form = formArg as ItemForm
   const isBuilder = useIsBuilder()
   const dispatch = useRunnerStoreDispatch()
-  const allGear = useRunnerStoreSelector(Selectors.gear.selectGear)
+  const allGear = useRunnerStoreSelector(Selectors.gear.selectAllGear)
 
   type OptionKey = keyof Required<NonNullable<typeof optionsProp>>
 

--- a/src/components/items/types/implants/forms/implantFormFields.tsx
+++ b/src/components/items/types/implants/forms/implantFormFields.tsx
@@ -64,7 +64,7 @@ interface CapacitySlotsChipProps extends ChipProps {
 }
 
 const CapacitySlotsChip: FC<CapacitySlotsChipProps> = ({ implantId, capacity, ...props }) => {
-  const gear = useRunnerStoreSelector(Selectors.gear.selectGear)
+  const gear = useRunnerStoreSelector(Selectors.gear.selectAllGear)
   const usedCapacity = Object.values(gear)
     .filter(isImplant)
     .filter((item) => item.parentId === implantId)

--- a/src/components/runner/adeptPowers/adeptPowersList.test.tsx
+++ b/src/components/runner/adeptPowers/adeptPowersList.test.tsx
@@ -64,8 +64,8 @@ describe("AdeptPowersList", () => {
     fireEvent.click(within(dialog).getByRole("button", { name: /save/i }))
 
     // Assert: state updated...
-    await waitFor(() => expect(store.state.powers).toHaveLength(1))
-    expect(store.state.powers[0].name).toBe("Combat Sense")
+    await waitFor(() => expect(store.getState().powers).toHaveLength(1))
+    expect(store.getState().powers[0].name).toBe("Combat Sense")
     // ...and the UI re-rendered off that same state.
     expect(await screen.findByText("Combat Sense")).toBeDefined()
   })

--- a/src/components/runner/adeptPowers/adeptPowersViewerSection.test.tsx
+++ b/src/components/runner/adeptPowers/adeptPowersViewerSection.test.tsx
@@ -54,7 +54,7 @@ describe("AdeptPowersViewerSection", () => {
     fireEvent.click(within(dialog).getByRole("button", { name: "Delete" }))
 
     // Assert: state updated...
-    await waitFor(() => expect(store.state.powers).toHaveLength(0))
+    await waitFor(() => expect(store.getState().powers).toHaveLength(0))
     // ...and the UI re-rendered off that same state.
     expect(screen.getByText("No adept powers learned")).toBeDefined()
   })

--- a/src/components/runner/contacts/contactsList.test.tsx
+++ b/src/components/runner/contacts/contactsList.test.tsx
@@ -64,9 +64,9 @@ describe("ContactsList", () => {
     fireEvent.click(within(dialog).getByRole("button", { name: /save/i }))
 
     // Assert: state updated...
-    await waitFor(() => expect(store.state.contacts).toHaveLength(1))
-    expect(store.state.contacts[0].name).toBe("Fixer Sam")
-    expect(store.state.contacts[0].id).not.toBe("")
+    await waitFor(() => expect(store.getState().contacts).toHaveLength(1))
+    expect(store.getState().contacts[0].name).toBe("Fixer Sam")
+    expect(store.getState().contacts[0].id).not.toBe("")
     // ...and the UI re-rendered off that same state.
     expect(await screen.findByText("Fixer Sam")).toBeDefined()
   })
@@ -95,8 +95,8 @@ describe("ContactsList", () => {
     fireEvent.click(within(dialog).getByRole("button", { name: /save/i }))
 
     // Assert
-    await waitFor(() => expect(store.state.contacts).toHaveLength(1))
-    const [contact] = store.state.contacts
+    await waitFor(() => expect(store.getState().contacts).toHaveLength(1))
+    const [contact] = store.getState().contacts
     expect(contact.knowledgeSkills).toEqual([{ name: "Street Gangs", rating: 1 }])
     expect(contact.favours).toEqual([
       { description: "Owes for a smuggling run", direction: FavourDirection.contactOwes },
@@ -112,7 +112,7 @@ describe("ContactsList", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Remove" }))
 
     // Assert: state updated...
-    await waitFor(() => expect(store.state.contacts).toHaveLength(0))
+    await waitFor(() => expect(store.getState().contacts).toHaveLength(0))
     // ...and the UI re-rendered off that same state.
     expect(screen.queryByText("Mr. Johnson")).toBeNull()
   })

--- a/src/components/runner/exportImport/exportRunnerButton.tsx
+++ b/src/components/runner/exportImport/exportRunnerButton.tsx
@@ -10,7 +10,7 @@ export const ExportRunnerButton: FC = () => {
   const store = useRunnerStoreContext()
 
   const handleExport = () => {
-    const runnerData = store.get()
+    const runnerData = store.getState()
     const yamlContent = runnerDataToYaml(runnerData)
     const sanitizedName =
       (runnerData.profile.alias || runnerData.profile.name || "runner")

--- a/src/components/runner/finances/endOfMonth/endOfMonthDialog.tsx
+++ b/src/components/runner/finances/endOfMonth/endOfMonthDialog.tsx
@@ -113,8 +113,8 @@ const EndOfMonthDialog: FC<Props> = ({ ctrl }) => {
 
   const handleTransitionExited = () => {
     // Read fresh state directly from stores so the reset always matches current data
-    const freshLoans = runnerDataStore.state.nuyen.loans
-    const freshQuality = runnerDataStore.state.profile.lifestyle?.quality ?? LifestyleType.Street
+    const freshLoans = runnerDataStore.getState().nuyen.loans
+    const freshQuality = runnerDataStore.getState().profile.lifestyle?.quality ?? LifestyleType.Street
     const freshUpkeep = Lifestyles[freshQuality].upkeep
     setCheckedIds(new Set([
       ...freshLoans.filter((l) => l.interestRate > 0).map((l) => l.id),

--- a/src/components/runner/finances/loans/loansSection.test.tsx
+++ b/src/components/runner/finances/loans/loansSection.test.tsx
@@ -53,9 +53,9 @@ describe("LoansSection", () => {
     fireEvent.click(within(dialog).getByRole("button", { name: /save/i }))
 
     // Assert: state updated...
-    await waitFor(() => expect(store.state.nuyen.loans).toHaveLength(1))
-    expect(store.state.nuyen.loans[0].lender).toBe("Fixer Sam")
-    expect(store.state.nuyen.loans[0].id).not.toBe("")
+    await waitFor(() => expect(store.getState().nuyen.loans).toHaveLength(1))
+    expect(store.getState().nuyen.loans[0].lender).toBe("Fixer Sam")
+    expect(store.getState().nuyen.loans[0].id).not.toBe("")
     // ...and the UI re-rendered off that same state.
     expect(await screen.findByText("Fixer Sam")).toBeDefined()
   })
@@ -71,7 +71,7 @@ describe("LoansSection", () => {
     fireEvent.click(await within(dialog).findByRole("button", { name: /confirm remove/i }))
 
     // Assert: state updated...
-    await waitFor(() => expect(store.state.nuyen.loans).toHaveLength(0))
+    await waitFor(() => expect(store.getState().nuyen.loans).toHaveLength(0))
     // ...and the UI re-rendered off that same state.
     expect(screen.queryByText("Mr. Johnson")).toBeNull()
   })

--- a/src/components/runner/finances/nuyen/nuyenSection.test.tsx
+++ b/src/components/runner/finances/nuyen/nuyenSection.test.tsx
@@ -34,7 +34,7 @@ describe("NuyenSection", () => {
     fireEvent.click(screen.getByRole("button", { name: "Deposit" }))
 
     // Assert: state updated...
-    await waitFor(() => expect(store.state.nuyen.current).toBe(150))
+    await waitFor(() => expect(store.getState().nuyen.current).toBe(150))
     // ...and the UI re-rendered off that same state.
     expect(screen.getByText("150¥")).toBeDefined()
   })
@@ -48,7 +48,7 @@ describe("NuyenSection", () => {
     fireEvent.click(screen.getByRole("button", { name: "Withdraw" }))
 
     // Assert
-    await waitFor(() => expect(store.state.nuyen.current).toBe(70))
+    await waitFor(() => expect(store.getState().nuyen.current).toBe(70))
   })
 
   it("setting dispatches setNuyenAmount and replaces the balance", async () => {
@@ -60,6 +60,6 @@ describe("NuyenSection", () => {
     fireEvent.click(screen.getByRole("button", { name: "Set" }))
 
     // Assert
-    await waitFor(() => expect(store.state.nuyen.current).toBe(42))
+    await waitFor(() => expect(store.getState().nuyen.current).toBe(42))
   })
 })

--- a/src/components/runner/gearPage/gearViewSection.tsx
+++ b/src/components/runner/gearPage/gearViewSection.tsx
@@ -22,7 +22,7 @@ interface GearViewSectionProps {
 
 export const GearViewSection: FC<GearViewSectionProps> = ({ section, searchTerms }) => {
   const [isManuallyOpen, setIsManuallyOpen] = useState(false)
-  const allGearItems = useRunnerStoreSelector(Selectors.gear.selectGear)
+  const allGearItems = useRunnerStoreSelector(Selectors.gear.selectAllGear)
 
   const allowedTypes = sectionGearTypes[section]
   const isSearching = searchTerms.length > 0

--- a/src/components/runner/karma/karmaSection.test.tsx
+++ b/src/components/runner/karma/karmaSection.test.tsx
@@ -45,8 +45,8 @@ describe("KarmaSection", () => {
     fireEvent.click(within(dialog).getByRole("button", { name: /add/i }))
 
     // Assert: state updated (default Amount is 1)...
-    await waitFor(() => expect(store.state.karma.current).toBe(6))
-    expect(store.state.karma.total).toBe(21)
+    await waitFor(() => expect(store.getState().karma.current).toBe(6))
+    expect(store.getState().karma.total).toBe(21)
     // ...and the UI re-rendered off that same state.
     expect(await screen.findByText("6")).toBeDefined()
     expect(screen.getByText("21")).toBeDefined()

--- a/src/components/runner/licenseCheck/licenseCheckDice.test.ts
+++ b/src/components/runner/licenseCheck/licenseCheckDice.test.ts
@@ -95,8 +95,8 @@ describe("rollOpposedTest", () => {
     await vi.runAllTimersAsync()
     await resultPromise
 
-    expect(credentialRoller.store.get().dice).toHaveLength(6)
-    expect(scannerRoller.store.get().dice).toHaveLength(8)
+    expect(credentialRoller.store.getState().dice).toHaveLength(6)
+    expect(scannerRoller.store.getState().dice).toHaveLength(8)
   })
 })
 

--- a/src/components/runner/licenseCheck/licenseCheckDice.ts
+++ b/src/components/runner/licenseCheck/licenseCheckDice.ts
@@ -53,8 +53,8 @@ export async function rollOpposedTest(
     scannerRoller.rollAll({ timeout: ROLL_TIMEOUT }),
   ])
 
-  const credentialHits = selectHits(credentialRoller.store.get())
-  const scannerHits = selectHits(scannerRoller.store.get())
+  const credentialHits = selectHits(credentialRoller.store.getState())
+  const scannerHits = selectHits(scannerRoller.store.getState())
   const status = credentialHits >= scannerHits ? "clear" as const : "flagged" as const
 
   return { credentialHits, scannerHits, status }

--- a/src/components/runner/licenseCheck/licenseCheckResultView.tsx
+++ b/src/components/runner/licenseCheck/licenseCheckResultView.tsx
@@ -9,7 +9,7 @@ import { Selectors, useRunnerStoreSelector } from "#/lib/stores/runner/runnerSto
 
 export const LicenseCheckResultView: FC = () => {
   const { result } = useLicenseCheck()
-  const gear = useRunnerStoreSelector(Selectors.gear.selectGear)
+  const gear = useRunnerStoreSelector(Selectors.gear.selectAllGear)
 
   if (!result) return null
 

--- a/src/components/runner/licenseCheck/licenseCheckSetupView.tsx
+++ b/src/components/runner/licenseCheck/licenseCheckSetupView.tsx
@@ -16,7 +16,7 @@ import { buildVerificationLanes } from "./licenseCheckLanes.ts"
 const ratingOptions = [1, 2, 3, 4, 5, 6]
 
 export const LicenseCheckSetupView: FC = () => {
-  const gear = useRunnerStoreSelector(Selectors.gear.selectGear)
+  const gear = useRunnerStoreSelector(Selectors.gear.selectAllGear)
   const { scannerRating, setScannerRating } = useLicenseCheck()
 
   // Display-only — Start Scan builds its own checked-items-only queue from these lanes.

--- a/src/components/runner/licenseCheck/licenseCheckWorkerSlot.tsx
+++ b/src/components/runner/licenseCheck/licenseCheckWorkerSlot.tsx
@@ -45,7 +45,7 @@ export const LicenseCheckWorkerSlot: FC<LicenseCheckWorkerSlotProps> = ({
   onIdle,
 }) => {
   const { scannerRating } = useLicenseCheck()
-  const gear = useRunnerStoreSelector(Selectors.gear.selectGear)
+  const gear = useRunnerStoreSelector(Selectors.gear.selectAllGear)
   const ratingPlusRating = useRunnerStoreSelector(
     Selectors.houseRules.select("items.licenseCheck.ratingPlusRating"),
   )

--- a/src/components/runner/magician/spells/spellsUtils.ts
+++ b/src/components/runner/magician/spells/spellsUtils.ts
@@ -1,4 +1,0 @@
-import { BuilderConfig } from "#/components/builder/builderConfig.ts"
-
-/** @deprecated Use `BuilderConfig.magic.spells.bpCost` instead. */
-export const SpellsBpPerSpell = BuilderConfig.magic.spells.bpCost

--- a/src/components/runner/magician/spells/spellsViewerSection.test.tsx
+++ b/src/components/runner/magician/spells/spellsViewerSection.test.tsx
@@ -75,6 +75,6 @@ describe("SpellsViewerSection", () => {
     fireEvent.click(screen.getByText("Sustained"))
 
     // Assert: state updated...
-    await waitFor(() => expect(store.state.spells[0].sustained).toBe(true))
+    await waitFor(() => expect(store.getState().spells[0].sustained).toBe(true))
   })
 })

--- a/src/components/runner/magician/spirits/spiritList.test.tsx
+++ b/src/components/runner/magician/spirits/spiritList.test.tsx
@@ -59,7 +59,7 @@ describe("SpiritList", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Dismiss" }))
 
     // Assert: state updated...
-    await waitFor(() => expect(store.state.spirits).toHaveLength(0))
+    await waitFor(() => expect(store.getState().spirits).toHaveLength(0))
     // ...and the UI re-rendered off that same state.
     expect(screen.queryByText("Ember")).toBeNull()
   })
@@ -67,7 +67,7 @@ describe("SpiritList", () => {
   it("resetting physical damage dispatches saveSpirit and updates the store", async () => {
     // Arrange: seeded with 2 boxes of physical damage taken
     const store = renderWithSpirits([fireSpirit])
-    expect(store.state.spirits[0].damage.physical).toBe(2)
+    expect(store.getState().spirits[0].damage.physical).toBe(2)
 
     // Act: the Physical damage track's Reset button is the first of the two
     // ("Reset" for Physical, then "Reset" for Stun).
@@ -75,8 +75,8 @@ describe("SpiritList", () => {
     fireEvent.click(resetPhysical)
 
     // Assert: state updated...
-    await waitFor(() => expect(store.state.spirits[0].damage.physical).toBe(0))
+    await waitFor(() => expect(store.getState().spirits[0].damage.physical).toBe(0))
     // ...and the UI re-rendered off that same state (only Reset buttons remain, no filled cells).
-    expect(store.state.spirits[0].damage.stun).toBe(0)
+    expect(store.getState().spirits[0].damage.stun).toBe(0)
   })
 })

--- a/src/components/runner/quickPanel/quickDamageSection.test.tsx
+++ b/src/components/runner/quickPanel/quickDamageSection.test.tsx
@@ -32,16 +32,16 @@ describe("QuickDamageSection", () => {
   it("resetting physical damage dispatches setDamage and updates the store", async () => {
     // Arrange: seeded with damage taken on both tracks
     const store = renderWithDamage(3, 2)
-    expect(store.state.damage.physical).toBe(3)
+    expect(store.getState().damage.physical).toBe(3)
 
     // Act: the Physical track's Reset button is the first of the two.
     const [resetPhysical] = screen.getAllByRole("button", { name: "Reset" })
     fireEvent.click(resetPhysical)
 
     // Assert: state updated...
-    await waitFor(() => expect(store.state.damage.physical).toBe(0))
+    await waitFor(() => expect(store.getState().damage.physical).toBe(0))
     // ...and the stun track (untouched) is unaffected.
-    expect(store.state.damage.stun).toBe(2)
+    expect(store.getState().damage.stun).toBe(2)
   })
 
   it("resetting stun damage dispatches setDamage and updates the store", async () => {
@@ -53,7 +53,7 @@ describe("QuickDamageSection", () => {
     fireEvent.click(resetStun)
 
     // Assert
-    await waitFor(() => expect(store.state.damage.stun).toBe(0))
-    expect(store.state.damage.physical).toBe(3)
+    await waitFor(() => expect(store.getState().damage.stun).toBe(0))
+    expect(store.getState().damage.physical).toBe(3)
   })
 })

--- a/src/components/runner/quickPanel/quickEdgeSection.test.tsx
+++ b/src/components/runner/quickPanel/quickEdgeSection.test.tsx
@@ -54,7 +54,7 @@ describe("QuickEdgeSection", () => {
     fireEvent.click(screen.getByRole("button", { name: "Spend 1" }))
 
     // Assert: state updated (setCurrentEdge is an async thunk)...
-    await waitFor(() => expect(store.state.edge.current).toBe(0))
+    await waitFor(() => expect(store.getState().edge.current).toBe(0))
     // ...and the UI re-rendered off that same state.
     expect((screen.getByRole("button", { name: "Spend 1" }) as HTMLButtonElement).disabled).toBe(true)
   })
@@ -67,7 +67,7 @@ describe("QuickEdgeSection", () => {
     fireEvent.click(screen.getByRole("button", { name: "Regain 1" }))
 
     // Assert
-    await waitFor(() => expect(store.state.edge.current).toBe(3))
+    await waitFor(() => expect(store.getState().edge.current).toBe(3))
   })
 
   it("clicking an edge cell above current sets current to that cell's value", async () => {
@@ -78,7 +78,7 @@ describe("QuickEdgeSection", () => {
     fireEvent.click(screen.getByRole("button", { name: "4" }))
 
     // Assert
-    await waitFor(() => expect(store.state.edge.current).toBe(4))
+    await waitFor(() => expect(store.getState().edge.current).toBe(4))
   })
 
   it("clicking the cell matching current toggles it back by one", async () => {
@@ -89,7 +89,7 @@ describe("QuickEdgeSection", () => {
     fireEvent.click(screen.getByRole("button", { name: "2" }))
 
     // Assert
-    await waitFor(() => expect(store.state.edge.current).toBe(1))
+    await waitFor(() => expect(store.getState().edge.current).toBe(1))
   })
 
   it("disables the burn button when max edge is 1", () => {
@@ -109,8 +109,8 @@ describe("QuickEdgeSection", () => {
     fireEvent.click(await screen.findByRole("button", { name: "BURN IT" }))
 
     // Assert
-    await waitFor(() => expect(store.state.attributes[AttributeKey.edge]).toBe(3))
-    expect(store.state.edge.current).toBe(0)
+    await waitFor(() => expect(store.getState().attributes[AttributeKey.edge]).toBe(3))
+    expect(store.getState().edge.current).toBe(0)
     expect(await screen.findByRole("button", { name: "3" })).toBeDefined()
   })
 
@@ -124,7 +124,7 @@ describe("QuickEdgeSection", () => {
 
     // Assert: dialog closes without dispatching burnEdge
     await waitFor(() => expect(screen.queryByRole("button", { name: "BURN IT" })).toBeNull())
-    expect(store.state.attributes[AttributeKey.edge]).toBe(4)
-    expect(store.state.edge.current).toBe(2)
+    expect(store.getState().attributes[AttributeKey.edge]).toBe(4)
+    expect(store.getState().edge.current).toBe(2)
   })
 })

--- a/src/components/runner/sheet/runnerDataStore.ts
+++ b/src/components/runner/sheet/runnerDataStore.ts
@@ -15,13 +15,6 @@ export class RunnerDataStore implements RunnerStore {
   }
 
   getState = (): RunnerData => this.compatStore.getState()
-  // required by the CompatStore/RunnerStore interface
-  // fallow-ignore-next-line unused-class-member
-  get = (): RunnerData => this.compatStore.getState()
-
-  get state(): RunnerData {
-    return this.compatStore.getState()
-  }
 
   setState = (updater: (prev: RunnerData) => RunnerData): void => this.compatStore.setState(updater)
   subscribe = (listener: (state: RunnerData) => void) => this.compatStore.subscribe(listener)

--- a/src/components/runner/technomancer/technomancerUtils.ts
+++ b/src/components/runner/technomancer/technomancerUtils.ts
@@ -1,10 +1,4 @@
-import { BuilderConfig } from "#/components/builder/builderConfig.ts"
 import { AwakeningType } from "#/system/awakeningType.ts"
-
-/** @deprecated Use `BuilderConfig.technomancer.complexForms.bpCost.perRating` instead. */
-export const ComplexFormBpPerRating = BuilderConfig.technomancer.complexForms.bpCost.perRating
-/** @deprecated Use `BuilderConfig.technomancer.sprites.bpCost.perTask` instead. */
-export const SpriteBpPerTask = BuilderConfig.technomancer.sprites.bpCost.perTask
 
 export const isTechnomancer = (awakeningType: AwakeningType): boolean => {
   return awakeningType === AwakeningType.Technomancer

--- a/src/components/system/initiative/initiativePassTracker.test.tsx
+++ b/src/components/system/initiative/initiativePassTracker.test.tsx
@@ -42,7 +42,7 @@ describe("InitiativePassTracker", () => {
     fireEvent.click(screen.getByRole("button", { name: "1" }))
 
     // Assert: state updated...
-    await waitFor(() => expect(store.state.initiative.passesCompleted).toEqual([0]))
+    await waitFor(() => expect(store.getState().initiative.passesCompleted).toEqual([0]))
     // ...and the UI re-rendered off that same state.
     expect(screen.getByRole("button", { name: "1" }).className).toContain("MuiButton-contained")
   })
@@ -55,6 +55,6 @@ describe("InitiativePassTracker", () => {
     fireEvent.click(screen.getByRole("button", { name: "1" }))
 
     // Assert
-    await waitFor(() => expect(store.state.initiative.passesCompleted).toEqual([]))
+    await waitFor(() => expect(store.getState().initiative.passesCompleted).toEqual([]))
   })
 })

--- a/src/components/system/initiative/initiativeSection.test.tsx
+++ b/src/components/system/initiative/initiativeSection.test.tsx
@@ -33,7 +33,7 @@ describe("InitiativeSection", () => {
     fireEvent.click(screen.getByRole("button", { name: "End Round" }))
 
     // Assert: state updated...
-    await waitFor(() => expect(store.state.initiative.passesCompleted).toEqual([]))
+    await waitFor(() => expect(store.getState().initiative.passesCompleted).toEqual([]))
     // ...and the UI re-rendered off that same state.
     expect(screen.getByRole("button", { name: "1" }).className).toContain("MuiButton-outlined")
   })

--- a/src/components/ui/dialog/dialogCtrl.test.ts
+++ b/src/components/ui/dialog/dialogCtrl.test.ts
@@ -24,10 +24,10 @@ describe("DialogCtrl", () => {
     const ctrl = new DialogCtrl<number>()
 
     ctrl.open()
-    expect(ctrl.store.state.open).toBe(true)
+    expect(ctrl.store.getState().open).toBe(true)
 
     ctrl.close(42)
-    expect(ctrl.store.state.open).toBe(false)
+    expect(ctrl.store.getState().open).toBe(false)
   })
 
   it("result() resolves only once even if close() is called multiple times", async () => {
@@ -65,7 +65,7 @@ describe("DialogCtrl", () => {
     ctrl.close()
 
     await expect(ctrl.result()).resolves.toBe("first")
-    expect(ctrl.store.state.open).toBe(false)
+    expect(ctrl.store.getState().open).toBe(false)
   })
 
   it("calling open() again before a previous open() resolves does not hang the first caller", async () => {

--- a/src/integrations/reduxToolkit/compatStore.ts
+++ b/src/integrations/reduxToolkit/compatStore.ts
@@ -6,16 +6,12 @@ export type StateUpdater<TState> = (prev: TState) => TState
 export interface CompatStore<TState> {
   readonly dispatch: ThunkDispatch<TState, undefined, UnknownAction>
   getState: () => TState
-  /** @deprecated alias for {@link getState}. */
-  get: () => TState
-  /** @deprecated snapshot alias for {@link getState}. */
-  readonly state: TState
   setState: (updater: StateUpdater<TState>) => void
   subscribe: (listener: (state: TState) => void) => { unsubscribe: () => void }
 }
 
 /**
- * A `configureStore` instance exposed through a `get`/`state`/`setState`/`subscribe` API, for call
+ * A `configureStore` instance exposed through a `getState`/`setState`/`subscribe` API, for call
  * sites that want a plain "read a snapshot, write a next value" store instead of dispatching
  * actions directly.
  *
@@ -23,7 +19,7 @@ export interface CompatStore<TState> {
  * updater — an Immer `produce(recipe)` call and a plain `(prev) => next` function both work.
  * `configureStore`'s `serializableCheck` is disabled because that payload is a function by design,
  * and `immutableStateInvariantMiddleware` is disabled because callers are free to hold a snapshot
- * from `get()`/`.state`, mutate it, and write it back via `setState` (some test helpers do exactly
+ * from `getState()`, mutate it, and write it back via `setState` (some test helpers do exactly
  * this).
  *
  * Pass a domain `reducer` (e.g. a `combineReducers` result) to back a store with dispatchable
@@ -54,10 +50,6 @@ export function createCompatStore<TState>(
   return {
     dispatch: store.dispatch,
     getState: () => store.getState(),
-    get: () => store.getState(),
-    get state() {
-      return store.getState()
-    },
     setState: (updater) => {
       store.dispatch(applyUpdater(updater))
     },

--- a/src/integrations/reduxToolkit/useSelector.ts
+++ b/src/integrations/reduxToolkit/useSelector.ts
@@ -7,7 +7,7 @@ export interface UseSelectorOptions<TSelected> {
 }
 
 /**
- * Reactive read of a {@link CompatStore}. Reading directly off `store.state`/`store.get()` gives a
+ * Reactive read of a {@link CompatStore}. Reading directly off `store.getState()` gives a
  * snapshot and will not trigger re-renders — always use this for reactive reads.
  */
 export function useSelector<TState, TSelected>(

--- a/src/lib/hooks/builder/buildPoints/useGearBuildPoints.ts
+++ b/src/lib/hooks/builder/buildPoints/useGearBuildPoints.ts
@@ -5,13 +5,6 @@ import { getTotalCost } from "#/components/builder/sections/gear/gearUtils.ts"
 import { useRunnerStoreSelector } from "#/lib/stores/runner/runnerStore.selectors.ts"
 import { Lifestyles, LifestyleType } from "#/system/lifestyleType.ts"
 
-/** @deprecated Use `BuilderConfig.gear.bpAllowance` instead. */
-export const GearBuildPointAllowance = BuilderConfig.gear.bpAllowance
-/** @deprecated Use `BuilderConfig.gear.nuyenPerBp` instead. */
-export const GearNuyenPerBuildPoint = BuilderConfig.gear.nuyenPerBp
-/** @deprecated Use `BuilderConfig.gear.nuyenPerBp * BuilderConfig.gear.bpAllowance` instead. */
-export const GearNuyenAllowance = BuilderConfig.gear.nuyenPerBp * BuilderConfig.gear.bpAllowance
-
 export const useGearTotalCost = () => {
   const gear = useRunnerStoreSelector((state) => state.gear)
   const allGear = Object.values(gear)

--- a/src/lib/hooks/runner/licenseCheck/licenseCheckState.ts
+++ b/src/lib/hooks/runner/licenseCheck/licenseCheckState.ts
@@ -33,7 +33,7 @@ export interface LicenseCheckState {
  * instead of receiving it as drilled props.
  */
 export function useLicenseCheckState(): LicenseCheckState {
-  const allGear = useRunnerStoreSelector(Selectors.gear.selectGear)
+  const allGear = useRunnerStoreSelector(Selectors.gear.selectAllGear)
 
   const [step, setStep] = useState<LicenseCheckStep>("setup")
   const [scannerRating, setScannerRating] = useState(3)

--- a/src/lib/stores/runner/gear/gearSlice.selectors.test.ts
+++ b/src/lib/stores/runner/gear/gearSlice.selectors.test.ts
@@ -21,7 +21,6 @@ import {
   selectAvailable,
   selectById,
   selectEquipped,
-  selectGear,
   selectGearOfType,
   selectStashed,
   sins,
@@ -44,17 +43,6 @@ const withGear = (...items: ItemData[]) =>
     data.gear = Object.fromEntries(items.map((gearItem) => [gearItem.id, gearItem]))
     return data
   })
-
-describe("selectGear", () => {
-  it("returns the gear record", () => {
-    const sheet = runnerDataFactory((s) => {
-      s.gear = { [item.id]: item }
-      return s
-    })
-
-    expect(selectGear(sheet)).toBe(sheet.gear)
-  })
-})
 
 describe("selectEquipped", () => {
   it("returns only items with equipped === true", () => {

--- a/src/lib/stores/runner/gear/gearSlice.selectors.ts
+++ b/src/lib/stores/runner/gear/gearSlice.selectors.ts
@@ -10,11 +10,6 @@ import type { ItemDataFor, ItemDataRecord } from "#/system/items/itemUtils.ts"
 import { isAvailable, isEquipped, isStashed } from "#/system/items/itemUtils.ts"
 import type { RunnerData } from "#/system/runnerData.ts"
 
-/** @deprecated - use {@link selectAllGear} instead **/
-export function selectGear(state: RunnerData): Record<string, ItemData> {
-  return state.gear
-}
-
 export function selectAllGear(state: RunnerData): Record<string, ItemData> {
   return state.gear
 }

--- a/src/system/dice/diceRoller.test.ts
+++ b/src/system/dice/diceRoller.test.ts
@@ -16,7 +16,7 @@ describe("DiceRoller", () => {
       const diceRoller = new DiceRoller()
 
       // Assert
-      expect(diceRoller.store.state.dice).toEqual([])
+      expect(diceRoller.store.getState().dice).toEqual([])
     })
   })
 
@@ -50,8 +50,8 @@ describe("DiceRoller", () => {
       diceRoller.addDice(3)
 
       // Assert
-      expect(diceRoller.store.state.dice).toHaveLength(3)
-      expect(diceRoller.store.state.dice.every((die) => die.value === null && !die.isRolling)).toBe(true)
+      expect(diceRoller.store.getState().dice).toHaveLength(3)
+      expect(diceRoller.store.getState().dice.every((die) => die.value === null && !die.isRolling)).toBe(true)
     })
 
     it("appends to existing dice rather than replacing them", () => {
@@ -63,7 +63,7 @@ describe("DiceRoller", () => {
       diceRoller.addDice(1)
 
       // Assert
-      expect(diceRoller.store.state.dice).toHaveLength(3)
+      expect(diceRoller.store.getState().dice).toHaveLength(3)
     })
 
     it("throws when count is zero", () => {
@@ -103,8 +103,8 @@ describe("DiceRoller", () => {
       diceRoller.removeDice(2)
 
       // Assert — first three dice are kept, last two are dropped
-      expect(diceRoller.store.state.dice).toHaveLength(3)
-      expect(diceRoller.store.state.dice.map((die) => die.value)).toEqual([1, 2, 3])
+      expect(diceRoller.store.getState().dice).toHaveLength(3)
+      expect(diceRoller.store.getState().dice.map((die) => die.value)).toEqual([1, 2, 3])
     })
 
     it("throws when count is zero", () => {
@@ -136,7 +136,7 @@ describe("DiceRoller", () => {
       diceRoller.setPoolSize(5)
 
       // Assert
-      expect(diceRoller.store.state.dice).toHaveLength(5)
+      expect(diceRoller.store.getState().dice).toHaveLength(5)
     })
 
     it("removes dice when the pool is larger than the target", () => {
@@ -148,20 +148,20 @@ describe("DiceRoller", () => {
       diceRoller.setPoolSize(2)
 
       // Assert
-      expect(diceRoller.store.state.dice).toHaveLength(2)
+      expect(diceRoller.store.getState().dice).toHaveLength(2)
     })
 
     it("does nothing when the pool is already the right size", () => {
       // Arrange
       const diceRoller = new DiceRoller()
       diceRoller.addDice(4)
-      const diceSnapshot = diceRoller.store.get().dice
+      const diceSnapshot = diceRoller.store.getState().dice
 
       // Act
       diceRoller.setPoolSize(4)
 
       // Assert
-      expect(diceRoller.store.state.dice).toBe(diceSnapshot)
+      expect(diceRoller.store.getState().dice).toBe(diceSnapshot)
     })
 
     it("can set the pool size to zero", () => {
@@ -173,7 +173,7 @@ describe("DiceRoller", () => {
       diceRoller.setPoolSize(0)
 
       // Assert
-      expect(diceRoller.store.state.dice).toHaveLength(0)
+      expect(diceRoller.store.getState().dice).toHaveLength(0)
     })
   })
 
@@ -190,7 +190,7 @@ describe("DiceRoller", () => {
       diceRoller.reset()
 
       // Assert
-      expect(diceRoller.store.state.dice.every((die) => die.value === null && !die.isRolling)).toBe(true)
+      expect(diceRoller.store.getState().dice.every((die) => die.value === null && !die.isRolling)).toBe(true)
     })
 
     it("preserves the number of dice in the pool", () => {
@@ -202,7 +202,7 @@ describe("DiceRoller", () => {
       diceRoller.reset()
 
       // Assert
-      expect(diceRoller.store.state.dice).toHaveLength(4)
+      expect(diceRoller.store.getState().dice).toHaveLength(4)
     })
   })
 
@@ -258,15 +258,15 @@ describe("DiceRoller", () => {
       const rollPromise = diceRoller.rollDie(0)
 
       // Assert — isRolling set synchronously before any timers fire
-      expect(diceRoller.store.state.dice[0].isRolling).toBe(true)
-      expect(diceRoller.store.state.dice[0].value).toBeNull()
+      expect(diceRoller.store.getState().dice[0].isRolling).toBe(true)
+      expect(diceRoller.store.getState().dice[0].value).toBeNull()
 
       vi.runAllTimers()
       await rollPromise
 
       // Assert — settled after timer fires
-      expect(diceRoller.store.state.dice[0].isRolling).toBe(false)
-      expect(diceRoller.store.state.dice[0].value).toBe(6)
+      expect(diceRoller.store.getState().dice[0].isRolling).toBe(false)
+      expect(diceRoller.store.getState().dice[0].value).toBe(6)
     })
 
     it("adds an extra die and rolls it when explodes is true and value is 6", async () => {
@@ -285,7 +285,7 @@ describe("DiceRoller", () => {
       await rollPromise
 
       // Assert — original die + 1 extra from explosion
-      expect(diceRoller.store.state.dice.length).toBeGreaterThan(1)
+      expect(diceRoller.store.getState().dice.length).toBeGreaterThan(1)
     })
 
     it("does NOT add an extra die when explodes is true but value is not 6", async () => {
@@ -300,8 +300,8 @@ describe("DiceRoller", () => {
       await rollPromise
 
       // Assert
-      expect(diceRoller.store.state.dice).toHaveLength(1)
-      expect(diceRoller.store.state.dice[0].value).toBe(1)
+      expect(diceRoller.store.getState().dice).toHaveLength(1)
+      expect(diceRoller.store.getState().dice[0].value).toBe(1)
     })
   })
 
@@ -324,8 +324,8 @@ describe("DiceRoller", () => {
       await rollPromise
 
       // Assert
-      expect(diceRoller.store.state.dice.every((die) => die.value !== null)).toBe(true)
-      expect(diceRoller.store.state.dice.every((die) => !die.isRolling)).toBe(true)
+      expect(diceRoller.store.getState().dice.every((die) => die.value !== null)).toBe(true)
+      expect(diceRoller.store.getState().dice.every((die) => !die.isRolling)).toBe(true)
     })
   })
 
@@ -348,7 +348,7 @@ describe("DiceRoller", () => {
       await rollPromise
 
       // Assert
-      const diceStates = diceRoller.store.state.dice
+      const diceStates = diceRoller.store.getState().dice
       expect(diceStates[0].value).toBeNull() // not rolled
       expect(diceStates[1].value).toBe(2)
       expect(diceStates[2].value).toBe(2)
@@ -367,7 +367,7 @@ describe("DiceRoller", () => {
       await rollPromise
 
       // Assert
-      expect(diceRoller.store.state.dice.every((die) => die.value === 4)).toBe(true)
+      expect(diceRoller.store.getState().dice.every((die) => die.value === 4)).toBe(true)
     })
 
     it("treats a negative startIndex as an offset from the end of the pool", async () => {
@@ -382,7 +382,7 @@ describe("DiceRoller", () => {
       await rollPromise
 
       // Assert
-      const diceStates = diceRoller.store.state.dice
+      const diceStates = diceRoller.store.getState().dice
       expect(diceStates[0].value).toBeNull() // not rolled
       expect(diceStates[1].value).toBeNull() // not rolled
       expect(diceStates[2].value).toBe(6) // rolled
@@ -417,7 +417,7 @@ describe("DiceRoller", () => {
       await rollPromise
 
       // Assert
-      const diceStates = diceRoller.store.state.dice
+      const diceStates = diceRoller.store.getState().dice
       expect(diceStates[0].value).toBe(6) // unchanged
       expect(diceStates[1].value).toBe(6) // re-rolled 1 → 6
       expect(diceStates[2].value).toBe(5) // unchanged
@@ -441,7 +441,7 @@ describe("DiceRoller", () => {
       await settledPromise
 
       // Assert — values are unchanged
-      const diceStates = diceRoller.store.state.dice
+      const diceStates = diceRoller.store.getState().dice
       expect(diceStates[0].value).toBe(5)
       expect(diceStates[1].value).toBe(6)
     })
@@ -484,7 +484,7 @@ describe("DiceRoller", () => {
 
       // Assert
       expect(result).toBe(diceRoller)
-      expect(diceRoller.store.state.dice.every((die) => !die.isRolling)).toBe(true)
+      expect(diceRoller.store.getState().dice.every((die) => !die.isRolling)).toBe(true)
     })
   })
 })

--- a/src/system/dice/diceRoller.ts
+++ b/src/system/dice/diceRoller.ts
@@ -35,7 +35,7 @@ export class DiceRoller {
   }
 
   public setPoolSize(numDice: number) {
-    const { dice } = this.store.get()
+    const { dice } = this.store.getState()
 
     const difference = Math.abs(dice.length - numDice)
     if (difference === 0) return this
@@ -51,7 +51,7 @@ export class DiceRoller {
 
   public settled(): Promise<this> {
     return new Promise((resolve) => {
-      if (selectAllSettled(this.store.get())) {
+      if (selectAllSettled(this.store.getState())) {
         resolve(this)
         return
       }
@@ -118,7 +118,7 @@ export class DiceRoller {
       }))
 
       if (options.explodes && value === 6) {
-        const { dice } = this.store.get()
+        const { dice } = this.store.getState()
         this.rollDie(dice.length - 1, { timeout: 500, explodes: true })
       }
     }, timeout)
@@ -131,7 +131,7 @@ export class DiceRoller {
   }
 
   public rollDice(startIndex: number = 0, endIndex: number = Infinity, options?: RollOptions) {
-    const { dice } = this.store.get()
+    const { dice } = this.store.getState()
 
     if (startIndex < 0) {
       startIndex = dice.length - Math.abs(startIndex)
@@ -152,7 +152,7 @@ export class DiceRoller {
       })
     }))
 
-    this.store.get()
+    this.store.getState()
       .dice
       .map((die, index) => ({ die, index }))
       .forEach(({ index }) => this.rollDie(index, options))
@@ -161,7 +161,7 @@ export class DiceRoller {
   }
 
   public rerollOnes(options: RollOptions = {}) {
-    this.store.get()
+    this.store.getState()
       .dice
       .map((die, index) => ({ die, index }))
       .filter(({ die }) => die.value === 1)
@@ -171,7 +171,7 @@ export class DiceRoller {
   }
 
   public rollMisses() {
-    this.store.get()
+    this.store.getState()
       .dice
       .map((die, index) => ({ die, index }))
       .filter(({ die }) => die.value === null || die.value <= 4)
@@ -184,7 +184,7 @@ export class DiceRoller {
     if (this.rollingIntervalId !== null) return
 
     this.rollingIntervalId = setInterval(() => {
-      const isRolling = selectIsRolling(this.store.get())
+      const isRolling = selectIsRolling(this.store.getState())
       if (!isRolling) {
         this.clearRollingInterval()
         return

--- a/src/system/karma/improvements/improvementUtils.ledger.test.ts
+++ b/src/system/karma/improvements/improvementUtils.ledger.test.ts
@@ -48,14 +48,14 @@ describe("applyImprovements — karma ledger writes", () => {
     applyImprovements(improvementStore, runnerStore)
 
     // Assert
-    const log = runnerStore.state.karma.log
+    const log = runnerStore.getState().karma.log
     expect(log).toHaveLength(2)
     expect(log.every((entry) => entry.source === "spendKarma")).toBe(true)
     expect(log.every((entry) => entry.amount < 0)).toBe(true)
     // Total amount in ledger matches karma deducted
     const totalDeducted = log.reduce((sum, entry) => sum + entry.amount, 0)
     expect(totalDeducted).toBe(-(20 + 4))
-    expect(runnerStore.state.karma.current).toBe(100 - 20 - 4)
+    expect(runnerStore.getState().karma.current).toBe(100 - 20 - 4)
   })
 
   it("preserves the full ImprovementEntry on each ledger entry for v2 undo support", () => {
@@ -81,7 +81,7 @@ describe("applyImprovements — karma ledger writes", () => {
     applyImprovements(improvementStore, runnerStore)
 
     // Assert — improvement payload round-trips onto the ledger entry
-    const logged = runnerStore.state.karma.log[0]
+    const logged = runnerStore.getState().karma.log[0]
     expect(logged.improvement).toEqual(added)
   })
 
@@ -106,7 +106,7 @@ describe("applyImprovements — karma ledger writes", () => {
     applyImprovements(improvementStore, runnerStore)
 
     // Assert
-    expect(runnerStore.state.karma.log[0].description).toBe("Raised AGI 4 → 5")
+    expect(runnerStore.getState().karma.log[0].description).toBe("Raised AGI 4 → 5")
   })
 
   it("does not append to the ledger when the improvement queue is empty", () => {
@@ -122,7 +122,7 @@ describe("applyImprovements — karma ledger writes", () => {
     applyImprovements(improvementStore, runnerStore)
 
     // Assert
-    expect(runnerStore.state.karma.log).toEqual([])
+    expect(runnerStore.getState().karma.log).toEqual([])
   })
 
   it("stamps each entry with an ISO 8601 timestamp", () => {
@@ -146,7 +146,7 @@ describe("applyImprovements — karma ledger writes", () => {
     applyImprovements(improvementStore, runnerStore)
 
     // Assert — ISO 8601 round-trips cleanly to a valid Date
-    const timestamp = runnerStore.state.karma.log[0].timestamp
+    const timestamp = runnerStore.getState().karma.log[0].timestamp
     expect(new Date(timestamp).toISOString()).toBe(timestamp)
   })
 
@@ -170,8 +170,8 @@ describe("applyImprovements — karma ledger writes", () => {
     applyImprovements(improvementStore, runnerStore)
 
     // Assert — ledger entry has its own id, distinct from FAKE_ID
-    expect(runnerStore.state.karma.log[0].id).not.toBe(FAKE_ID)
-    expect(runnerStore.state.karma.log[0].id).toMatch(
+    expect(runnerStore.getState().karma.log[0].id).not.toBe(FAKE_ID)
+    expect(runnerStore.getState().karma.log[0].id).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
     )
   })

--- a/src/system/karma/improvements/improvementUtils.ts
+++ b/src/system/karma/improvements/improvementUtils.ts
@@ -30,7 +30,7 @@ export const applyImprovements = (
   improvementsStore: ImprovementStore,
   runnerStore: RunnerStore,
 ): void => {
-  const improvementsState = improvementsStore.store.state
+  const improvementsState = improvementsStore.store.getState()
 
   runnerStore.setState(produce((sheet) => {
     for (const entry of Object.values(improvementsState)) {


### PR DESCRIPTION
## Summary

A round of cleanup for code marked `@deprecated`:

- Deleted three orphaned util files (`attributeUtils.ts`, `spellsUtils.ts`, `qualitiesUtils.ts`) whose only exports were unused `@deprecated` `BuilderConfig` aliases, and dropped the same kind of unused deprecated constants from `technomancerUtils.ts`, `contactsBuilderUtils.ts`, `skillsBuilderUtils.ts`, and `useGearBuildPoints.ts`.
- Inlined the one still-referenced deprecated constant (`GearNuyenPerBuildPoint`) onto `BuilderConfig.gear.nuyenPerBp` directly at its call site (`startingNuyenSection.tsx`).
- Replaced all `Selectors.gear.selectGear` usages with the identical `selectAllGear` and removed the deprecated duplicate selector.
- Migrated every `CompatStore` consumer off the deprecated `.get()` / `.state` aliases onto `.getState()`, across ~35 files (dice roller, dice tray, dialog controller, improvements store, license check, karma, and their tests), and dropped those aliases from the `CompatStore` interface, its implementation, and `RunnerDataStore`'s pass-throughs.

`painTolerance` (`gameEffectType.ts` / `gameEffectData.ts`) is intentionally left `@deprecated` — it's still required to parse pre-migration runner data via the `20260502_splitPainToleranceEffects` migration, so removing it would break loading older character files.

## Test plan

- [x] `yarn tsc` — no errors
- [x] `yarn eslint` — no errors
- [x] `yarn test:unit` — 141 files / 946 tests passing
- [x] `yarn build` — succeeds
- [x] `yarn fallow dead-code` — no new findings introduced by this change


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnrXGL1LEUsShuQCLwKd6b)_