### PR TITLE
Rename ItemDataCard dispatcher to AnyItemCard (ADR-0010)

### DIFF
--- a/src/components/builder/sections/gear/generic/itemsList.tsx
+++ b/src/components/builder/sections/gear/generic/itemsList.tsx
@@ -5,7 +5,7 @@ import Stack from "@mui/material/Stack"
 import { RiAddLine } from "@remixicon/react"
 import type { FC } from "react"
 
-import { ItemDataCard } from "#/components/itemCard/itemDataCard.tsx"
+import { AnyItemCard } from "#/components/itemCard/anyItemCard.tsx"
 import { useItemFormDialog } from "#/components/items/dialogs/itemFormDialog.tsx"
 import { isNewItem } from "#/lib/stores/runner/gear/gearSlice.actions.ts"
 import { Actions } from "#/lib/stores/runner/runnerStore.actions.ts"
@@ -43,7 +43,7 @@ export const ItemsList: FC<ItemsListProps> = ({ itemLabel = "Item", itemType, it
   return (
     <Stack sx={{ gap: 1 }}>
       {topLevelItems.map((item) => (
-        <ItemDataCard
+        <AnyItemCard
           key={item.id}
           item={item}
           onOpen={() => handleEdit(item)}

--- a/src/components/builder/sections/gear/weapons/weaponsList.tsx
+++ b/src/components/builder/sections/gear/weapons/weaponsList.tsx
@@ -3,9 +3,9 @@ import Stack from "@mui/material/Stack"
 import { RiAddLine } from "@remixicon/react"
 import type { FC } from "react"
 
-import { AnyItemCard } from "#/components/itemCard/anyItemCard.tsx"
 import { useItemFormDialog } from "#/components/items/dialogs/itemFormDialog.tsx"
 import { useWeaponFormDialog } from "#/components/items/types/weapons/dialogs/weaponFormDialog.tsx"
+import { WeaponDataCard } from "#/components/items/types/weapons/weaponDataCard.tsx"
 import { useGearByType } from "#/lib/hooks/items/gearHooks.ts"
 import { isNewItem } from "#/lib/stores/runner/gear/gearSlice.actions.ts"
 import { Actions } from "#/lib/stores/runner/runnerStore.actions.ts"
@@ -33,7 +33,7 @@ export const WeaponsList: FC = () => {
   return (
     <Stack sx={{ gap: 1 }}>
       {topLevelWeapons.map((weapon) => (
-        <AnyItemCard key={weapon.id} item={weapon} onOpen={() => handleEditWeapon(weapon)} />
+        <WeaponDataCard key={weapon.id} weapon={weapon} onOpen={() => handleEditWeapon(weapon)} />
       ))}
 
       <Button

--- a/src/components/builder/sections/gear/weapons/weaponsList.tsx
+++ b/src/components/builder/sections/gear/weapons/weaponsList.tsx
@@ -3,7 +3,7 @@ import Stack from "@mui/material/Stack"
 import { RiAddLine } from "@remixicon/react"
 import type { FC } from "react"
 
-import { ItemDataCard } from "#/components/itemCard/itemDataCard.tsx"
+import { AnyItemCard } from "#/components/itemCard/anyItemCard.tsx"
 import { useItemFormDialog } from "#/components/items/dialogs/itemFormDialog.tsx"
 import { useWeaponFormDialog } from "#/components/items/types/weapons/dialogs/weaponFormDialog.tsx"
 import { useGearByType } from "#/lib/hooks/items/gearHooks.ts"
@@ -33,7 +33,7 @@ export const WeaponsList: FC = () => {
   return (
     <Stack sx={{ gap: 1 }}>
       {topLevelWeapons.map((weapon) => (
-        <ItemDataCard key={weapon.id} item={weapon} onOpen={() => handleEditWeapon(weapon)} />
+        <AnyItemCard key={weapon.id} item={weapon} onOpen={() => handleEditWeapon(weapon)} />
       ))}
 
       <Button

--- a/src/components/itemCard/anyItemCard.test.tsx
+++ b/src/components/itemCard/anyItemCard.test.tsx
@@ -10,7 +10,7 @@ import { runnerDataFactory } from "#/system/runnerData.factory.ts"
 import { SkillKey } from "#/system/skills/skillKey.ts"
 import { renderWithProviders, ThemeWrapper } from "#testUtils/renderUtils.tsx"
 
-import { ItemDataCard } from "./itemDataCard.tsx"
+import { AnyItemCard } from "./anyItemCard.tsx"
 
 const weapon: WeaponData = {
   id: "00000000-0000-0000-0000-000000000001",
@@ -24,9 +24,9 @@ const weapon: WeaponData = {
 const runnerStoreWithWeapon = () =>
   new RunnerDataStore(runnerDataFactory((runner) => ({ ...runner, gear: { [weapon.id]: weapon } })))
 
-describe("ItemDataCard", () => {
+describe("AnyItemCard", () => {
   it("dispatches weapons to WeaponDataCard", () => {
-    renderWithProviders(<ItemDataCard item={weapon} />, { runnerStore: runnerStoreWithWeapon() })
+    renderWithProviders(<AnyItemCard item={weapon} />, { runnerStore: runnerStoreWithWeapon() })
 
     expect(screen.getByText("Ares Predator V")).toBeDefined()
     expect(screen.getByText("DV: 8P")).toBeDefined()
@@ -39,14 +39,14 @@ describe("ItemDataCard", () => {
       itemType: ItemType.other,
     }
 
-    render(<ItemDataCard item={item} />, { wrapper: ThemeWrapper })
+    render(<AnyItemCard item={item} />, { wrapper: ThemeWrapper })
 
     expect(screen.getByText("Fake SIN")).toBeDefined()
   })
 
   it("passes onOpen through to the rendered card", () => {
     const onOpen = vi.fn()
-    renderWithProviders(<ItemDataCard item={weapon} onOpen={onOpen} />, {
+    renderWithProviders(<AnyItemCard item={weapon} onOpen={onOpen} />, {
       runnerStore: runnerStoreWithWeapon(),
     })
 
@@ -57,7 +57,7 @@ describe("ItemDataCard", () => {
 
   it("passes onEdit through to the rendered card's quick-action menu", () => {
     const onEdit = vi.fn()
-    renderWithProviders(<ItemDataCard item={weapon} onEdit={onEdit} />, {
+    renderWithProviders(<AnyItemCard item={weapon} onEdit={onEdit} />, {
       runnerStore: runnerStoreWithWeapon(),
     })
 

--- a/src/components/itemCard/anyItemCard.tsx
+++ b/src/components/itemCard/anyItemCard.tsx
@@ -23,7 +23,7 @@ import { ItemType } from "#/system/itemType.ts"
 
 import { ItemDataCardRoot } from "./itemDataCardRoot.tsx"
 
-export interface ItemDataCardProps {
+export interface AnyItemCardProps {
   item: ItemData
   /** When provided, the whole card becomes tappable/keyboard-activatable and navigates to the item's details page. */
   onOpen?: () => void
@@ -40,7 +40,7 @@ export interface ItemDataCardProps {
  * cards must depend on `ItemDataCardRoot`/`DataCard` instead of this file, or
  * importing it here would create a cycle.
  */
-export const ItemDataCard: FC<ItemDataCardProps> = ({ item, onOpen, onEdit, onRemove }) => {
+export const AnyItemCard: FC<AnyItemCardProps> = ({ item, onOpen, onEdit, onRemove }) => {
   switch (item.itemType) {
     // The switch narrows `item.itemType`, not `item` itself, since ItemData
     // isn't a discriminated union of per-type interfaces; each case match

--- a/src/components/items/details/anyItemDetails.test.tsx
+++ b/src/components/items/details/anyItemDetails.test.tsx
@@ -10,7 +10,7 @@ import { runnerDataFactory } from "#/system/runnerData.factory.ts"
 import { SkillKey } from "#/system/skills/skillKey.ts"
 import { renderWithProviders } from "#testUtils/renderUtils.tsx"
 
-import { ItemDetails } from "./itemDetails.tsx"
+import { AnyItemDetails } from "./anyItemDetails.tsx"
 
 const weapon: WeaponData = {
   id: "00000000-0000-0000-0000-000000000001",
@@ -24,9 +24,9 @@ const weapon: WeaponData = {
 const runnerStoreWithWeapon = () =>
   new RunnerDataStore(runnerDataFactory((runner) => ({ ...runner, gear: { [weapon.id]: weapon } })))
 
-describe("ItemDetails", () => {
+describe("AnyItemDetails", () => {
   it("dispatches weapons to WeaponItemDetails", () => {
-    renderWithProviders(<ItemDetails item={weapon} />, { runnerStore: runnerStoreWithWeapon() })
+    renderWithProviders(<AnyItemDetails item={weapon} />, { runnerStore: runnerStoreWithWeapon() })
 
     expect(screen.getByText("Ares Predator V")).toBeDefined()
     expect(screen.getByText("DV")).toBeDefined()
@@ -40,7 +40,7 @@ describe("ItemDetails", () => {
       itemType: ItemType.other,
     }
 
-    renderWithProviders(<ItemDetails item={item} />, {
+    renderWithProviders(<AnyItemDetails item={item} />, {
       runnerStore: new RunnerDataStore(runnerDataFactory((runner) => ({ ...runner, gear: { [item.id]: item } }))),
     })
 

--- a/src/components/items/details/anyItemDetails.tsx
+++ b/src/components/items/details/anyItemDetails.tsx
@@ -27,7 +27,7 @@ import { ItemType } from "#/system/itemType.ts"
 
 import { ItemDetailsRoot } from "./itemDetailsRoot.tsx"
 
-export interface ItemDetailsProps {
+export interface AnyItemDetailsProps {
   item: ItemData
   /**
    * Remove action for item types without a typed details view (the
@@ -59,7 +59,7 @@ export interface ItemDetailsProps {
  * `AnyItemCard`. Only the fallback path needs one supplied here, via the
  * generic `useItemFormDialog()`.
  */
-export const ItemDetails: FC<ItemDetailsProps> = ({ item, onRemove, onRemoved, onOpenAttachment }) => {
+export const AnyItemDetails: FC<AnyItemDetailsProps> = ({ item, onRemove, onRemoved, onOpenAttachment }) => {
   const dispatch = useRunnerStoreDispatch()
   const itemFormDialog = useItemFormDialog()
 

--- a/src/components/items/details/itemDetails.Subitem.tsx
+++ b/src/components/items/details/itemDetails.Subitem.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react"
 
-import { ItemDataCard } from "#/components/itemCard/itemDataCard.tsx"
+import { AnyItemCard } from "#/components/itemCard/anyItemCard.tsx"
 import type { ItemData } from "#/system/itemData.ts"
 
 export interface ItemDetailsSubitemProps {
@@ -10,13 +10,13 @@ export interface ItemDetailsSubitemProps {
 }
 
 /**
- * Attached-item row for ItemDetails. Renders the full nested ItemDataCard rather
+ * Attached-item row for ItemDetails. Renders the full nested AnyItemCard rather
  * than a one-line name — attachments are themselves complete Items with
  * their own id, so the higher-fidelity details context shows them as such
  * and lets each one drill into its own details page.
  */
 export const ItemDetailsSubitem: FC<ItemDetailsSubitemProps> = ({ item, onOpen }) => (
-  <ItemDataCard item={item} onOpen={onOpen} />
+  <AnyItemCard item={item} onOpen={onOpen} />
 )
 
 ItemDetailsSubitem.displayName = "ItemDetails.Subitem"

--- a/src/components/items/details/itemDetails.tsx
+++ b/src/components/items/details/itemDetails.tsx
@@ -48,7 +48,7 @@ export interface ItemDetailsProps {
 /**
  * Renders the typed details view for `item.itemType`, falling back to
  * `ItemDetailsRoot` (common fields only, no type-specific slots) for item
- * types without one yet. Mirrors `ItemDataCard`'s dispatcher — this is the only
+ * types without one yet. Mirrors `AnyItemCard`'s dispatcher — this is the only
  * module allowed to depend on every typed details view; typed views must
  * depend on `ItemDetailsRoot`/`ItemDetailsSlot` instead of this file, or
  * importing it here would create a cycle.
@@ -56,7 +56,7 @@ export interface ItemDetailsProps {
  * Typed views own their own edit-dialog wiring internally (each opens its
  * matching `use*FormDialog()` hook), the same way they already own their own
  * removal — there's no list context above them to supply it, unlike
- * `ItemDataCard`. Only the fallback path needs one supplied here, via the
+ * `AnyItemCard`. Only the fallback path needs one supplied here, via the
  * generic `useItemFormDialog()`.
  */
 export const ItemDetails: FC<ItemDetailsProps> = ({ item, onRemove, onRemoved, onOpenAttachment }) => {

--- a/src/components/items/details/itemDetailsRoot.tsx
+++ b/src/components/items/details/itemDetailsRoot.tsx
@@ -39,7 +39,7 @@ export interface ItemDetailsRootProps extends PropsWithChildren {
  * children to override the field auto-rendered from `item`/`type`; `Rating`
  * and `Content` are purely additive, with no default rendering of their own.
  * Typed details views (e.g. `WeaponItemDetails`) wrap this; the
- * `ItemDetails` dispatcher falls back to this directly for item types
+ * `AnyItemDetails` dispatcher falls back to this directly for item types
  * without a typed details view.
  */
 export const ItemDetailsRoot: FC<ItemDetailsRootProps> = ({

--- a/src/components/items/details/itemDetailsSlot.tsx
+++ b/src/components/items/details/itemDetailsSlot.tsx
@@ -33,8 +33,8 @@ export type { ItemDetailsTypeProps } from "./itemDetails.Type.tsx"
  * typed details view wrapping it). Parallel to `ItemCardSlot`, but not built
  * on top of it — card slots are condensed for space, ItemDetails slots
  * render the same concepts at full fidelity (see ADR-0009). Kept separate
- * from the `ItemDetails` dispatcher so typed details views can depend on
- * slots without depending on `ItemDetails` itself, which would otherwise
+ * from the `AnyItemDetails` dispatcher so typed details views can depend on
+ * slots without depending on `AnyItemDetails` itself, which would otherwise
  * import every typed details view and create a cycle.
  *
  * `ItemDetailsRoot` renders `Title`/`Type`/`Source`/`Availability`/

--- a/src/components/items/types/armor/equippedArmorSection.tsx
+++ b/src/components/items/types/armor/equippedArmorSection.tsx
@@ -3,7 +3,7 @@ import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
 import type { FC } from "react"
 
-import { ItemDataCard } from "#/components/itemCard/itemDataCard.tsx"
+import { AnyItemCard } from "#/components/itemCard/anyItemCard.tsx"
 import { Label } from "#/components/ui/text/label.tsx"
 import { useGearByType } from "#/lib/hooks/items/gearHooks.ts"
 import { useEncumbrance } from "#/lib/hooks/system/encumbrance/useEncumbrance.ts"
@@ -45,7 +45,7 @@ export const EquippedArmorSection: FC = () => {
         )}
       </Stack>
       {equippedArmor.map((armor) => (
-        <ItemDataCard key={armor.id} item={armor} />
+        <AnyItemCard key={armor.id} item={armor} />
       ))}
     </Stack>
   )

--- a/src/components/items/types/armor/equippedArmorSection.tsx
+++ b/src/components/items/types/armor/equippedArmorSection.tsx
@@ -3,12 +3,13 @@ import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
 import type { FC } from "react"
 
-import { AnyItemCard } from "#/components/itemCard/anyItemCard.tsx"
 import { Label } from "#/components/ui/text/label.tsx"
 import { useGearByType } from "#/lib/hooks/items/gearHooks.ts"
 import { useEncumbrance } from "#/lib/hooks/system/encumbrance/useEncumbrance.ts"
 import type { ArmorData } from "#/system/gear/armorData.ts"
 import { ItemType } from "#/system/itemType.ts"
+
+import { ArmorDataCard } from "./armorDataCard.tsx"
 
 export const EquippedArmorSection: FC = () => {
   const allArmor = useGearByType<ArmorData>(ItemType.armor)
@@ -45,7 +46,7 @@ export const EquippedArmorSection: FC = () => {
         )}
       </Stack>
       {equippedArmor.map((armor) => (
-        <AnyItemCard key={armor.id} item={armor} />
+        <ArmorDataCard key={armor.id} armor={armor} />
       ))}
     </Stack>
   )

--- a/src/components/runner/gearPage/weaponsSectionContent.tsx
+++ b/src/components/runner/gearPage/weaponsSectionContent.tsx
@@ -2,7 +2,7 @@ import Stack from "@mui/material/Stack"
 import { useNavigate } from "@tanstack/react-router"
 import type { FC } from "react"
 
-import { ItemDataCard } from "#/components/itemCard/itemDataCard.tsx"
+import { AnyItemCard } from "#/components/itemCard/anyItemCard.tsx"
 import { useWeaponFormDialog } from "#/components/items/types/weapons/dialogs/weaponFormDialog.tsx"
 import { isNewItem } from "#/lib/stores/runner/gear/gearSlice.actions.ts"
 import { Actions } from "#/lib/stores/runner/runnerStore.actions.ts"
@@ -25,7 +25,7 @@ export const WeaponsSectionContent: FC = () => {
   return (
     <Stack sx={{ gap: 1 }}>
       {Object.values(weapons).map((item) => (
-        <ItemDataCard
+        <AnyItemCard
           key={item.id}
           item={item}
           onOpen={() => navigate({ to: "/$runnerId/item/$itemId", params: { itemId: item.id } })}

--- a/src/components/runner/gearPage/weaponsSectionContent.tsx
+++ b/src/components/runner/gearPage/weaponsSectionContent.tsx
@@ -2,8 +2,8 @@ import Stack from "@mui/material/Stack"
 import { useNavigate } from "@tanstack/react-router"
 import type { FC } from "react"
 
-import { AnyItemCard } from "#/components/itemCard/anyItemCard.tsx"
 import { useWeaponFormDialog } from "#/components/items/types/weapons/dialogs/weaponFormDialog.tsx"
+import { WeaponDataCard } from "#/components/items/types/weapons/weaponDataCard.tsx"
 import { isNewItem } from "#/lib/stores/runner/gear/gearSlice.actions.ts"
 import { Actions } from "#/lib/stores/runner/runnerStore.actions.ts"
 import { useRunnerStoreDispatch } from "#/lib/stores/runner/runnerStore.dispatch.ts"
@@ -25,9 +25,9 @@ export const WeaponsSectionContent: FC = () => {
   return (
     <Stack sx={{ gap: 1 }}>
       {Object.values(weapons).map((item) => (
-        <AnyItemCard
+        <WeaponDataCard
           key={item.id}
-          item={item}
+          weapon={item}
           onOpen={() => navigate({ to: "/$runnerId/item/$itemId", params: { itemId: item.id } })}
           onEdit={() => handleEditWeapon(item)}
         />

--- a/src/routes/$runnerId/_details/item.$itemId.tsx
+++ b/src/routes/$runnerId/_details/item.$itemId.tsx
@@ -15,7 +15,7 @@ export const Route = createFileRoute("/$runnerId/_details/item/$itemId")({
 })
 
 /**
- * One shared route for every item type (mirrors the `ItemDataCard` dispatcher):
+ * One shared route for every item type (mirrors the `AnyItemCard` dispatcher):
  * items are stored flat (`RunnerData.gear`), not partitioned by section, so
  * there's no per-section detail route to duplicate the dispatch logic in.
  * Renders full-screen via the `_details` layout — a drill-down page isn't a

--- a/src/routes/$runnerId/_details/item.$itemId.tsx
+++ b/src/routes/$runnerId/_details/item.$itemId.tsx
@@ -4,7 +4,7 @@ import Typography from "@mui/material/Typography"
 import { RiArrowLeftLine } from "@remixicon/react"
 import { createFileRoute, useRouter } from "@tanstack/react-router"
 
-import { ItemDetails } from "#/components/items/details/itemDetails.tsx"
+import { AnyItemDetails } from "#/components/items/details/anyItemDetails.tsx"
 import { Actions } from "#/lib/stores/runner/runnerStore.actions.ts"
 import { useRunnerStoreDispatch } from "#/lib/stores/runner/runnerStore.dispatch.ts"
 import { Selectors, useRunnerStoreSelector } from "#/lib/stores/runner/runnerStore.selectors.ts"
@@ -47,7 +47,7 @@ function ItemDetailsRoute() {
       )}
 
       {item && (
-        <ItemDetails
+        <AnyItemDetails
           item={item}
           onRemove={() => {
             dispatch(Actions.gear.removeItem({ id: item.id }))


### PR DESCRIPTION
## Summary

Implements the dispatcher rename decided in [ADR-0010](../blob/shadowrun-4e/docs/adr/0010-entity-card-composition.md):

> **Rename the dispatcher: `ItemDataCard` → `AnyItemCard`.** `AnyItemCard({ item })` is the component that accepts any `ItemData` and renders the correct typed card, same behavior as today's dispatcher, new name. This is what breaks the cycle: `AnyItemCard` is the *only* module allowed to import every typed card.

- `src/components/itemCard/itemDataCard.tsx` → `anyItemCard.tsx`; `ItemDataCard` → `AnyItemCard`, `ItemDataCardProps` → `AnyItemCardProps` (git-tracked rename, behavior unchanged)
- `itemDataCard.test.tsx` → `anyItemCard.test.tsx`, updated to match
- Updated every call site: builder gear lists (`itemsList.tsx`, `weaponsList.tsx`), runner gear page (`weaponsSectionContent.tsx`), item details (`itemDetails.Subitem.tsx`), equipped armor section, and doc-comment references in `itemDetails.tsx` and the item details route

`ItemDataCardRoot` is untouched — it's the separate `ItemData`-common-fields layer between `DataCard` and each typed card, not the dispatcher this ADR renames.

**Out of scope:** the broader tiered `EntityCard`/`ItemCard` compound-component rewrite that ADR-0010 also describes (new element primitives, migrating every typed card off `DataCardSlot`) is tracked separately in `docs/features/0013-entity-card-migration.md`, which is still in Draft status with open questions and an explicitly staged, type-by-type rollout plan. This PR is just the mechanical rename called out in the ADR's "Consequences" section, which unblocks that later work without bundling in a much larger, riskier change.

## Test plan

- [x] `yarn tsc` — clean
- [x] `yarn eslint` — clean
- [x] `yarn test:unit` — 976/976 passing (150 files)
- [x] `yarn fallow dead-code --format json` — no new findings related to this change


---
_Generated by [Claude Code](https://claude.ai/code/session_01YHNg4HpBPTAUPKSgd9PmFK)_