### PR TITLE
Use #/lib/uuidUtils.ts UUID alias instead of node:crypto

### DIFF
--- a/src/components/items/types/devices/dialogs/programFormDialog.tsx
+++ b/src/components/items/types/devices/dialogs/programFormDialog.tsx
@@ -1,5 +1,3 @@
-import type { UUID } from "node:crypto"
-
 import type { FC } from "react"
 
 import { ItemDialog } from "#/components/items/dialogs/itemDialog.tsx"
@@ -8,6 +6,7 @@ import { GearFormLicenseSection } from "#/components/items/types/licenses/gearFo
 import type { AnyDialogCtrl } from "#/components/ui/dialog/dialogCtrl.ts"
 import { programFieldMap, useProgramForm } from "#/lib/hooks/items/types/devices/forms/useProgramForm.tsx"
 import { useDialog } from "#/lib/hooks/ui/dialog/useDialog.tsx"
+import type { UUID } from "#/lib/uuidUtils.ts"
 import type { ProgramData } from "#/system/gear/programData.ts"
 import { ItemType } from "#/system/itemType.ts"
 

--- a/src/components/items/types/implants/dialogs/implantFormDialog.tsx
+++ b/src/components/items/types/implants/dialogs/implantFormDialog.tsx
@@ -1,5 +1,3 @@
-import type { UUID } from "node:crypto"
-
 import type { FC } from "react"
 
 import type { ItemDialogProps } from "#/components/items/dialogs/itemDialog.tsx"
@@ -9,6 +7,7 @@ import { getImplantEffectiveNuyenCost } from "#/components/items/types/implants/
 import { GearFormLicenseSection } from "#/components/items/types/licenses/gearFormLicenseSection.tsx"
 import { implantFieldMap, useImplantForm } from "#/lib/hooks/items/types/implants/forms/useImplantForm.tsx"
 import { useDialog } from "#/lib/hooks/ui/dialog/useDialog.tsx"
+import type { UUID } from "#/lib/uuidUtils.ts"
 import type { ImplantData } from "#/system/gear/implantData.ts"
 
 interface CyberwareFormDialogProps {

--- a/src/components/runner/finances/endOfMonth/endOfMonthDialog.tsx
+++ b/src/components/runner/finances/endOfMonth/endOfMonthDialog.tsx
@@ -1,5 +1,3 @@
-import type { UUID } from "node:crypto"
-
 import Button from "@mui/material/Button"
 import Checkbox from "@mui/material/Checkbox"
 import Divider from "@mui/material/Divider"
@@ -17,6 +15,7 @@ import { useDialog } from "#/lib/hooks/ui/dialog/useDialog.tsx"
 import { Actions } from "#/lib/stores/runner/runnerStore.actions.ts"
 import { useRunnerStoreDispatch } from "#/lib/stores/runner/runnerStore.dispatch.ts"
 import { Selectors, useRunnerStoreSelector } from "#/lib/stores/runner/runnerStore.selectors.ts"
+import type { UUID } from "#/lib/uuidUtils.ts"
 import { Lifestyles, LifestyleType } from "#/system/lifestyleType.ts"
 import { calculateMonthlyInterest } from "#/system/loanData.ts"
 

--- a/src/components/runner/licenseCheck/licenseCheckAlerts.test.ts
+++ b/src/components/runner/licenseCheck/licenseCheckAlerts.test.ts
@@ -1,7 +1,6 @@
-import type { UUID } from "node:crypto"
-
 import { describe, expect, it } from "vitest"
 
+import type { UUID } from "#/lib/uuidUtils.ts"
 import { EntityKind } from "#/system/entityKind.ts"
 import type { SinData } from "#/system/gear/sinData.ts"
 import type { ItemData } from "#/system/itemData.ts"

--- a/src/data/migrations/017_addKarmaLog.test.ts
+++ b/src/data/migrations/017_addKarmaLog.test.ts
@@ -1,7 +1,6 @@
-import type { UUID } from "node:crypto"
-
 import { describe, expect, it } from "vitest"
 
+import type { UUID } from "#/lib/uuidUtils.ts"
 import type { KarmaLedgerEntry } from "#/system/karma/karmaLedgerEntry.ts"
 
 import migration from "./017_addKarmaLog.ts"

--- a/src/lib/hooks/improvements/useSectionQueuedSummaries.test.ts
+++ b/src/lib/hooks/improvements/useSectionQueuedSummaries.test.ts
@@ -1,7 +1,6 @@
-import type { UUID } from "node:crypto"
-
 import { describe, expect, it } from "vitest"
 
+import type { UUID } from "#/lib/uuidUtils.ts"
 import { AttributeKey } from "#/system/attributeKey.ts"
 import { EntityKind } from "#/system/entityKind.ts"
 import type {

--- a/src/lib/hooks/items/types/licenses/forms/useLicenseForm.tsx
+++ b/src/lib/hooks/items/types/licenses/forms/useLicenseForm.tsx
@@ -1,8 +1,7 @@
-import type { UUID } from "node:crypto"
-
 import type { GearSubmitMeta } from "#/components/items/gearSubmitMeta.ts"
 import { DefaultFakeLicenseRating, getLicenseCost } from "#/components/items/types/licenses/licenseUtils.ts"
 import { useItemForm, itemDefaults } from "#/lib/hooks/items/forms/useItemForm.tsx"
+import type { UUID } from "#/lib/uuidUtils.ts"
 import { NullUuid } from "#/lib/uuidUtils.ts"
 import type { LicenseData } from "#/system/gear/licenseData.ts"
 import { ItemType } from "#/system/itemType.ts"

--- a/src/lib/hooks/runner/qualities/form/useQualityForm.ts
+++ b/src/lib/hooks/runner/qualities/form/useQualityForm.ts
@@ -1,6 +1,5 @@
-import type { UUID } from "node:crypto"
-
 import { useAppForm } from "#/integrations/tanstackForm/useAppForm.ts"
+import type { UUID } from "#/lib/uuidUtils.ts"
 import { NullUuid } from "#/lib/uuidUtils.ts"
 import { EntityKind } from "#/system/entityKind.ts"
 import type { QualityData } from "#/system/qualityData.ts"

--- a/src/lib/hooks/system/initiativeTracker/useInitiativeTracker.ts
+++ b/src/lib/hooks/system/initiativeTracker/useInitiativeTracker.ts
@@ -1,5 +1,3 @@
-import type { UUID } from "node:crypto"
-
 import type { Combatant } from "#/lib/stores/initiativeTracker/initiativeTrackerData.ts"
 import {
   addCombatant,
@@ -17,6 +15,7 @@ import {
   useInitiativeTrackerDispatch,
   useInitiativeTrackerSelector,
 } from "#/lib/stores/initiativeTracker/initiativeTrackerStore.ts"
+import type { UUID } from "#/lib/uuidUtils.ts"
 
 export const useInitiativeTracker = () => {
   const dispatch = useInitiativeTrackerDispatch()

--- a/src/lib/persistence/runnerId.ts
+++ b/src/lib/persistence/runnerId.ts
@@ -1,4 +1,4 @@
-import type { UUID } from "node:crypto"
+import type { UUID } from "#/lib/uuidUtils.ts"
 
 export type RunnerId = string | UUID
 

--- a/src/lib/persistence/runnerManager.ts
+++ b/src/lib/persistence/runnerManager.ts
@@ -1,5 +1,3 @@
-import type { UUID } from "node:crypto"
-
 import { AsyncDebouncer } from "@tanstack/pacer"
 
 import { applyMigrations } from "#/data/applyMigrations.ts"
@@ -8,6 +6,7 @@ import { RunnerNotFoundError } from "#/lib/errors/runnerNotFoundError.ts"
 import type { JsonValue } from "#/lib/jsonUtils.ts"
 import { toJsonValue } from "#/lib/jsonUtils.ts"
 import type { AsyncJsonStorage } from "#/lib/storage/asyncStorage.ts"
+import type { UUID } from "#/lib/uuidUtils.ts"
 import type { RunnerData } from "#/system/runnerData.ts"
 import { RunnerMetaSchema } from "#/system/runnerData.ts"
 

--- a/src/lib/stores/initiativeTracker/initiativeTrackerData.ts
+++ b/src/lib/stores/initiativeTracker/initiativeTrackerData.ts
@@ -1,5 +1,4 @@
-import type { UUID } from "node:crypto"
-
+import type { UUID } from "#/lib/uuidUtils.ts"
 import type { AttributeKey } from "#/system/attributeKey.ts"
 
 export interface SkillEntry {

--- a/src/lib/stores/initiativeTracker/initiativeTrackerSlice.actions.ts
+++ b/src/lib/stores/initiativeTracker/initiativeTrackerSlice.actions.ts
@@ -1,6 +1,6 @@
-import type { UUID } from "node:crypto"
-
 import { createAction } from "@reduxjs/toolkit"
+
+import type { UUID } from "#/lib/uuidUtils.ts"
 
 import type { Combatant } from "./initiativeTrackerData.ts"
 

--- a/src/lib/stores/initiativeTracker/initiativeTrackerSlice.selectors.ts
+++ b/src/lib/stores/initiativeTracker/initiativeTrackerSlice.selectors.ts
@@ -1,6 +1,6 @@
-import type { UUID } from "node:crypto"
-
 import { createSelector } from "reselect"
+
+import type { UUID } from "#/lib/uuidUtils.ts"
 
 import type { Combatant, InitiativeTrackerState } from "./initiativeTrackerData.ts"
 import { sortCombatants } from "./initiativeTrackerData.ts"

--- a/src/lib/stores/runner/gear/gearSlice.actions.ts
+++ b/src/lib/stores/runner/gear/gearSlice.actions.ts
@@ -1,7 +1,6 @@
-import type { UUID } from "node:crypto"
-
 import { createAction } from "@reduxjs/toolkit"
 
+import type { UUID } from "#/lib/uuidUtils.ts"
 import { NullUuid } from "#/lib/uuidUtils.ts"
 import type { ArmorData } from "#/system/gear/armorData.ts"
 import type { CredstickData } from "#/system/gear/credstickData.ts"
@@ -21,7 +20,7 @@ export const addItem = createAction("gear/add", (item: Omit<ItemData, "id">) => 
 
 export const setItem = createAction<ItemData>("gear/set")
 
-export const patchItem = createAction<{ itemId: string, data: Partial<ItemData> }>("gear/patch")
+export const patchItem = createAction<{ itemId: UUID, data: Partial<ItemData> }>("gear/patch")
 
 export const removeItem = createAction<{ id: UUID, removeChildren?: boolean }>("gear/remove")
 

--- a/src/lib/stores/runner/karma/karmaSlice.actions.ts
+++ b/src/lib/stores/runner/karma/karmaSlice.actions.ts
@@ -1,7 +1,6 @@
-import type { UUID } from "node:crypto"
-
 import { createAction } from "@reduxjs/toolkit"
 
+import type { UUID } from "#/lib/uuidUtils.ts"
 import type { KarmaLedgerEntry } from "#/system/karma/karmaLedgerEntry.ts"
 
 export const addKarma = createAction("karma/addKarma", (amount: number) => {

--- a/src/lib/stores/runner/nuyen/nuyenSlice.actions.ts
+++ b/src/lib/stores/runner/nuyen/nuyenSlice.actions.ts
@@ -1,7 +1,6 @@
-import type { UUID } from "node:crypto"
-
 import { createAction } from "@reduxjs/toolkit"
 
+import type { UUID } from "#/lib/uuidUtils.ts"
 import { NullUuid } from "#/lib/uuidUtils.ts"
 import type { LoanData } from "#/system/loanData.ts"
 

--- a/src/lib/stores/runner/qualities/qualitiesSlice.test.ts
+++ b/src/lib/stores/runner/qualities/qualitiesSlice.test.ts
@@ -1,7 +1,6 @@
-import type { UUID } from "node:crypto"
-
 import { describe, expect, it } from "vitest"
 
+import type { UUID } from "#/lib/uuidUtils.ts"
 import { EntityKind } from "#/system/entityKind.ts"
 import type { QualityData } from "#/system/qualityData.ts"
 

--- a/src/system/contactData.ts
+++ b/src/system/contactData.ts
@@ -1,4 +1,4 @@
-import type { UUID } from "node:crypto"
+import type { UUID } from "#/lib/uuidUtils.ts"
 
 import type { FavourData } from "./favourData.ts"
 import type { KnowledgeSkillData } from "./skills/knowledgeSkillData.ts"

--- a/src/system/karma/improvements/improvementEntry.ts
+++ b/src/system/karma/improvements/improvementEntry.ts
@@ -1,5 +1,4 @@
-import type { UUID } from "node:crypto"
-
+import type { UUID } from "#/lib/uuidUtils.ts"
 import type { AttributeKey } from "#/system/attributeKey.ts"
 import type { ComplexFormData } from "#/system/magic/complexFormData.ts"
 import type { SpellData } from "#/system/magic/spellData.ts"

--- a/src/system/karma/improvements/improvementStore.ts
+++ b/src/system/karma/improvements/improvementStore.ts
@@ -1,9 +1,8 @@
-import type { UUID } from "node:crypto"
-
 import { produce } from "immer"
 
 import type { CompatStore } from "#/integrations/reduxToolkit/compatStore.ts"
 import { createCompatStore } from "#/integrations/reduxToolkit/compatStore.ts"
+import type { UUID } from "#/lib/uuidUtils.ts"
 
 import type { ImprovementEntry } from "./improvementEntry.ts"
 

--- a/src/system/karma/improvements/improvementUtils.breakSkillGroup.test.ts
+++ b/src/system/karma/improvements/improvementUtils.breakSkillGroup.test.ts
@@ -1,8 +1,7 @@
-import type { UUID } from "node:crypto"
-
 import { produce } from "immer"
 import { describe, expect, it } from "vitest"
 
+import type { UUID } from "#/lib/uuidUtils.ts"
 import { runnerDataFactory } from "#/system/runnerData.factory.ts"
 import { SkillGroupKey } from "#/system/skills/skillGroupKey.ts"
 import { SkillKey } from "#/system/skills/skillKey.ts"

--- a/src/system/karma/improvements/improvementUtils.complexForm.test.ts
+++ b/src/system/karma/improvements/improvementUtils.complexForm.test.ts
@@ -1,8 +1,7 @@
-import type { UUID } from "node:crypto"
-
 import { produce } from "immer"
 import { describe, expect, it } from "vitest"
 
+import type { UUID } from "#/lib/uuidUtils.ts"
 import { EntityKind } from "#/system/entityKind.ts"
 import { runnerDataFactory } from "#/system/runnerData.factory.ts"
 

--- a/src/system/karma/improvements/improvementUtils.cost.test.ts
+++ b/src/system/karma/improvements/improvementUtils.cost.test.ts
@@ -1,7 +1,6 @@
-import type { UUID } from "node:crypto"
-
 import { describe, expect, it } from "vitest"
 
+import type { UUID } from "#/lib/uuidUtils.ts"
 import { AttributeKey } from "#/system/attributeKey.ts"
 import { EntityKind } from "#/system/entityKind.ts"
 import { SkillGroupKey } from "#/system/skills/skillGroupKey.ts"

--- a/src/system/karma/improvements/improvementUtils.learn.test.ts
+++ b/src/system/karma/improvements/improvementUtils.learn.test.ts
@@ -1,8 +1,7 @@
-import type { UUID } from "node:crypto"
-
 import { produce } from "immer"
 import { describe, expect, it } from "vitest"
 
+import type { UUID } from "#/lib/uuidUtils.ts"
 import { runnerDataFactory } from "#/system/runnerData.factory.ts"
 import { SkillGroupKey } from "#/system/skills/skillGroupKey.ts"
 import { SkillKey } from "#/system/skills/skillKey.ts"

--- a/src/system/karma/improvements/improvementUtils.ledger.test.ts
+++ b/src/system/karma/improvements/improvementUtils.ledger.test.ts
@@ -1,8 +1,7 @@
-import type { UUID } from "node:crypto"
-
 import { describe, expect, it } from "vitest"
 
 import { RunnerDataStore } from "#/components/runner/sheet/runnerDataStore.ts"
+import type { UUID } from "#/lib/uuidUtils.ts"
 import { AttributeKey } from "#/system/attributeKey.ts"
 import { runnerDataFactory } from "#/system/runnerData.factory.ts"
 import { SkillKey } from "#/system/skills/skillKey.ts"

--- a/src/system/karma/improvements/improvementUtils.magicAdvancement.test.ts
+++ b/src/system/karma/improvements/improvementUtils.magicAdvancement.test.ts
@@ -1,8 +1,7 @@
-import type { UUID } from "node:crypto"
-
 import { produce } from "immer"
 import { describe, expect, it } from "vitest"
 
+import type { UUID } from "#/lib/uuidUtils.ts"
 import { runnerDataFactory } from "#/system/runnerData.factory.ts"
 
 import type { InitiationIncreaseEntry, SubmersionIncreaseEntry } from "./improvementEntry.ts"

--- a/src/system/karma/improvements/improvementUtils.quality.test.ts
+++ b/src/system/karma/improvements/improvementUtils.quality.test.ts
@@ -1,8 +1,7 @@
-import type { UUID } from "node:crypto"
-
 import { produce } from "immer"
 import { describe, expect, it } from "vitest"
 
+import type { UUID } from "#/lib/uuidUtils.ts"
 import { EntityKind } from "#/system/entityKind.ts"
 import { runnerDataFactory } from "#/system/runnerData.factory.ts"
 

--- a/src/system/karma/improvements/improvementUtils.ts
+++ b/src/system/karma/improvements/improvementUtils.ts
@@ -1,11 +1,10 @@
-import type { UUID } from "node:crypto"
-
 import type { Draft } from "immer"
 import { produce } from "immer"
 
 import { getSkillsInGroup } from "#/components/builder/sections/skills/activeSkills/skillGroupUtils.ts"
 import { ImprovementsConfig } from "#/components/improvements/improvementsConfig.ts"
 import type { RunnerStore } from "#/lib/stores/runner/runnerStore.ts"
+import type { UUID } from "#/lib/uuidUtils.ts"
 import { EntityKind } from "#/system/entityKind.ts"
 import type { RunnerData } from "#/system/runnerData.ts"
 import type { SkillGroupKey } from "#/system/skills/skillGroupKey.ts"

--- a/src/system/karma/karmaLedgerEntry.ts
+++ b/src/system/karma/karmaLedgerEntry.ts
@@ -1,4 +1,4 @@
-import type { UUID } from "node:crypto"
+import type { UUID } from "#/lib/uuidUtils.ts"
 
 import type { ImprovementEntry } from "./improvements/improvementEntry.ts"
 

--- a/src/system/loanData.ts
+++ b/src/system/loanData.ts
@@ -1,4 +1,4 @@
-import type { UUID } from "node:crypto"
+import type { UUID } from "#/lib/uuidUtils.ts"
 
 export interface LoanData {
   id: UUID

--- a/src/system/magic/spiritData.ts
+++ b/src/system/magic/spiritData.ts
@@ -1,7 +1,6 @@
-import type { UUID } from "node:crypto"
-
 import { z } from "zod"
 
+import type { UUID } from "#/lib/uuidUtils.ts"
 import { AttributeKey } from "#/system/attributeKey.ts"
 import type { DamageTrackKey } from "#/system/damageTrackKey.ts"
 import type { EntityDamage } from "#/system/entityData.ts"

--- a/src/system/qualityData.ts
+++ b/src/system/qualityData.ts
@@ -1,4 +1,4 @@
-import type { UUID } from "node:crypto"
+import type { UUID } from "#/lib/uuidUtils.ts"
 
 import type { EntityKind } from "./entityKind.ts"
 import type { GameEffectData } from "./gameEffects/gameEffectData.ts"


### PR DESCRIPTION
Swaps the node:crypto UUID type import for the project's own #/lib/uuidUtils.ts alias across the files that only needed the import path changed (per AGENTS.md's "All local imports must include the file extension" convention, and to avoid a Node-specific type import in browser code). Purely mechanical — the UUID type itself is unchanged in this commit.

Split out of the larger "entities with items" change.