### PR TITLE
docs: require desktop + Pixel 8 screenshots for UI changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,11 +247,12 @@ doubt, omit the prop and let the theme do the work.
 ## UI changes
 
 Whenever a task involves changes to the visual appearance or layout of a component (new UI, updated styles, added
-controls, rearranged sections), **always include at least one screenshot** of the affected area in your PR or summary.
-Take the screenshot after the dev server is running (`yarn dev`) and the change is visible in the browser. Capture the
-smallest region that clearly shows the new state. Attach the image as part of your response or PR description so
-reviewers can quickly verify the visual result without running the app locally. Do not include screenshots in the git
-commit
+controls, rearranged sections), **always include screenshots** of the affected area in your PR or summary, captured
+in **both** a desktop viewport and a Pixel 8 viewport (412×915, as used by Chrome DevTools device emulation).
+Take the screenshots after the dev server is running (`yarn dev`) and the change is visible in the browser. Capture
+the smallest region that clearly shows the new state in each viewport. Attach both images as part of your response
+or PR description so reviewers can quickly verify the visual result on both desktop and mobile without running the
+app locally. Do not include screenshots in the git commit
 
 - Don't use short or ambiguous variable names. Prefer descriptive identifiers (for example `characterHealth` instead of
   `hp`, `damageThreshold` instead of `dt`). Short names are acceptable only for well-known conventions (`id`, `ok`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,8 @@
 # CLAUDE.md
 
-This repo's authoritative agent instructions live in [AGENTS.md](./AGENTS.md) — read that first for
-commands, architecture, and conventions.
+This repo's authoritative agent instructions live in [AGENTS.md](./AGENTS.md). **You must read AGENTS.md in full
+before continuing with any task in this repo** — it covers commands, architecture, and conventions that apply to
+every change.
 
 <!-- Also read the list of available agent skills from `.agents/skills/` — see
      `.agents/skills/CLAUDE.md` for an index. -->


### PR DESCRIPTION
## Summary

Updates the "UI changes" section of `AGENTS.md` so that any PR touching visual appearance or layout must include screenshots of the affected area in **both** a desktop viewport and a Pixel 8 viewport (412×915, matching Chrome DevTools device emulation), instead of just a single screenshot.

## Changes

- `AGENTS.md`: reworded the UI changes requirement to call for screenshots in both desktop and Pixel 8 viewports.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UzGAzhd2SPbL6N3q8wL1Gk)_