### PR TITLE
Add Finances, Karma, and Reputation sections to the Runner editor

### DIFF
--- a/src/components/builder/runnerEditor.tsx
+++ b/src/components/builder/runnerEditor.tsx
@@ -26,9 +26,12 @@ import { AttributesBuilderSection } from "./sections/attributes/attributesBuilde
 import { BiologyBuilderSection } from "./sections/biology/biologyBuilderSection.tsx"
 import { BuilderSectionId } from "./sections/builderSectionId.ts"
 import { ContactsBuilderSection } from "./sections/contacts/contactsBuilderSection.tsx"
+import { FinancesBuilderSection } from "./sections/finances/financesBuilderSection.tsx"
 import { GearBuilderSection } from "./sections/gear/gearBuilderSection.tsx"
+import { KarmaBuilderSection } from "./sections/karma/karmaBuilderSection.tsx"
 import { ProfileBuilderSection } from "./sections/profile/profileBuilderSection.tsx"
 import { QualitiesBuilderSection } from "./sections/qualities/qualitiesBuilderSection.tsx"
+import { ReputationBuilderSection } from "./sections/reputation/reputationBuilderSection.tsx"
 import { AdeptPowersBuilderSection } from "./sections/resources/adept/adeptPowersBuilderSection.tsx"
 import { SpellsBuilderSection } from "./sections/resources/magician/spellsBuilderSection.tsx"
 import {
@@ -45,6 +48,7 @@ interface RunnerEditorProps {
 const tabComponents: Record<EditorTabId, FC> = {
   [BuilderSectionId.profile]: ProfileBuilderSection,
   [BuilderSectionId.biology]: BiologyBuilderSection,
+  [BuilderSectionId.reputation]: ReputationBuilderSection,
   [BuilderSectionId.attributes]: AttributesBuilderSection,
   [BuilderSectionId.qualities]: QualitiesBuilderSection,
   [BuilderSectionId.activeSkills]: ActiveSkillsBuilderSection,
@@ -55,6 +59,8 @@ const tabComponents: Record<EditorTabId, FC> = {
   [BuilderSectionId.sprites]: SpritesBuilderSection,
   [BuilderSectionId.gear]: GearBuilderSection,
   [BuilderSectionId.contacts]: ContactsBuilderSection,
+  [BuilderSectionId.karma]: KarmaBuilderSection,
+  [BuilderSectionId.finances]: FinancesBuilderSection,
   [FINALIZE_TAB_ID]: FinalizeSection,
 }
 

--- a/src/components/builder/sections/builderSectionId.ts
+++ b/src/components/builder/sections/builderSectionId.ts
@@ -1,6 +1,7 @@
 export enum BuilderSectionId {
   profile = "profile",
   biology = "biology",
+  reputation = "reputation",
   attributes = "attributes",
   qualities = "qualities",
   activeSkills = "active-skills",
@@ -11,6 +12,8 @@ export enum BuilderSectionId {
   sprites = "sprites",
   gear = "gear",
   contacts = "contacts",
+  karma = "karma",
+  finances = "finances",
 }
 
 interface BuilderSectionInfo {
@@ -20,6 +23,7 @@ interface BuilderSectionInfo {
 export const builderSections: Record<BuilderSectionId, BuilderSectionInfo> = {
   [BuilderSectionId.profile]: { label: "Profile" },
   [BuilderSectionId.biology]: { label: "Biology" },
+  [BuilderSectionId.reputation]: { label: "Reputation" },
   [BuilderSectionId.attributes]: { label: "Attributes" },
   [BuilderSectionId.qualities]: { label: "Qualities" },
   [BuilderSectionId.activeSkills]: { label: "Active Skills" },
@@ -30,6 +34,8 @@ export const builderSections: Record<BuilderSectionId, BuilderSectionInfo> = {
   [BuilderSectionId.sprites]: { label: "Sprites" },
   [BuilderSectionId.gear]: { label: "Gear" },
   [BuilderSectionId.contacts]: { label: "Contacts" },
+  [BuilderSectionId.karma]: { label: "Karma" },
+  [BuilderSectionId.finances]: { label: "Finances" },
 }
 
 export const builderSectionOrder = Object.values(BuilderSectionId)

--- a/src/components/builder/sections/finances/financesBuilderSection.test.tsx
+++ b/src/components/builder/sections/finances/financesBuilderSection.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import type { FC, PropsWithChildren } from "react"
+import { describe, expect, it } from "vitest"
+
+import { RunnerDataStore } from "#/components/runner/sheet/runnerDataStore.ts"
+import { RunnerStoreProvider } from "#/components/runner/sheet/runnerStoreProvider.tsx"
+import { runnerDataFactory } from "#/system/runnerData.factory.ts"
+
+import { FinancesBuilderSection } from "./financesBuilderSection.tsx"
+
+function renderSection(nuyen: number) {
+  const runnerData = runnerDataFactory((data) => {
+    data.nuyen.current = nuyen
+    return data
+  })
+  const store = new RunnerDataStore(runnerData)
+
+  const Wrapper: FC<PropsWithChildren> = ({ children }) => (
+    <RunnerStoreProvider store={store}>{children}</RunnerStoreProvider>
+  )
+
+  render(<FinancesBuilderSection />, { wrapper: Wrapper })
+
+  return store
+}
+
+describe("FinancesBuilderSection", () => {
+  it("renders the Finances section header and the runner's nuyen from the store", () => {
+    // Arrange / Act
+    renderSection(1500)
+
+    // Assert
+    expect(screen.getByRole("heading", { name: "Finances" })).toBeDefined()
+    expect(screen.getByLabelText("Adjust")).toBeDefined()
+  })
+
+  it("setting nuyen dispatches setNuyenAmount, updating the store", async () => {
+    // Arrange
+    const store = renderSection(1000)
+
+    // Act
+    fireEvent.change(screen.getByLabelText("Adjust"), { target: { value: "2500" } })
+    fireEvent.click(screen.getByRole("button", { name: "Set" }))
+
+    // Assert
+    await waitFor(() => expect(store.getState().nuyen.current).toBe(2500))
+  })
+})

--- a/src/components/builder/sections/finances/financesBuilderSection.tsx
+++ b/src/components/builder/sections/finances/financesBuilderSection.tsx
@@ -1,0 +1,13 @@
+import type { FC } from "react"
+
+import { BuilderSection } from "#/components/builder/sections/builderSection.tsx"
+import { BuilderSectionId } from "#/components/builder/sections/builderSectionId.ts"
+import { FinancesSection } from "#/components/runner/finances/financesSection.tsx"
+
+export const FinancesBuilderSection: FC = () => {
+  return (
+    <BuilderSection id={BuilderSectionId.finances}>
+      <FinancesSection />
+    </BuilderSection>
+  )
+}

--- a/src/components/builder/sections/karma/karmaBuilderSection.test.tsx
+++ b/src/components/builder/sections/karma/karmaBuilderSection.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react"
+import type { FC, PropsWithChildren } from "react"
+import { describe, expect, it } from "vitest"
+
+import { RunnerDataStore } from "#/components/runner/sheet/runnerDataStore.ts"
+import { RunnerStoreProvider } from "#/components/runner/sheet/runnerStoreProvider.tsx"
+import { runnerDataFactory } from "#/system/runnerData.factory.ts"
+
+import { KarmaBuilderSection } from "./karmaBuilderSection.tsx"
+
+describe("KarmaBuilderSection", () => {
+  it("renders the Karma section header and the runner's karma from the store", () => {
+    // Arrange
+    const runnerData = runnerDataFactory((data) => {
+      data.karma.current = 5
+      data.karma.total = 20
+      return data
+    })
+    const store = new RunnerDataStore(runnerData)
+    const Wrapper: FC<PropsWithChildren> = ({ children }) => (
+      <RunnerStoreProvider store={store}>{children}</RunnerStoreProvider>
+    )
+
+    // Act
+    render(<KarmaBuilderSection />, { wrapper: Wrapper })
+
+    // Assert
+    expect(screen.getByRole("heading", { name: "Karma" })).toBeDefined()
+    expect(screen.getByText("5")).toBeDefined()
+    expect(screen.getByText("20")).toBeDefined()
+  })
+})

--- a/src/components/builder/sections/karma/karmaBuilderSection.tsx
+++ b/src/components/builder/sections/karma/karmaBuilderSection.tsx
@@ -1,0 +1,13 @@
+import type { FC } from "react"
+
+import { BuilderSection } from "#/components/builder/sections/builderSection.tsx"
+import { BuilderSectionId } from "#/components/builder/sections/builderSectionId.ts"
+import { KarmaSection } from "#/components/runner/karma/karmaSection.tsx"
+
+export const KarmaBuilderSection: FC = () => {
+  return (
+    <BuilderSection id={BuilderSectionId.karma}>
+      <KarmaSection />
+    </BuilderSection>
+  )
+}

--- a/src/components/builder/sections/reputation/reputationBuilderSection.test.tsx
+++ b/src/components/builder/sections/reputation/reputationBuilderSection.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import type { FC, PropsWithChildren } from "react"
+import { describe, expect, it } from "vitest"
+
+import { RunnerDataStore } from "#/components/runner/sheet/runnerDataStore.ts"
+import { RunnerStoreProvider } from "#/components/runner/sheet/runnerStoreProvider.tsx"
+import { runnerDataFactory } from "#/system/runnerData.factory.ts"
+
+import { ReputationBuilderSection } from "./reputationBuilderSection.tsx"
+
+function renderSection() {
+  const runnerData = runnerDataFactory((data) => {
+    data.profile.streetCred = 3
+    data.profile.notoriety = 1
+    data.profile.publicAwarenessModifier = 2
+    return data
+  })
+  const store = new RunnerDataStore(runnerData)
+
+  const Wrapper: FC<PropsWithChildren> = ({ children }) => (
+    <RunnerStoreProvider store={store}>{children}</RunnerStoreProvider>
+  )
+
+  render(<ReputationBuilderSection />, { wrapper: Wrapper })
+
+  return store
+}
+
+describe("ReputationBuilderSection", () => {
+  it("shows the runner's reputation fields and computed public awareness from the store", () => {
+    // Arrange / Act
+    renderSection()
+
+    // Assert
+    expect((screen.getByLabelText("Street Cred") as HTMLInputElement).value).toBe("3")
+    expect((screen.getByLabelText("Notoriety") as HTMLInputElement).value).toBe("1")
+    expect((screen.getByLabelText("Awareness Modifier") as HTMLInputElement).value).toBe("2")
+    // floor((3 + 1) / 3) + 2 = 1 + 2 = 3
+    expect(screen.getByText("3", { selector: "p" })).toBeDefined()
+  })
+
+  it("editing Street Cred dispatches setStreetCred, updating the store and the UI", async () => {
+    // Arrange
+    const store = renderSection()
+
+    // Act
+    fireEvent.change(screen.getByLabelText("Street Cred"), { target: { value: "8" } })
+
+    // Assert: state updated...
+    await waitFor(() => expect(store.getState().profile.streetCred).toBe(8))
+    // ...and the UI re-rendered off that same state.
+    expect((screen.getByLabelText("Street Cred") as HTMLInputElement).value).toBe("8")
+  })
+
+  it("editing Notoriety dispatches setNotoriety, updating the store and the UI", async () => {
+    // Arrange
+    const store = renderSection()
+
+    // Act
+    fireEvent.change(screen.getByLabelText("Notoriety"), { target: { value: "5" } })
+
+    // Assert
+    await waitFor(() => expect(store.getState().profile.notoriety).toBe(5))
+    expect((screen.getByLabelText("Notoriety") as HTMLInputElement).value).toBe("5")
+  })
+})

--- a/src/components/builder/sections/reputation/reputationBuilderSection.tsx
+++ b/src/components/builder/sections/reputation/reputationBuilderSection.tsx
@@ -1,0 +1,58 @@
+import Stack from "@mui/material/Stack"
+import TextField from "@mui/material/TextField"
+import Typography from "@mui/material/Typography"
+import type { FC } from "react"
+
+import { BuilderSection } from "#/components/builder/sections/builderSection.tsx"
+import { BuilderSectionId } from "#/components/builder/sections/builderSectionId.ts"
+import { Label } from "#/components/ui/text/label.tsx"
+import { Actions } from "#/lib/stores/runner/runnerStore.actions.ts"
+import { useRunnerStoreDispatch } from "#/lib/stores/runner/runnerStore.dispatch.ts"
+import { Selectors, useRunnerStoreSelector } from "#/lib/stores/runner/runnerStore.selectors.ts"
+
+export const ReputationBuilderSection: FC = () => {
+  const dispatch = useRunnerStoreDispatch()
+  const streetCred = useRunnerStoreSelector(Selectors.profile.selectStreetCred)
+  const notoriety = useRunnerStoreSelector(Selectors.profile.selectNotoriety)
+  const publicAwarenessModifier = useRunnerStoreSelector(Selectors.profile.selectPublicAwarenessModifier)
+  const publicAwareness = useRunnerStoreSelector(Selectors.profile.selectPublicAwareness)
+
+  return (
+    <BuilderSection id={BuilderSectionId.reputation}>
+      <Stack direction="row" sx={{ gap: 1 }}>
+        <TextField
+          label="Street Cred"
+          type="number"
+          size="small"
+          fullWidth
+          value={streetCred}
+          slotProps={{ htmlInput: { min: 0 } }}
+          onChange={(e) => dispatch(Actions.profile.setStreetCred(Math.max(0, parseInt(e.target.value, 10) || 0)))}
+        />
+        <TextField
+          label="Notoriety"
+          type="number"
+          size="small"
+          fullWidth
+          value={notoriety}
+          slotProps={{ htmlInput: { min: 0 } }}
+          onChange={(e) => dispatch(Actions.profile.setNotoriety(Math.max(0, parseInt(e.target.value, 10) || 0)))}
+        />
+        <TextField
+          label="Awareness Modifier"
+          type="number"
+          size="small"
+          fullWidth
+          value={publicAwarenessModifier}
+          onChange={(e) =>
+            dispatch(Actions.profile.setProfilePublicAwarenessModifier(parseInt(e.target.value, 10) || 0))}
+        />
+      </Stack>
+
+      <Stack sx={{ alignItems: "center", gap: 1 }}>
+        <Label label="Public Awareness" />
+        <Typography sx={{ fontWeight: "bold" }}>{publicAwareness}</Typography>
+      </Stack>
+    </BuilderSection>
+  )
+}

--- a/src/components/runner/finances/financesSection.tsx
+++ b/src/components/runner/finances/financesSection.tsx
@@ -1,0 +1,88 @@
+import Button from "@mui/material/Button"
+import Grid from "@mui/material/Grid"
+import Stack from "@mui/material/Stack"
+import Typography from "@mui/material/Typography"
+import type { FC } from "react"
+
+import { Nuyen } from "#/components/ui/nuyen.tsx"
+import { Label } from "#/components/ui/text/label.tsx"
+import { useNetWorth } from "#/lib/hooks/runner/finances/nuyen/useNetWorth.tsx"
+import { Selectors, useRunnerStoreSelector } from "#/lib/stores/runner/runnerStore.selectors.ts"
+import { Lifestyles, LifestyleType } from "#/system/lifestyleType.ts"
+import { calculateMonthlyInterest } from "#/system/loanData.ts"
+
+import { useEndOfMonthDialog } from "./endOfMonth/endOfMonthDialog.tsx"
+import { LifestyleSection } from "./lifestyle/lifestyleSection.tsx"
+import { LoansSection } from "./loans/loansSection.tsx"
+import { NuyenSection } from "./nuyen/nuyenSection.tsx"
+
+export const FinancesSection: FC = () => {
+  const endOfMonthDialog = useEndOfMonthDialog()
+
+  const netWorth = useNetWorth()
+  const nuyenBalance = useRunnerStoreSelector(Selectors.nuyen.selectNuyenAmount)
+  const loans = useRunnerStoreSelector(Selectors.nuyen.selectLoans)
+  const loansBalance = loans.reduce((sum, loan) => sum + loan.amount, 0)
+
+  const lifestyleQuality = useRunnerStoreSelector(Selectors.profile.selectLifestyleQuality) ?? LifestyleType.Street
+  const lifestyleMonthsPaid = useRunnerStoreSelector(Selectors.profile.selectLifestyleMonthsPaid) ?? 1
+  const lifestyleUpkeep = Lifestyles[lifestyleQuality].upkeep
+
+  const monthlyNuyenCost = lifestyleMonthsPaid === 0 ? lifestyleUpkeep : 0
+  const monthlyInterest = loans
+    .filter((l) => l.interestRate > 0)
+    .reduce((sum, l) => sum + calculateMonthlyInterest(l), 0)
+  const totalMonthlyExpenses = monthlyNuyenCost + monthlyInterest
+
+  return (
+    <Stack>
+      <Stack direction="row" sx={{ alignItems: "center", justifyContent: "flex-end", gap: 1 }}>
+        <Button
+          size="small"
+          variant="outlined"
+          color="warning"
+          onClick={() => endOfMonthDialog.open()}
+        >
+          End of Month{totalMonthlyExpenses > 0 && <> — <Nuyen amount={totalMonthlyExpenses} /></>}
+        </Button>
+      </Stack>
+
+      <Grid container columns={3} spacing={1}>
+        <Grid size={1}>
+          <Stack sx={{ alignItems: "center", gap: 1, flexGrow: 1 }}>
+            <Label label="Nuyen" />
+            <Typography color={nuyenBalance < 0 ? "error.main" : "text.primary"}>
+              <Nuyen amount={nuyenBalance} />
+            </Typography>
+          </Stack>
+        </Grid>
+
+        <Grid size={1}>
+          <Stack sx={{ alignItems: "center", gap: 1, flexGrow: 1 }}>
+            <Label label="Loans" />
+            <Typography color={loansBalance > 0 ? "error.main" : "text.primary"}>
+              <Nuyen amount={loansBalance} />
+            </Typography>
+          </Stack>
+        </Grid>
+
+        <Grid size={1}>
+          <Stack sx={{ alignItems: "center", gap: 1, flexGrow: 1 }}>
+            <Label label="Net Worth" />
+            <Typography color={netWorth < 0 ? "error.main" : "text.primary"}>
+              <Nuyen amount={netWorth} />
+            </Typography>
+          </Stack>
+        </Grid>
+      </Grid>
+
+      <NuyenSection />
+
+      <LoansSection />
+
+      <LifestyleSection />
+
+      {endOfMonthDialog.dialog}
+    </Stack>
+  )
+}

--- a/src/lib/stores/runner/profile/profileSlice.actions.test.ts
+++ b/src/lib/stores/runner/profile/profileSlice.actions.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+
+import { setNotoriety, setStreetCred } from "./profileSlice.actions.ts"
+import { profileReducer } from "./profileSlice.ts"
+
+describe("setStreetCred", () => {
+  it("sets streetCred to the given value", () => {
+    // Arrange
+    const state = profileReducer(undefined, { type: "@@INIT" })
+
+    // Act
+    const next = profileReducer(state, setStreetCred(4))
+
+    // Assert
+    expect(next.streetCred).toBe(4)
+  })
+})
+
+describe("setNotoriety", () => {
+  it("sets notoriety to the given value", () => {
+    // Arrange
+    const state = profileReducer(undefined, { type: "@@INIT" })
+
+    // Act
+    const next = profileReducer(state, setNotoriety(2))
+
+    // Assert
+    expect(next.notoriety).toBe(2)
+  })
+})

--- a/src/lib/stores/runner/profile/profileSlice.actions.ts
+++ b/src/lib/stores/runner/profile/profileSlice.actions.ts
@@ -8,5 +8,7 @@ export const setProfileArchetype = createAction<string | null>("profile/setArche
 export const setProfileDescription = createAction<string | null>("profile/setDescription")
 export const setProfilePersonality = createAction<string | null>("profile/setPersonality")
 export const setProfilePublicAwarenessModifier = createAction<number | undefined>("profile/setPublicAwarenessModifier")
+export const setStreetCred = createAction<number>("profile/setStreetCred")
+export const setNotoriety = createAction<number>("profile/setNotoriety")
 export const setLifestyleQuality = createAction<LifestyleType>("profile/setLifestyleQuality")
 export const setLifestyleMonthsPaid = createAction<number>("profile/setLifestyleMonthsPaid")

--- a/src/lib/stores/runner/profile/profileSlice.selectors.test.ts
+++ b/src/lib/stores/runner/profile/profileSlice.selectors.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+
+import { runnerDataFactory } from "#/system/runnerData.factory.ts"
+
+import { selectPublicAwareness } from "./profileSlice.selectors.ts"
+
+describe("selectPublicAwareness", () => {
+  it("computes floor((streetCred + notoriety) / 3) plus the modifier", () => {
+    // Arrange
+    const state = runnerDataFactory((data) => {
+      data.profile.streetCred = 5
+      data.profile.notoriety = 2
+      data.profile.publicAwarenessModifier = 1
+      return data
+    })
+
+    // Act
+    const publicAwareness = selectPublicAwareness(state)
+
+    // Assert: floor((5 + 2) / 3) + 1 = 2 + 1 = 3
+    expect(publicAwareness).toBe(3)
+  })
+
+  it("defaults the modifier to 0 when unset", () => {
+    // Arrange
+    const state = runnerDataFactory((data) => {
+      data.profile.streetCred = 4
+      data.profile.notoriety = 0
+      return data
+    })
+
+    // Act
+    const publicAwareness = selectPublicAwareness(state)
+
+    // Assert: floor(4 / 3) + 0 = 1
+    expect(publicAwareness).toBe(1)
+  })
+
+  it("never returns a value below 0", () => {
+    // Arrange
+    const state = runnerDataFactory((data) => {
+      data.profile.streetCred = 0
+      data.profile.notoriety = 0
+      data.profile.publicAwarenessModifier = -5
+      return data
+    })
+
+    // Act
+    const publicAwareness = selectPublicAwareness(state)
+
+    // Assert
+    expect(publicAwareness).toBe(0)
+  })
+})

--- a/src/lib/stores/runner/profile/profileSlice.selectors.ts
+++ b/src/lib/stores/runner/profile/profileSlice.selectors.ts
@@ -19,6 +19,26 @@ export function selectLifestyle(state: RunnerData): RunnerData["profile"]["lifes
   return state.profile.lifestyle
 }
 
+export function selectStreetCred(state: RunnerData): number {
+  return state.profile.streetCred
+}
+
+export function selectNotoriety(state: RunnerData): number {
+  return state.profile.notoriety
+}
+
+export function selectPublicAwarenessModifier(state: RunnerData): number {
+  return state.profile.publicAwarenessModifier ?? 0
+}
+
+export const selectPublicAwareness = createSelector(
+  selectStreetCred,
+  selectNotoriety,
+  selectPublicAwarenessModifier,
+  (streetCred, notoriety, publicAwarenessModifier) =>
+    Math.max(0, Math.floor((streetCred + notoriety) / 3) + publicAwarenessModifier),
+)
+
 export const selectLifestyleQuality = createSelector(
   selectLifestyle,
   (lifestyle) => lifestyle?.quality,

--- a/src/lib/stores/runner/profile/profileSlice.ts
+++ b/src/lib/stores/runner/profile/profileSlice.ts
@@ -6,12 +6,14 @@ import type { RunnerData } from "#/system/runnerData.ts"
 import {
   setLifestyleMonthsPaid,
   setLifestyleQuality,
+  setNotoriety,
   setProfileAlias,
   setProfileArchetype,
   setProfileDescription,
   setProfileName,
   setProfilePersonality,
   setProfilePublicAwarenessModifier,
+  setStreetCred,
 } from "./profileSlice.actions.ts"
 
 const initialState: RunnerData["profile"] = {
@@ -44,6 +46,12 @@ export const profileReducer = createReducer(initialState, (builder) => {
     })
     .addCase(setProfilePublicAwarenessModifier, (state, action) => {
       state.publicAwarenessModifier = action.payload
+    })
+    .addCase(setStreetCred, (state, action) => {
+      state.streetCred = action.payload
+    })
+    .addCase(setNotoriety, (state, action) => {
+      state.notoriety = action.payload
     })
     .addCase(setLifestyleQuality, (state, action) => {
       state.lifestyle = { ...(state.lifestyle ?? { quality: action.payload, monthsPaid: 1 }), quality: action.payload }

--- a/src/routes/$runnerId/_viewer/about.tsx
+++ b/src/routes/$runnerId/_viewer/about.tsx
@@ -14,7 +14,7 @@ import { ProfileSection } from "#/components/runner/profile/profileSection.tsx"
 import { QualitiesViewerSection } from "#/components/runner/qualities/qualitiesViewerSection.tsx"
 import { Label } from "#/components/ui/text/label.tsx"
 import { SectionHeader } from "#/components/ui/text/sectionHeader.tsx"
-import { useRunnerStoreSelector } from "#/lib/stores/runner/runnerStore.selectors.ts"
+import { Selectors, useRunnerStoreSelector } from "#/lib/stores/runner/runnerStore.selectors.ts"
 
 export const Route = createFileRoute("/$runnerId/_viewer/about")({
   component: RouteComponent,
@@ -23,11 +23,7 @@ export const Route = createFileRoute("/$runnerId/_viewer/about")({
 function RouteComponent() {
   const profileEditDialog = useProfileEditDialog()
   const profile = useRunnerStoreSelector((s) => s.profile)
-
-  const publicAwareness = Math.max(
-    0,
-    Math.floor((profile.streetCred + profile.notoriety) / 3) + (profile.publicAwarenessModifier ?? 0),
-  )
+  const publicAwareness = useRunnerStoreSelector(Selectors.profile.selectPublicAwareness)
 
   return (
     <Stack sx={{ position: "relative" }}>

--- a/src/routes/$runnerId/_viewer/finances.tsx
+++ b/src/routes/$runnerId/_viewer/finances.tsx
@@ -1,97 +1,22 @@
-import Button from "@mui/material/Button"
-import Grid from "@mui/material/Grid"
 import Stack from "@mui/material/Stack"
-import Typography from "@mui/material/Typography"
 import { createFileRoute } from "@tanstack/react-router"
 
 import { CredstickSection } from "#/components/items/types/credsticks/credstickSection.tsx"
-import { useEndOfMonthDialog } from "#/components/runner/finances/endOfMonth/endOfMonthDialog.tsx"
-import { LifestyleSection } from "#/components/runner/finances/lifestyle/lifestyleSection.tsx"
-import { LoansSection } from "#/components/runner/finances/loans/loansSection.tsx"
-import { NuyenSection } from "#/components/runner/finances/nuyen/nuyenSection.tsx"
-import { Nuyen } from "#/components/ui/nuyen.tsx"
-import { Label } from "#/components/ui/text/label.tsx"
+import { FinancesSection } from "#/components/runner/finances/financesSection.tsx"
 import { SectionHeader } from "#/components/ui/text/sectionHeader.tsx"
-import { useNetWorth } from "#/lib/hooks/runner/finances/nuyen/useNetWorth.tsx"
-import { Selectors, useRunnerStoreSelector } from "#/lib/stores/runner/runnerStore.selectors.ts"
-import { Lifestyles, LifestyleType } from "#/system/lifestyleType.ts"
-import { calculateMonthlyInterest } from "#/system/loanData.ts"
 
 export const Route = createFileRoute("/$runnerId/_viewer/finances")({
   component: RouteComponent,
 })
 
 function RouteComponent() {
-  const endOfMonthDialog = useEndOfMonthDialog()
-
-  const netWorth = useNetWorth()
-  const nuyenBalance = useRunnerStoreSelector(Selectors.nuyen.selectNuyenAmount)
-  const loans = useRunnerStoreSelector(Selectors.nuyen.selectLoans)
-  const loansBalance = loans.reduce((sum, loan) => sum + loan.amount, 0)
-
-  const lifestyleQuality = useRunnerStoreSelector(Selectors.profile.selectLifestyleQuality) ?? LifestyleType.Street
-  const lifestyleMonthsPaid = useRunnerStoreSelector(Selectors.profile.selectLifestyleMonthsPaid) ?? 1
-  const lifestyleUpkeep = Lifestyles[lifestyleQuality].upkeep
-
-  const monthlyNuyenCost = lifestyleMonthsPaid === 0 ? lifestyleUpkeep : 0
-  const monthlyInterest = loans
-    .filter((l) => l.interestRate > 0)
-    .reduce((sum, l) => sum + calculateMonthlyInterest(l), 0)
-  const totalMonthlyExpenses = monthlyNuyenCost + monthlyInterest
-
   return (
     <Stack>
       <SectionHeader>Finances</SectionHeader>
 
-      <Stack direction="row" sx={{ alignItems: "center", justifyContent: "flex-end", gap: 1 }}>
-        <Button
-          size="small"
-          variant="outlined"
-          color="warning"
-          onClick={() => endOfMonthDialog.open()}
-        >
-          End of Month{totalMonthlyExpenses > 0 && <> — <Nuyen amount={totalMonthlyExpenses} /></>}
-        </Button>
-      </Stack>
-
-      <Grid container columns={3} spacing={1}>
-        <Grid size={1}>
-          <Stack sx={{ alignItems: "center", gap: 1, flexGrow: 1 }}>
-            <Label label="Nuyen" />
-            <Typography color={nuyenBalance < 0 ? "error.main" : "text.primary"}>
-              <Nuyen amount={nuyenBalance} />
-            </Typography>
-          </Stack>
-        </Grid>
-
-        <Grid size={1}>
-          <Stack sx={{ alignItems: "center", gap: 1, flexGrow: 1 }}>
-            <Label label="Loans" />
-            <Typography color={loansBalance > 0 ? "error.main" : "text.primary"}>
-              <Nuyen amount={loansBalance} />
-            </Typography>
-          </Stack>
-        </Grid>
-
-        <Grid size={1}>
-          <Stack sx={{ alignItems: "center", gap: 1, flexGrow: 1 }}>
-            <Label label="Net Worth" />
-            <Typography color={netWorth < 0 ? "error.main" : "text.primary"}>
-              <Nuyen amount={netWorth} />
-            </Typography>
-          </Stack>
-        </Grid>
-      </Grid>
-
-      <NuyenSection />
+      <FinancesSection />
 
       <CredstickSection />
-
-      <LoansSection />
-
-      <LifestyleSection />
-
-      {endOfMonthDialog.dialog}
     </Stack>
   )
 }


### PR DESCRIPTION
## Summary

The full-page Runner editor (`/edit/$runnerId`, `RunnerEditor`) covered every part of a Runner — profile, biology, attributes, skills, gear, contacts, etc. — except **Finances**, **Karma**, and **Reputation**. Those were only viewable in the Viewer (`about.tsx` / `finances.tsx`), and Street Cred / Notoriety had no editing path anywhere in the app at all.

- Added three new editor tabs: **Reputation**, **Karma**, **Finances** (`BuilderSectionId.reputation/karma/finances`), wired into `RunnerEditor`'s tab map and nav.
- **Reputation** is a new form for Street Cred, Notoriety, and the Public Awareness modifier, backed by new `setStreetCred`/`setNotoriety` profile actions (previously there was no action to set either value) and a shared `selectPublicAwareness` selector (extracted from a formula that was previously inlined only in `about.tsx`).
- **Karma** and **Finances** reuse the existing Viewer components (`KarmaSection`, `NuyenSection`, `LoansSection`, `LifestyleSection`) — they already worked against the shared `RunnerStoreContext`, so no new state plumbing was needed.
- Extracted the `finances.tsx` route body into a shared `FinancesSection` component so the Viewer page and the new editor tab don't duplicate the net-worth/monthly-expense calculations. `CredstickSection` was left out of the shared component (and only rendered by the Viewer route) since it navigates to `/$runnerId/item/$itemId`, which would exit the in-progress edit unexpectedly.
- These tabs are only added to the tabbed `RunnerEditor` (post-creation edit), not the single-scroll `RunnerBuilder` (character creation) — creation-time nuyen/karma/reputation aren't meaningful yet at that point.

## Test plan

- [x] `yarn tsc` — no errors
- [x] `yarn eslint` — no errors
- [x] `yarn vitest run` — full suite passes (973 tests), including new tests for the reducer actions, the `selectPublicAwareness` selector, and each new builder section
- [x] Manually verified in the browser (dev server + Playwright) against the `Artemis` fixture: Reputation, Karma, and Finances tabs all appear in the editor nav and render live data correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_01KBo31M7KcuXdqc7FMjSqve)_