### PR TITLE
Fix unreachable profile edit button on the About page

### DIFF
--- a/src/routes/$runnerId/_viewer/about.tsx
+++ b/src/routes/$runnerId/_viewer/about.tsx
@@ -30,7 +30,7 @@ function RouteComponent() {
   )
 
   return (
-    <Stack>
+    <Stack sx={{ position: "relative" }}>
       <IconButton
         size="small"
         onClick={() => profileEditDialog.open()}


### PR DESCRIPTION
## Summary

The task asked for an edit button and dialog for the runner's profile/biography info on the viewer. That functionality already existed (`ProfileEditDialog` + an `IconButton` on the About page), but while verifying it in a browser I found the button was actually unclickable.

- The edit-profile `IconButton` in `src/routes/$runnerId/_viewer/about.tsx` used `position: "absolute", top: 8, right: 8` inside a `Stack` with no `position: relative`.
- Without a positioned ancestor, the button escaped to the top-right corner of the *viewport* instead of the profile header, landing underneath the sticky app `AppBar`, which intercepted all pointer events.
- Fix: add `position: "relative"` to the containing `Stack` so the button anchors next to the runner's name, as originally intended.

## Test plan

- [x] `yarn eslint` on the changed file — clean
- [x] `yarn tsc --noEmit` — no errors
- [x] Ran the app in a headless browser (Playwright): opened a runner, confirmed the edit icon now renders next to the runner's name and is clickable, opened the "Edit Profile" dialog, edited the Description field, saved, and confirmed the change rendered on the page


---
_Generated by [Claude Code](https://claude.ai/code/session_01GX593UPqjc8zTU4U1bBxvJ)_