### PR TITLE
Matrix interactions design: CONTEXT.md, ADR, and feature doc

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -187,8 +187,8 @@ _Avoid_: creature, critter (same reasoning as Spirit)
 **Entity**:
 The umbrella term for anything with a stat block, ratings, or effects it can contribute — a
 stat-bearing thing, not just carried equipment. Covers **Item**, **Quality**, **Spell**,
-**Complex Form**, **Adept Power**, **Drug** _(planned)_, **Spirit**, **Sprite**, and **Agent**
-_(planned)_.
+**Complex Form**, **Adept Power**, **Drug** _(planned)_, **Spirit**, **Sprite**, **Agent**
+_(planned)_, and **MatrixNode**.
 _Avoid_: GameEntity (redundant with this term); Object (too broad/generic); Data (reserved for
 the `*Data` DTO suffix convention — see RunnerData)
 
@@ -273,16 +273,24 @@ already mirror Attribute + Skill tests structurally. `RunnerData.attributes` and
 `selectAttrValue` return `0` for a key that's absent or not computable for that subject (e.g.
 asking a Runner for Firewall).
 
-**Entity Matrix Presence** _(`EntityData.matrix?: { attr: Partial<MatrixAttrs> }`)_:
-Almost every **Entity** — not just `Item` — can be present in the matrix. By default this is a
+**Entity Matrix Presence** _(`EntityData.matrix?: true | MatrixStats`)_:
+Almost every **Entity** — not just `Item` — can be present in the matrix. `matrix: true` is a
 "simplified" presence: all four `MatrixAttrs` resolve to the Entity's own **Rating**, with no
 separate data stored (avoids a value that could drift out of sync after the Entity's Rating
-changes). Setting one or more keys in `attr` overrides just those stats for that Entity — a
-"fully specced" presence. **Commlink** is the canonical fully-specced case: its four stats are
-independently set via `attr`, not derived from a Rating.
-_Avoid_: MatrixNode, Node (as code identifiers for this field — reserved for user-facing copy
-only; see below for the still-open question of whether standalone hackable hosts are a separate
-type from this field)
+changes). `matrix: MatrixStats` (a `Partial<MatrixAttrs>`) is a "fully specced" presence — set
+keys override that stat, unset keys still fall back to Rating. `undefined` means the Entity has
+no matrix presence at all. **Commlink** is the canonical fully-specced case. **MatrixNode**
+(below) is always fully specced, by definition.
+
+**MatrixNode** _(displayed as "Node")_:
+A hackable system in the matrix — a corp server, security system, or other host a Runner can
+connect to and gain an account on. It is itself an **Entity** (added to the list under
+**Entity**, below), not a field bolted onto some other Entity — its `matrix` is always a
+`MatrixStats` value, since being a matrix presence is its entire purpose. User-facing copy and
+rulebook references say "Node"; the code identifier is `MatrixNode` to avoid colliding with the
+DOM global `Node` (same naming-collision class as `RunnerData` vs. `CharacterData` — see
+`RunnerData` above).
+_Avoid_: Node (as a code identifier — reserved for user-facing copy only), Host
 
 **Commlink**:
 A Runner's personal matrix device and network hub. Has four hardware stats — **Response**,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -184,21 +184,12 @@ A matrix being compiled by a Technomancer. Analogous to a Spirit in the matrix d
 own stat block, Level rating, and Services owed. Requires a **StatusSheet**.
 _Avoid_: creature, critter (same reasoning as Spirit)
 
-**Agent**:
-An autonomous matrix construct, structurally analogous to a Spirit/Sprite (its own Entity, own
-`rating`, requires a **StatusSheet**) rather than an owned `Item` like **Program**, even though a
-Player interacts with both the same way (loaded onto a device, run as a copy on a `MatrixNode`).
-Its single `rating` doubles as Pilot, System, Firewall, and the Skill side of any dice pool it
-rolls — an Agent has no separate skill list. Its Response and Signal are never its own; they're
-resolved live from whichever `MatrixNode` it's currently running on (see **Entity Matrix
-Presence**).
-_Avoid_: bot, program (Program is a distinct, simpler Item type — see below)
-
 **Entity**:
 The umbrella term for anything with a stat block, ratings, or effects it can contribute — a
 stat-bearing thing, not just carried equipment. Covers **Item**, **Quality**, **Spell**,
-**Complex Form**, **Adept Power**, **Drug** _(planned)_, **Spirit**, **Sprite**, **Agent**, and
-**MatrixNode**.
+**Complex Form**, **Adept Power**, **Drug** _(planned)_, **Spirit**, **Sprite**, and
+**MatrixNode**. (**Program** and **Agent** are `Item` subtypes, not separate entries in this
+list — see below.)
 _Avoid_: GameEntity (redundant with this term); Object (too broad/generic); Data (reserved for
 the `*Data` DTO suffix convention — see RunnerData)
 
@@ -337,7 +328,7 @@ opposed to simulating hacking tests or matrix combat. Holds:
 - `knownNodes: KnownNode[]` — every `MatrixNode` the Runner currently has some access to
 - `activeNodeId` — which Known Node the Runner is presently working in; every other Known Node is
   informally a "subscription" (nothing marks them separately — non-active is the only distinction)
-- `runningInstances` — running copies of Programs/Agents (see **Running Instance**)
+- `activePrograms` — running copies of Programs/Agents (see **ActiveProgram**, below)
 
 Cleared by the Player-triggered **Clear Matrix Session** action (start of a new run), not
 automatically. `RunnerData.gameState` is a new top-level namespace intended to eventually hold
@@ -350,15 +341,9 @@ field) since a Known Node only ever exists inside **Matrix Game State** today.
 _Avoid_: Subscribed Node (there's no separate subscribed-nodes list — every Known Node other than
 the Active Node is one)
 
-**Running Instance**:
-A running copy of a Program or Agent on a `MatrixNode` — `{ sourceId, nodeId }`, referencing the
-owned Program/Agent Entity and the Known Node hosting it. Multiple copies of the same source can
-run at once; each consumes one **Processor Limit** slot on its Node. Requires at least `user`
-**Access Level** on that Node to start.
-
 **Clear Matrix Session**:
 A Player-triggered action (parallel to **End of Month**) that wipes `gameState.matrix` —
-`knownNodes` and `runningInstances` — at the start of a new run.
+`knownNodes` and `activePrograms` — at the start of a new run.
 
 **Commlink**:
 A Runner's personal matrix device and network hub. Has four hardware stats — **Response**,
@@ -368,8 +353,25 @@ Stored as an Item with `ItemType.device`. May have Programs loaded onto it as At
 **Program**:
 Software loaded onto a Commlink. Used in matrix tests the same way Active Skills are used in
 physical tests — e.g. `Response + Analyze` forms a valid dice pool. A Commlink has a limited
-number of program slots determined by its System rating.
+number of program slots determined by its System rating. An owned Program can be run as an
+**ActiveProgram** on a `MatrixNode` (see below).
 _Avoid_: app, software (software is the broader category; Program is the matrix-test-relevant subtype)
+
+**Agent**:
+An `Item` subtype of **Program** (`Entity → Item → Program → Agent`) — an autonomous matrix
+construct, not just loaded software. Like **Vehicle**, being an `Item` doesn't exclude requiring
+a **StatusSheet**: Agent gets one, the same way Vehicle does. Its single `rating` doubles as
+Pilot, System, Firewall, and the Skill side of any dice pool it rolls — an Agent has no separate
+skill list. Its Response and Signal are never its own; they're resolved live from whichever
+`MatrixNode` currently hosts it as an **ActiveProgram** (see **Entity Matrix Presence**).
+_Avoid_: bot
+
+**ActiveProgram**:
+A running copy of a Program or Agent on a `MatrixNode` — `{ sourceId, nodeId }`, referencing the
+owned Program/Agent `Item` and the Known Node hosting it. Multiple copies of the same source can
+run at once; each consumes one **Processor Limit** slot on its Node. Requires at least `user`
+**Access Level** on that Node to start.
+_Avoid_: Running Instance (earlier working name)
 
 **Matrix Test**:
 A dice pool test using a Commlink stat (Response, System, Firewall, or Signal) combined with a

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -264,12 +264,25 @@ concentration. Linked to a specific spell via `slottedSpellId`; the spell catego
 slotted spell still appears in the Runner's spell list.
 _Avoid_: spell holder
 
-**MatrixNode** _(displayed as "Node")_:
-A hackable system in the matrix — a corp server, security system, or other host a Runner can
-connect to and gain an account on. User-facing copy and rulebook references say "Node"; the code
-identifier is `MatrixNode` to avoid colliding with the DOM global `Node` (same naming-collision
-class as `RunnerData` vs. `CharacterData` — see `RunnerData` above).
-_Avoid_: Node (as a code identifier — reserved for user-facing copy only), Host
+**MatrixAttrs**:
+The four matrix-test stats — Firewall, Response, Signal, System — that substitute for Attributes
+in Matrix Tests (see **Commlink**, **Matrix Test**). Added as members of the same `AttributeKey`
+enum used for Runner attributes (BOD, AGI, …), rather than a separate enum, since Matrix Tests
+already mirror Attribute + Skill tests structurally. `RunnerData.attributes` and any
+`MatrixAttrs`-bearing bag are both `Partial<Record<AttributeKey, number>>`; `selectAttrBase` and
+`selectAttrValue` return `0` for a key that's absent or not computable for that subject (e.g.
+asking a Runner for Firewall).
+
+**Entity Matrix Presence** _(`EntityData.matrix?: { attr: Partial<MatrixAttrs> }`)_:
+Almost every **Entity** — not just `Item` — can be present in the matrix. By default this is a
+"simplified" presence: all four `MatrixAttrs` resolve to the Entity's own **Rating**, with no
+separate data stored (avoids a value that could drift out of sync after the Entity's Rating
+changes). Setting one or more keys in `attr` overrides just those stats for that Entity — a
+"fully specced" presence. **Commlink** is the canonical fully-specced case: its four stats are
+independently set via `attr`, not derived from a Rating.
+_Avoid_: MatrixNode, Node (as code identifiers for this field — reserved for user-facing copy
+only; see below for the still-open question of whether standalone hackable hosts are a separate
+type from this field)
 
 **Commlink**:
 A Runner's personal matrix device and network hub. Has four hardware stats — **Response**,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -320,16 +320,45 @@ Processor Limit, rounded down) drops the Node's effective Response by 1. E.g. Pr
 Response −1 at 3 programs running, −2 at 6, −3 at 9.
 
 **Subscription Limit**:
-The cap on how many `MatrixNode`s a Runner can hold a **Subscribed Node** entry for at once.
-Equal to the System rating of whichever Commlink the Runner is currently running their persona
-from.
+The cap on how many `MatrixNode`s a Runner can hold a **Known Node** entry for at once (see
+**Matrix Game State**). Equal to the System rating of whichever Commlink the Runner is currently
+running their persona from.
 
-**Subscribed Node**:
-A quick-reference entry in a Runner's matrix game state for a `MatrixNode` they currently have
-access to — the Node's ratings and the access level the Runner holds there. Player-maintained
-(not derived from simulating a hacking test this pass); cleared at the start of a new run. One
-Subscribed Node can be flagged as the **Active Node** — the one the Runner is currently working
-in.
+**Access Level** (`none` | `user` | `security` | `admin`):
+How much access a Runner has on a given `MatrixNode`. Contributes to the (display-only) hacking
+threshold as an offset: `user` +0, `security` +3, `admin` +6; `none` means no account at all yet.
+Player-set directly on a **Known Node** entry — this pass doesn't simulate the hacking test
+itself (Hacking on the Fly / Probing), just tracks the outcome and displays the threshold
+(`Firewall + (System if Probing) + Access Level offset`) as a reference number.
+
+**Matrix Game State** (`RunnerData.gameState.matrix`):
+The Player-facing matrix session-management state — the helper-tools scope of this feature, as
+opposed to simulating hacking tests or matrix combat. Holds:
+- `knownNodes: KnownNode[]` — every `MatrixNode` the Runner currently has some access to
+- `activeNodeId` — which Known Node the Runner is presently working in; every other Known Node is
+  informally a "subscription" (nothing marks them separately — non-active is the only distinction)
+- `runningInstances` — running copies of Programs/Agents (see **Running Instance**)
+
+Cleared by the Player-triggered **Clear Matrix Session** action (start of a new run), not
+automatically. `RunnerData.gameState` is a new top-level namespace intended to eventually hold
+other in-play state beyond matrix (nothing else lives there yet).
+
+**Known Node**:
+`MatrixNodeData & { accessLevel: AccessLevel }` — a `MatrixNode` the Runner currently has some
+access to, flattened with the Access Level onto one record (not wrapped in a separate `node`
+field) since a Known Node only ever exists inside **Matrix Game State** today.
+_Avoid_: Subscribed Node (there's no separate subscribed-nodes list — every Known Node other than
+the Active Node is one)
+
+**Running Instance**:
+A running copy of a Program or Agent on a `MatrixNode` — `{ sourceId, nodeId }`, referencing the
+owned Program/Agent Entity and the Known Node hosting it. Multiple copies of the same source can
+run at once; each consumes one **Processor Limit** slot on its Node. Requires at least `user`
+**Access Level** on that Node to start.
+
+**Clear Matrix Session**:
+A Player-triggered action (parallel to **End of Month**) that wipes `gameState.matrix` —
+`knownNodes` and `runningInstances` — at the start of a new run.
 
 **Commlink**:
 A Runner's personal matrix device and network hub. Has four hardware stats — **Response**,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -184,11 +184,21 @@ A matrix being compiled by a Technomancer. Analogous to a Spirit in the matrix d
 own stat block, Level rating, and Services owed. Requires a **StatusSheet**.
 _Avoid_: creature, critter (same reasoning as Spirit)
 
+**Agent**:
+An autonomous matrix construct, structurally analogous to a Spirit/Sprite (its own Entity, own
+`rating`, requires a **StatusSheet**) rather than an owned `Item` like **Program**, even though a
+Player interacts with both the same way (loaded onto a device, run as a copy on a `MatrixNode`).
+Its single `rating` doubles as Pilot, System, Firewall, and the Skill side of any dice pool it
+rolls — an Agent has no separate skill list. Its Response and Signal are never its own; they're
+resolved live from whichever `MatrixNode` it's currently running on (see **Entity Matrix
+Presence**).
+_Avoid_: bot, program (Program is a distinct, simpler Item type — see below)
+
 **Entity**:
 The umbrella term for anything with a stat block, ratings, or effects it can contribute — a
 stat-bearing thing, not just carried equipment. Covers **Item**, **Quality**, **Spell**,
-**Complex Form**, **Adept Power**, **Drug** _(planned)_, **Spirit**, **Sprite**, **Agent**
-_(planned)_, and **MatrixNode**.
+**Complex Form**, **Adept Power**, **Drug** _(planned)_, **Spirit**, **Sprite**, **Agent**, and
+**MatrixNode**.
 _Avoid_: GameEntity (redundant with this term); Object (too broad/generic); Data (reserved for
 the `*Data` DTO suffix convention — see RunnerData)
 
@@ -282,6 +292,11 @@ keys override that stat, unset keys still fall back to Rating. `undefined` means
 no matrix presence at all. **Commlink** is the canonical fully-specced case. **MatrixNode**
 (below) is always fully specced, by definition.
 
+Response and Signal are a special case for anything *running on* a `MatrixNode` (a loaded
+**Program**, a running **Agent**): those two stats are never stored on the running thing itself —
+they're resolved live from whichever Node currently hosts it. Only System/Firewall (and, for
+Agent, its Pilot/Skill use) come from the running thing's own rating.
+
 **MatrixNode** _(displayed as "Node")_:
 A hackable system in the matrix — a corp server, security system, or other host a Runner can
 connect to and gain an account on. It is itself an **Entity** (added to the list under
@@ -300,6 +315,21 @@ difference between the two.
 The cap on programs a `MatrixNode` can run simultaneously, mirroring the existing rule that a
 Commlink's loaded programs are capped by its System rating (`docs/features/0005-matrix-programs.md`).
 Formula depends on **Node Type**: `General` = System rating; `Nexus` = System rating × 3.
+Exceeding it isn't a hard block — every multiple of the Processor Limit reached (running count ÷
+Processor Limit, rounded down) drops the Node's effective Response by 1. E.g. Processor Limit 3:
+Response −1 at 3 programs running, −2 at 6, −3 at 9.
+
+**Subscription Limit**:
+The cap on how many `MatrixNode`s a Runner can hold a **Subscribed Node** entry for at once.
+Equal to the System rating of whichever Commlink the Runner is currently running their persona
+from.
+
+**Subscribed Node**:
+A quick-reference entry in a Runner's matrix game state for a `MatrixNode` they currently have
+access to — the Node's ratings and the access level the Runner holds there. Player-maintained
+(not derived from simulating a hacking test this pass); cleared at the start of a new run. One
+Subscribed Node can be flagged as the **Active Node** — the one the Runner is currently working
+in.
 
 **Commlink**:
 A Runner's personal matrix device and network hub. Has four hardware stats — **Response**,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -292,6 +292,15 @@ DOM global `Node` (same naming-collision class as `RunnerData` vs. `CharacterDat
 `RunnerData` above).
 _Avoid_: Node (as a code identifier — reserved for user-facing copy only), Host
 
+**Node Type** (`General` | `Nexus`):
+Determines a `MatrixNode`'s **Processor Limit** formula and nothing else — no other mechanical
+difference between the two.
+
+**Processor Limit**:
+The cap on programs a `MatrixNode` can run simultaneously, mirroring the existing rule that a
+Commlink's loaded programs are capped by its System rating (`docs/features/0005-matrix-programs.md`).
+Formula depends on **Node Type**: `General` = System rating; `Nexus` = System rating × 3.
+
 **Commlink**:
 A Runner's personal matrix device and network hub. Has four hardware stats — **Response**,
 **System**, **Firewall**, and **Signal** — that substitute for attributes in matrix tests.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -264,6 +264,13 @@ concentration. Linked to a specific spell via `slottedSpellId`; the spell catego
 slotted spell still appears in the Runner's spell list.
 _Avoid_: spell holder
 
+**MatrixNode** _(displayed as "Node")_:
+A hackable system in the matrix — a corp server, security system, or other host a Runner can
+connect to and gain an account on. User-facing copy and rulebook references say "Node"; the code
+identifier is `MatrixNode` to avoid colliding with the DOM global `Node` (same naming-collision
+class as `RunnerData` vs. `CharacterData` — see `RunnerData` above).
+_Avoid_: Node (as a code identifier — reserved for user-facing copy only), Host
+
 **Commlink**:
 A Runner's personal matrix device and network hub. Has four hardware stats — **Response**,
 **System**, **Firewall**, and **Signal** — that substitute for attributes in matrix tests.

--- a/docs/adr/0012-matrix-entity-model.md
+++ b/docs/adr/0012-matrix-entity-model.md
@@ -1,0 +1,30 @@
+# Matrix stats and entities reuse the existing Attribute/Item systems
+
+Matrix Tests (`Response`/`System`/`Firewall`/`Signal` + Program rating) already mirror
+`Attribute + Skill` tests structurally, so rather than building a parallel stat/resolver system
+for `MatrixNode` and other matrix-capable Entities, we extended `AttributeKey` with the four
+matrix stats and made every attribute bag (`RunnerData.attributes`, and any Entity's matrix
+stats) `Partial<Record<AttributeKey, number>>`, with `selectAttrBase`/`selectAttrValue`
+defaulting absent/inapplicable keys to `0`. This lets Matrix Tests reuse the existing dice-pool
+and `GameEffect` machinery end-to-end, answering the open question left in
+`docs/features/0005-matrix-programs.md` about whether matrix tests need their own resolver.
+
+Similarly, `Agent` was deliberately placed as an `Item` subtype (`Entity → Item → Program →
+Agent`) rather than a standalone Entity alongside `Spirit`/`Sprite`, even though it's
+autonomous and requires a `StatusSheet` like they do — `Vehicle` already proves "is an Item" and
+"requires a StatusSheet" aren't exclusive. This keeps Agent inside the existing Item/gear
+tooling (lists, forms, `ItemType` dispatch) instead of introducing a fourth storage location for
+stat-bearing things.
+
+## Consequences
+
+- `RunnerData.attributes` moves from a fully-populated `Record` to a `Partial<Record>` — a
+  type-level breaking change for any code assuming every key is present. No data migration is
+  needed (existing persisted Runners already populate all 12 original keys); this is a call-site
+  audit, not a schema change.
+- An Entity's simplified matrix presence (`matrix: true`) derives its four stats from the
+  Entity's own Rating live, rather than storing a snapshot — avoids drift after the Entity's
+  Rating changes, at the cost of nothing being a plain stored number for the simple case.
+- Response/Signal for a running `ActiveProgram` (Program or Agent) are resolved from its current
+  host `MatrixNode`, never from the Program/Agent's own data — this is a resolver-level rule, not
+  something visible in either type's shape.

--- a/docs/features/0005-matrix-programs.md
+++ b/docs/features/0005-matrix-programs.md
@@ -27,8 +27,10 @@ and matrix test dice pool calculations are not yet implemented.
       structure, or use a distinct formula?
 - [ ] **Matrix test UI** — where does a Player roll a matrix test? On the Commlink's StatusSheet,
       or inline on the main Viewer?
-- [ ] **GameEffect integration** — should Program ratings feed into the GameEffect system as
-      `dicePoolMod` entries, or does the matrix test system use its own resolver?
+- [x] **GameEffect integration** — resolved by `docs/features/0014-matrix-interactions.md`:
+      `Response`/`System`/`Firewall`/`Signal` are literal `AttributeKey` entries now, so Matrix
+      Tests reuse the existing Attribute/`GameEffect` dice-pool machinery rather than a separate
+      resolver. The dice pool computation itself is still not implemented.
 
 ## Constraints
 
@@ -57,3 +59,6 @@ and matrix test dice pool calculations are not yet implemented.
   StatusSheet (matrix damage track lives here)
 - [`docs/features/0006-game-effect-resolution-model.md`](./0006-game-effect-resolution-model.md)
   — how Program ratings feed into dice pools
+- [`docs/features/0014-matrix-interactions.md`](./0014-matrix-interactions.md) — Nodes, Agents,
+  and the Matrix tab helper tools; establishes the shared `MatrixAttrs`/`AttributeKey` plumbing
+  this feature's dice pools will run on

--- a/docs/features/0014-matrix-interactions.md
+++ b/docs/features/0014-matrix-interactions.md
@@ -1,0 +1,141 @@
+# Matrix Interactions
+
+> **Status:** Draft
+>
+> **GitHub Issues / PRs:**
+> <!-- Add links once the feature is ready to implement. A feature may have multiple. -->
+
+Player-facing helper tools for managing Matrix presence during a run: an active `MatrixNode`,
+a roster of Known Nodes, running Programs/Agents, and a Matrix Actions cheatsheet — on the
+existing Matrix tab (`src/routes/$runnerId/_viewer/matrix.tsx`). This pass is explicitly
+bookkeeping, not simulation: it does not compute Matrix Test dice pools, run the Hacking on the
+Fly/Probing extended tests, or model matrix combat. It establishes the entity model (`MatrixNode`,
+`Program`/`Agent` as `Item` subtypes, the shared Matrix attribute system) that a later pass can
+build real dice-pool computation on top of.
+
+## Open Questions
+
+- [ ] **Cheatsheet content** — what exact list of Matrix Actions (with descriptions/formulas)
+      belongs on the cheatsheet, and is it static copy or does any of it read live Node/Runner
+      values?
+- [ ] **`ItemType.software` vs `ItemType.program`** — carried over from
+      `docs/features/0005-matrix-programs.md`, still unresolved; doesn't block this feature since
+      Program's own shape isn't changing, just gaining Agent as a subtype.
+- [ ] **Complex Forms** — do Technomancer Complex Forms participate in `ActiveProgram` the same
+      way Agents do, or are they out of scope for this pass? Not addressed in this design round.
+- [ ] **Matrix tab layout** — exact placement/ordering of the Active Node panel, Known Nodes
+      list, Programs/Agents lists, and cheatsheet on the existing Matrix tab.
+- [ ] **Agent StatusSheet contents** — beyond `rating` and a Matrix damage track, does Agent need
+      anything else in its stat block (e.g. does it ever act independently of being an
+      `ActiveProgram`)?
+
+## Constraints
+
+- `AttributeKey` gains `firewall`, `response`, `signal`, `system`. `RunnerData.attributes` and
+  any Entity's matrix-stats bag both become `Partial<Record<AttributeKey, number>>`;
+  `selectAttrBase`/`selectAttrValue` return `0` for an absent or inapplicable key. See
+  `docs/adr/0012-matrix-entity-model.md`.
+- `EntityData.matrix?: true | MatrixStats` needs threading through every Entity kind that can
+  have a matrix presence. `true` derives all four stats from the Entity's own **Rating**;
+  `MatrixStats` (`Partial<MatrixAttrs>`) overrides specific keys, falling back to Rating for the
+  rest.
+- `MatrixNode` is a new top-level Entity kind (not an `Item`) — needs its own `MatrixNodeData`
+  type, wherever Entity kinds are enumerated/switched over.
+- `Program` (existing `ItemType.program`) gains `Agent` as a subtype (`Entity → Item → Program →
+  Agent`). Agent requires a `StatusSheet`, following the `Vehicle` precedent that being an `Item`
+  doesn't preclude one. Agent's `rating` serves as Pilot/System/Firewall/Skill; its Response/Signal
+  resolve live from whichever `MatrixNode` currently hosts it as an `ActiveProgram` — this is
+  resolver logic, not a stored field.
+- `RunnerData.gameState` is a brand-new top-level namespace; `gameState.matrix` is its only
+  member so far. Needs a migration adding the default empty shape.
+- Existing Matrix tab pieces (damage track via `Selectors.damage.selectMatrixTrack`, the Programs
+  list via `MatrixProgramsSection`) are the extension points — reuse, don't replace.
+- Access Level and hacking thresholds are Player-set/display-only this pass — no Extended Test
+  wiring, no dice pool computation.
+
+## Domain Notes
+
+New/changed `CONTEXT.md` terms (full definitions there): **MatrixAttrs**, **Entity Matrix
+Presence**, **MatrixNode**, **Node Type**, **Processor Limit**, **Subscription Limit**, **Access
+Level**, **Matrix Game State**, **Known Node**, **ActiveProgram**, **Clear Matrix Session**,
+**Agent** (revised — now an `Item`/`Program` subtype, not a standalone Entity).
+
+## Rough Interface Sketches
+
+_High-level shapes only — no implementation code._
+
+```ts
+// AttributeKey gains four members (existing enum, see src/system/attributeKey.ts)
+enum AttributeKey {
+  // ...existing Runner attributes
+  firewall = "firewall",
+  response = "response",
+  signal = "signal",
+  system = "system",
+}
+
+type MatrixStats = Partial<Record<AttributeKey, number>> // conceptually restricted to the 4 matrix keys
+
+interface EntityData {
+  // ...existing fields
+  matrix?: true | MatrixStats
+}
+
+enum NodeType { general = "general", nexus = "nexus" }
+
+interface MatrixNodeData extends EntityData {
+  id: string
+  name: string
+  rating: number
+  matrix: MatrixStats // MatrixNode is always fully specced
+  nodeType: NodeType
+}
+
+enum AccessLevel { none = "none", user = "user", security = "security", admin = "admin" }
+
+type KnownNode = MatrixNodeData & { accessLevel: AccessLevel }
+
+interface ActiveProgram {
+  sourceId: string // id of an owned Program or Agent Item
+  nodeId: string   // id of a KnownNode
+}
+
+interface MatrixGameState {
+  knownNodes: KnownNode[]
+  activeNodeId?: string
+  activePrograms: ActiveProgram[]
+}
+
+interface RunnerData {
+  // ...existing fields
+  gameState: {
+    matrix: MatrixGameState
+  }
+}
+
+// Agent: Item subtype of Program
+interface AgentData extends ProgramData {
+  damage: { matrix: number } // Matrix Damage Track, per CONTEXT.md
+  // rating (inherited) doubles as Pilot / System / Firewall / Skill
+}
+```
+
+## Out of Scope
+
+- Simulating Hacking on the Fly / Probing as Extended Tests (thresholds are displayed, not rolled)
+- Matrix Test dice pool computation generally (deferred; this pass only establishes the shared
+  attribute plumbing it will need)
+- Full matrix combat (IC, trace, black ice) — same exclusion as `docs/features/0005-matrix-programs.md`
+- Device modes (Active/Passive/Hidden) — deferred to a later pass
+- Technomancer Complex Forms' relationship to `ActiveProgram` (open question above)
+
+## Related Features
+
+- [`docs/features/0005-matrix-programs.md`](./0005-matrix-programs.md) — Matrix Programs & Matrix
+  Tests; this feature's `MatrixAttrs`/`ActiveProgram` groundwork directly informs that doc's open
+  "GameEffect integration" question (answered: Node/Program ratings are literal `AttributeKey`
+  entries, so no separate resolver is needed) but doesn't implement the dice pool itself
+- [`docs/features/0008-entity-status-sheets.md`](./0008-entity-status-sheets.md) — Agent's
+  StatusSheet follows the same pattern established there for Spirit/Sprite/Vehicle
+- [`docs/adr/0012-matrix-entity-model.md`](../adr/0012-matrix-entity-model.md) — the attribute
+  unification and Agent-as-Item decisions this feature is built on


### PR DESCRIPTION
## Summary

Design-only PR (no implementation code) resulting from a domain-modeling "grilling" session with
the repo owner on Matrix interactions support (Nodes, Hacking, Devices/Programs/Agents), per
`docs/adr/0003-feature-docs-as-source-of-truth.md`'s workflow: this PR is the `docs/features/`
deliverable a human would later run `/to-prd` against, not the implementation itself.

- **`CONTEXT.md`**: defines `MatrixAttrs`, Entity Matrix Presence (`EntityData.matrix?: true |
  MatrixStats`), `MatrixNode` (a new Entity kind; code identifier avoids colliding with the DOM
  global `Node`), `Node Type`/`Processor Limit`, `Subscription Limit`, `Access Level`, `Matrix
  Game State` (`RunnerData.gameState.matrix`), `Known Node`, `ActiveProgram`, `Clear Matrix
  Session`, and revises `Agent` to be an `Item`/`Program` subtype (`Entity → Item → Program →
  Agent`) rather than a standalone Entity.
- **`docs/adr/0012-matrix-entity-model.md`**: records why Matrix stats reuse the existing
  `AttributeKey`/attribute-bag system instead of a bespoke resolver, and why Agent is an `Item`
  subtype rather than a Spirit/Sprite-style standalone Entity.
- **`docs/features/0014-matrix-interactions.md`**: the feature doc — constraints, rough interface
  sketches, and remaining open questions (cheatsheet content, `ItemType.software` vs `.program`,
  Complex Forms' relationship to `ActiveProgram`, exact tab layout) for a future PRD/implementation
  pass.
- Cross-references and resolves an open question in the existing
  `docs/features/0005-matrix-programs.md`.

This pass is scoped to Player-facing helper tools (an active Node, known Nodes, running
Programs/Agents, a cheatsheet) — it explicitly does not simulate Hacking on the Fly/Probing as
Extended Tests or compute Matrix Test dice pools; see the feature doc's Out of Scope section.

## Test plan

- [x] No code changes — this PR is glossary/ADR/feature-doc only
- [ ] Follow-up implementation PR(s) will add unit tests once a PRD Issue is generated from the
      feature doc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ukv2nngEoktpmp3KwdezCN)_