### PR TITLE
Add optional specialization field to Contact knowledge skills

### DIFF
--- a/src/components/runner/contacts/form/contactFormFields.tsx
+++ b/src/components/runner/contacts/form/contactFormFields.tsx
@@ -90,6 +90,13 @@ export const ContactFormFields = withFieldGroup({
                       value={skill.name}
                       onChange={(e) => field.replaceValue(index, { ...skill, name: e.target.value })}
                     />
+                    <TextField
+                      label="Specialization (optional)"
+                      size="small"
+                      fullWidth
+                      value={skill.specialization ?? ""}
+                      onChange={(e) => field.replaceValue(index, { ...skill, specialization: e.target.value })}
+                    />
                     <FormControl size="small" sx={{ minWidth: 90 }}>
                       <InputLabel>Rating</InputLabel>
                       <Select


### PR DESCRIPTION
## Summary

- `KnowledgeSkillData` already supports an optional `specialization?: string`, but the Contact form never exposed it in the UI.
- Adds an optional "Specialization" text input next to each knowledge skill row in `ContactFormFields`, shared by both the Builder and Viewer contact dialogs.

## Test plan

- [x] `yarn tsc --noEmit`
- [x] `yarn vitest run src/components/runner/contacts`
- [x] `yarn eslint src/components/runner/contacts/form/contactFormFields.tsx`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pz3yzbAJgeeccJgHW1nWnz)_