### PR TITLE
Add duplicate runner button to character select

### DIFF
--- a/src/components/runner/runnerRosterList.tsx
+++ b/src/components/runner/runnerRosterList.tsx
@@ -1,3 +1,4 @@
+import ContentCopyIcon from "@mui/icons-material/ContentCopy"
 import DeleteIcon from "@mui/icons-material/Delete"
 import DownloadIcon from "@mui/icons-material/Download"
 import EditIcon from "@mui/icons-material/Edit"
@@ -23,6 +24,7 @@ import type { RunnerLoadError } from "#/lib/persistence/runnerLoadError.ts"
 import type { RunnerData } from "#/system/runnerData.ts"
 
 import { downloadTextFile } from "./exportImport/exportUtils.ts"
+import { resolveAlias } from "./runnerUtils.ts"
 
 interface RunnerRosterListProps {
   runners: Record<string, RunnerData>
@@ -87,6 +89,19 @@ export default function RunnerRosterList({
   const handleDeleteRunner = (runner: RunnerData) => {
     closeMenu()
     void confirmAndDeleteRunner(runner)
+  }
+
+  const handleDuplicateRunner = async (runner: RunnerData) => {
+    closeMenu()
+    const existingAliases = new Set(sortedRunners.map((r) => r.profile.alias))
+    const newAlias = resolveAlias(runner.profile.alias, existingAliases)
+    const duplicated: RunnerData = {
+      ...runner,
+      id: crypto.randomUUID(),
+      profile: { ...runner.profile, alias: newAlias },
+    }
+    await runnerManager.saveRunner(duplicated)
+    await router.invalidate()
   }
 
   return (
@@ -195,6 +210,10 @@ export default function RunnerRosterList({
         <MenuItem onClick={() => menuState && handleEditRunner(menuState.runner)}>
           <ListItemIcon><EditIcon fontSize="small" /></ListItemIcon>
           Edit
+        </MenuItem>
+        <MenuItem onClick={() => menuState && void handleDuplicateRunner(menuState.runner)}>
+          <ListItemIcon><ContentCopyIcon fontSize="small" /></ListItemIcon>
+          Duplicate
         </MenuItem>
         <MenuItem onClick={() => menuState && handleDeleteRunner(menuState.runner)} sx={{ color: "error.main" }}>
           <ListItemIcon sx={{ color: "error.main" }}><DeleteIcon fontSize="small" /></ListItemIcon>


### PR DESCRIPTION
## Summary
- Add a "Duplicate" action to the per-runner overflow menu on the character select (roster) list
- Duplicating creates a copy of the runner with a new id and an auto-resolved alias (e.g. "Name 2", "Name 3", ...) using the existing `resolveAlias` helper, saved via `RunnerManager.saveRunner`

## Test plan
- [x] `yarn tsc` passes
- [x] `yarn eslint src/components/runner/runnerRosterList.tsx` passes
- [x] `yarn test:unit` (runnerRosterList/runnerManager/runnerUtils suites) passes
- [ ] Manually verify in browser: open character select, click the overflow menu on a runner, click "Duplicate", confirm a new entry appears with an incremented alias

---
_Generated by [Claude Code](https://claude.ai/code/session_01R77RFthTFabrPA9vrqVbVY)_